### PR TITLE
feat(admin): add `--loglevel` flag to varlogadm

### DIFF
--- a/cmd/varlogadm/cli.go
+++ b/cmd/varlogadm/cli.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/urfave/cli/v2"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/kakao/varlog/internal/admin"
 	"github.com/kakao/varlog/internal/admin/mrmanager"
@@ -53,6 +54,7 @@ func newStartCommand() *cli.Command {
 			flagLogToStderr.BoolFlag(),
 			flagLogFileRetentionDays.IntFlag(false, 0),
 			flagLogFileCompression.BoolFlag(),
+			flagLogLevel.StringFlag(false, "info"),
 		},
 	}
 }
@@ -115,10 +117,16 @@ func start(c *cli.Context) error {
 }
 
 func newLogger(c *cli.Context) (*zap.Logger, error) {
+	level, err := zapcore.ParseLevel(c.String(flagLogLevel.Name))
+	if err != nil {
+		return nil, err
+	}
+
 	opts := []log.Option{
 		log.WithHumanFriendly(),
 		log.WithLocalTime(),
 		log.WithZapLoggerOptions(zap.AddStacktrace(zap.DPanicLevel)),
+		log.WithLogLevel(level),
 	}
 	if !c.Bool(flagLogToStderr.Name) {
 		opts = append(opts, log.WithoutLogToStderr())

--- a/cmd/varlogadm/flags.go
+++ b/cmd/varlogadm/flags.go
@@ -81,4 +81,9 @@ var (
 		Aliases: []string{"log-file-compression"},
 		Envs:    []string{"LOGFILE_COMPRESSION", "LOG_FILE_COMPRESSION"},
 	}
+	flagLogLevel = flags.FlagDesc{
+		Name:    "loglevel",
+		Aliases: []string{"log-level"},
+		Envs:    []string{"LOGLEVEL", "LOG_LEVEL"},
+	}
 )


### PR DESCRIPTION
### What this PR does

This change adds a new flag `--loglevel` to varlogadm. It specifies the log level of the admin server.
Its default value is "info". Possible values are "debug", "info", "warn", "error", "dpanic", "panic", and "fatal".

### Which issue(s) this PR resolves

Resolves #79

### Anything else

Links:

- https://github.com/uber-go/zap/blob/0d6a75bccff91a3106f193c9e4e1678738a63f9d/zapcore/level.go#L35-L52

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/80)
<!-- Reviewable:end -->
