### PR TITLE
fix(storage): apply WithoutSync option correctly

### DIFF
--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -74,7 +74,7 @@ func New(opts ...Option) (*Storage, error) {
 	return &Storage{
 		config:    cfg,
 		db:        db,
-		writeOpts: &pebble.WriteOptions{Sync: false},
+		writeOpts: &pebble.WriteOptions{Sync: cfg.sync},
 	}, nil
 }
 

--- a/internal/storage/testing.go
+++ b/internal/storage/testing.go
@@ -7,7 +7,10 @@ import (
 )
 
 func TestNewStorage(tb testing.TB, opts ...Option) *Storage {
-	defaultOpts := []Option{WithPath(tb.TempDir())}
+	defaultOpts := []Option{
+		WithPath(tb.TempDir()),
+		WithoutSync(), // FIXME: Use only in mac since sync is too slow in mac os.
+	}
 	s, err := New(append(defaultOpts, opts...)...)
 	assert.NoError(tb, err)
 	return s


### PR DESCRIPTION
### What this PR does

This patch fixed the missing use of the sync option of `internal/storage.(*Storage)`. The sync operation of WAL can be deferred by using the option `WithoutSync`.

### Which issue(s) this PR resolves

Resolves #102

### Anything else

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/103)
<!-- Reviewable:end -->
