### PR TITLE
fix list storagenodes json exception

### DIFF
--- a/bin/start_varlogsn.py
+++ b/bin/start_varlogsn.py
@@ -61,7 +61,8 @@ def get_data_dirs(admin: str, snid: int):
            f"--snid={snid}"]
     out = subprocess.check_output(cmd)
     snm = json.loads(out)
-    return [logstream["path"] for logstream in snm["logStreams"]]
+    logstreams = snm.get("logStreams", [])
+    return [logstream["path"] for logstream in logstreams]
 
 
 def truncate(path: str) -> None:

--- a/bin/tests/test_start_varlogsn.py
+++ b/bin/tests/test_start_varlogsn.py
@@ -22,6 +22,14 @@ class StartVarlogsnTestCase(unittest.TestCase):
             self.assertIn("storageNodeId", snms[0])
             self.assertIn("address", snms[0])
 
+    def test_parse_get_storagenode_without_logstreams_response(self):
+        with open(TESTDATA.joinpath('getstoragenode.1.golden.json')) as f:
+            snm = json.load(f)
+            self.assertIn("storageNodeId", snm)
+            self.assertIn("address", snm)
+            self.assertIn("logStreams", snm)
+            self.assertIsInstance(snm["logStreams"], list)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/internal/admin/stats/repository.go
+++ b/internal/admin/stats/repository.go
@@ -127,7 +127,11 @@ func (s *repository) GetStorageNode(snid types.StorageNodeID) (*vmspb.StorageNod
 	if !ok {
 		return nil, false
 	}
-	return proto.Clone(snm).(*vmspb.StorageNodeMetadata), true
+	copied := proto.Clone(snm).(*vmspb.StorageNodeMetadata)
+	if len(copied.LogStreamReplicas) == 0 {
+		copied.LogStreamReplicas = []snpb.LogStreamReplicaMetadataDescriptor{}
+	}
+	return copied, true
 }
 
 func (s *repository) ListStorageNodes() []vmspb.StorageNodeMetadata {
@@ -136,6 +140,9 @@ func (s *repository) ListStorageNodes() []vmspb.StorageNodeMetadata {
 	snms := make([]vmspb.StorageNodeMetadata, 0, len(s.storageNodes))
 	for _, snm := range s.storageNodes {
 		copied := *proto.Clone(snm).(*vmspb.StorageNodeMetadata)
+		if len(copied.LogStreamReplicas) == 0 {
+			copied.LogStreamReplicas = []snpb.LogStreamReplicaMetadataDescriptor{}
+		}
 		snms = append(snms, copied)
 	}
 	sort.Slice(snms, func(i, j int) bool {

--- a/internal/varlogctl/controller_test.go
+++ b/internal/varlogctl/controller_test.go
@@ -122,6 +122,32 @@ var (
 		LastHeartbeatTime: time.Date(2022, time.November, 1, 11, 37, 19, 0, time.UTC),
 	}
 
+	snm2 = &vmspb.StorageNodeMetadata{
+		StorageNodeMetadataDescriptor: snpb.StorageNodeMetadataDescriptor{
+			ClusterID: cid,
+			StorageNode: varlogpb.StorageNode{
+				StorageNodeID: snid1,
+				Address:       addr1,
+			},
+			Storages: []varlogpb.StorageDescriptor{
+				{
+					Path:  "/tmp1",
+					Used:  32 << 10,
+					Total: 1 << 20,
+				},
+				{
+					Path:  "/tmp2",
+					Used:  64 << 10,
+					Total: 2 << 20,
+				},
+			},
+			LogStreamReplicas: []snpb.LogStreamReplicaMetadataDescriptor{},
+			StartTime:         time.Date(2022, time.October, 1, 3, 23, 21, 0, time.UTC),
+		},
+		CreateTime:        time.Date(2022, time.September, 27, 17, 46, 40, 0, time.UTC),
+		LastHeartbeatTime: time.Date(2022, time.November, 1, 11, 37, 19, 0, time.UTC),
+	}
+
 	td1 = &varlogpb.TopicDescriptor{
 		TopicID: tpid1,
 		Status:  varlogpb.TopicStatusRunning,
@@ -174,6 +200,14 @@ func TestController(t *testing.T) {
 			executeFunc: storagenode.Describe(snm1.StorageNode.StorageNodeID),
 			initMock: func(adm *varlog.MockAdmin) {
 				adm.EXPECT().GetStorageNode(gomock.Any(), snm1.StorageNode.StorageNodeID).Return(snm1, nil)
+			},
+		},
+		{
+			name:        "GetStorageNode1",
+			golden:      "varlogctl/getstoragenode.1.golden.json",
+			executeFunc: storagenode.Describe(snm2.StorageNode.StorageNodeID),
+			initMock: func(adm *varlog.MockAdmin) {
+				adm.EXPECT().GetStorageNode(gomock.Any(), snm2.StorageNode.StorageNodeID).Return(snm2, nil)
 			},
 		},
 		{

--- a/testdata/varlogctl/getstoragenode.1.golden.json
+++ b/testdata/varlogctl/getstoragenode.1.golden.json
@@ -1,0 +1,1 @@
+{"clusterId":1,"storageNodeId":1,"address":"127.0.0.1:10000","storages":[{"path":"/tmp1","used":32768,"total":1048576},{"path":"/tmp2","used":65536,"total":2097152}],"logStreams":[],"startTime":"2022-10-01T03:23:21Z","createTime":"2022-09-27T17:46:40Z","lastHeartbeatTime":"2022-11-01T11:37:19Z"}


### PR DESCRIPTION
### What this PR does

To fix an exception in the `start_vartsn.py`, it sets an empty slice to the `proto/snpb.(StorageNodeMetadataDescriptor).LogStreamReplicas` when there is no log stream replicas in the storage node.

### Which issue(s) this PR resolves

Resolves #88

### Anything else

When there was no log stream replica in a storage node, the JSON field `logStreams` in the GetStrorageNode response was null.
It can cause an exception while accessing the field after decoding the response, for example `TypeError: 'NoneType' object is not iterable`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/90)
<!-- Reviewable:end -->
