### PR TITLE
feat(sn): add CLI flags to varlogsn

### DIFF
--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -71,6 +71,9 @@ func newStartCommand() *cli.Command {
 
 			flagLogDir.StringFlag(false, ""),
 			flagLogToStderr.BoolFlag(),
+			flagLogFileRetentionDays.IntFlag(false, 0),
+			flagLogFileCompression.BoolFlag(),
+			flagLogLevel.StringFlag(false, "info"),
 
 			flagExporterType.StringFlag(false, "noop"),
 			flagExporterStopTimeout.DurationFlag(false, 5*time.Second),

--- a/cmd/varlogsn/flags.go
+++ b/cmd/varlogsn/flags.go
@@ -136,6 +136,21 @@ var (
 		Name: "logtostderr",
 		Envs: []string{"LOGTOSTDERR"},
 	}
+	flagLogFileRetentionDays = flags.FlagDesc{
+		Name:    "logfile-retention-days",
+		Aliases: []string{"log-file-retention-days"},
+		Envs:    []string{"LOGFILE_RETENTION_DAYS", "LOG_FILE_RETENTION_DAYS"},
+	}
+	flagLogFileCompression = flags.FlagDesc{
+		Name:    "logfile-compression",
+		Aliases: []string{"log-file-compression"},
+		Envs:    []string{"LOGFILE_COMPRESSION", "LOG_FILE_COMPRESSION"},
+	}
+	flagLogLevel = flags.FlagDesc{
+		Name:    "loglevel",
+		Aliases: []string{"log-level"},
+		Envs:    []string{"LOGLEVEL", "LOG_LEVEL"},
+	}
 
 	// flags for telemetry.
 	flagExporterType = flags.FlagDesc{


### PR DESCRIPTION
### What this PR does

This patch adds new CLI flags to the varlogsn:

- `--logfile-retention-days`: Durations in days the log files are retained.
- `--logfile-compression`: Whether log files are compressed.
- `--loglevel`: Log level, for instance, "debug", "info", "warn", "error", "dpanic", "panic", and
  "fatal".

### Which issue(s) this PR resolves

### Anything else

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/83)
<!-- Reviewable:end -->
