### PR TITLE
fix(mr): let newbie logstream know cur version

### DIFF
--- a/internal/metarepos/report_collector.go
+++ b/internal/metarepos/report_collector.go
@@ -887,6 +887,10 @@ func (lc *logStreamCommitter) getCatchupVersion(resetCatchupHelper bool) (types.
 	}
 
 	if beginVer > ver {
+		if ver.Invalid() {
+			// Let newbie logStream know version.
+			return beginVer - 1, true
+		}
 		return beginVer, true
 	}
 
@@ -956,20 +960,28 @@ CatchupLoop:
 
 			cr.Version = crs.Version
 			cr.HighWatermark, lc.catchupHelper.expectedEndPos = crs.LastHighWatermark(lc.topicID, lc.catchupHelper.expectedEndPos)
+		} else {
+			// Let newbie LogStream know Version.
+			cr.Version = crs.Version
+			cr.TopicID = lc.topicID
+			cr.LogStreamID = lc.lsID
+			cr.CommittedGLSNOffset = types.MinGLSN
+			cr.CommittedLLSNOffset = types.MinLLSN
+			cr.CommittedGLSNLength = 0
+		}
 
-			err := lc.helper.commit(ctx, cr)
-			if err != nil {
-				return
-			}
+		err := lc.helper.commit(ctx, cr)
+		if err != nil {
+			return
+		}
 
-			min, max, recordable := lc.sampleTracer.commit(lc.lsID, cr.CommittedLLSNOffset, cr.CommittedLLSNOffset+types.LLSN(cr.CommittedGLSNLength))
-			if recordable {
-				lc.tmStub.mb.Records("mr.report_commit.delay").Record(ctx,
-					float64(time.Since(min).Nanoseconds())/float64(time.Millisecond))
+		min, max, recordable := lc.sampleTracer.commit(lc.lsID, cr.CommittedLLSNOffset, cr.CommittedLLSNOffset+types.LLSN(cr.CommittedGLSNLength))
+		if recordable {
+			lc.tmStub.mb.Records("mr.report_commit.delay").Record(ctx,
+				float64(time.Since(min).Nanoseconds())/float64(time.Millisecond))
 
-				lc.tmStub.mb.Records("mr.replicate.delay").Record(ctx,
-					float64(max.Sub(min).Nanoseconds())/float64(time.Millisecond))
-			}
+			lc.tmStub.mb.Records("mr.replicate.delay").Record(ctx,
+				float64(max.Sub(min).Nanoseconds())/float64(time.Millisecond))
 		}
 
 		lc.setSentVersion(crs.Version)

--- a/tests/it/cluster/cluster_test.go
+++ b/tests/it/cluster/cluster_test.go
@@ -293,7 +293,9 @@ func TestNewbieLogStream(t *testing.T) {
 				client := env.ClientAtIndex(t, 0)
 
 				for i := 0; i < 32; i++ {
-					lsid := lsIDs[i%env.NumberOfLogStreams(topicID)]
+					// AppendTo Newbie first
+					numLS := env.NumberOfLogStreams(topicID)
+					lsid := lsIDs[(numLS-1)-(i%numLS)]
 					res := client.AppendTo(context.Background(), topicID, lsid, [][]byte{[]byte("foo")})
 					So(res.Err, ShouldBeNil)
 					So(res.Metadata[0].GLSN, ShouldNotEqual, types.InvalidGLSN)

--- a/tests/it/management/management_test.go
+++ b/tests/it/management/management_test.go
@@ -721,7 +721,15 @@ func TestAddLogStreamTopic(t *testing.T) {
 			}
 
 			Convey("Then it should Appendable", func(ctx C) {
+				env.ClientRefresh(t)
+				client = env.ClientAtIndex(t, 0)
+
 				for _, topicID := range env.TopicIDs() {
+					rsp, _ := env.GetVMSClient(t).DescribeTopic(context.Background(), topicID)
+					// AppendTo newbie LogStream
+					res := client.AppendTo(context.Background(), topicID, rsp.LogStreams[1].LogStreamID, [][]byte{[]byte("foo")})
+					So(res.Err, ShouldBeNil)
+
 					for i := 0; i < numLogs; i++ {
 						res := client.Append(context.Background(), topicID, [][]byte{[]byte("foo")})
 						So(res.Err, ShouldBeNil)


### PR DESCRIPTION
**Send empty commit result to new logstream**
When a new logstream is created, metadata repository sends an empty commit result 
containing the version so that the logstream knows the current version.

Resolves #52

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/65)
<!-- Reviewable:end -->
