### PR TITLE
fix(mr): handle duplicated RegisterLogStream(#62)

### DIFF
--- a/internal/metarepos/raft_metadata_repository.go
+++ b/internal/metarepos/raft_metadata_repository.go
@@ -135,6 +135,7 @@ func NewRaftMetadataRepository(options *MetadataRepositoryOptions) *RaftMetadata
 		sw:                stopwaiter.New(),
 		tmStub:            tmStub,
 		topicEndPos:       make(map[types.TopicID]int),
+		requestNum:        uint64(time.Now().UnixNano()),
 	}
 
 	mr.storage = NewMetadataStorage(mr.sendAck, options.SnapCount, mr.logger.Named("storage"))

--- a/internal/metarepos/storage.go
+++ b/internal/metarepos/storage.go
@@ -431,6 +431,11 @@ func (ms *MetadataStorage) registerLogStream(ls *varlogpb.LogStreamDescriptor) e
 		return verrors.ErrAlreadyExists
 	}
 
+	if equal {
+		// To ensure that it is applied to the meta cache
+		return nil
+	}
+
 	_, cur := ms.getStateMachine()
 
 	ms.mtMu.Lock()


### PR DESCRIPTION
### What this PR does

This PR fixes the handling of duplicated RegisterLogStream command.

Some commands proposed with guarantee options can be applied multiple times. 
UncommitReports was reset because MR did not handle the duplicate RegisterLogStream command. 
This caused subsequent reports to be ignored.

### Which issue(s) this PR resolves

Resolves #62 

### Anything else

Include any links or documentation that might be helpful for reviewers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/86)
<!-- Reviewable:end -->
