### PR TITLE
feat(admin): use gRPC codes to clarify errors returned from `proto/vmspb.UpdateLogStream` RPC

### DIFF
--- a/internal/admin/admerrors/errors.go
+++ b/internal/admin/admerrors/errors.go
@@ -6,9 +6,14 @@ import (
 )
 
 var (
-	ErrNoSuchStorageNode         = status.Error(codes.NotFound, "no such storage node")
-	ErrNoSuchTopic               = status.Error(codes.NotFound, "no such topic")
-	ErrNoSuchLogStream           = status.Error(codes.NotFound, "no such log stream")
-	ErrClusterMetadataNotFetched = status.Error(codes.Unavailable, "cluster metadata not fetched")
-	ErrNotIdleReplicas           = status.Error(codes.FailedPrecondition, "not idle replicas")
+	ErrNoSuchStorageNode = status.Error(codes.NotFound, "no such storage node")
+	ErrNoSuchTopic       = status.Error(codes.NotFound, "no such topic")
+	// ErrNoSuchLogStream indicates that the log stream does not exist.
+	ErrNoSuchLogStream = status.Error(codes.NotFound, "no such log stream")
+	// ErrClusterMetadataNotFetched indicates that the cluster metadata
+	// cannot be fetched from the metadata repository.
+	// It is usually resolved by retrying with a backoff.
+	ErrClusterMetadataNotFetched     = status.Error(codes.Unavailable, "cluster metadata not fetched")
+	ErrNotIdleReplicas               = status.Error(codes.FailedPrecondition, "not idle replicas")
+	ErrMetadataRepositoryUnavailable = status.Error(codes.Unavailable, "metadata repository unavailable")
 )

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/status"
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpcctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
@@ -16,6 +17,7 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
@@ -536,6 +538,12 @@ func (adm *Admin) waitUnsealed(ctx context.Context, lsid types.LogStreamID) erro
 func (adm *Admin) updateLogStream(ctx context.Context, lsid types.LogStreamID, poppedReplica, pushedReplica varlogpb.ReplicaDescriptor) (*varlogpb.LogStreamDescriptor, error) {
 	// NOTE (jun): Name of the method - updateLogStream can be confused.
 	// updateLogStream can change only replicas. To update status, use Seal or Unseal.
+	if poppedReplica.StorageNodeID == pushedReplica.StorageNodeID {
+		if poppedReplica.Path != pushedReplica.Path {
+			return nil, status.Errorf(codes.Unimplemented, "update log stream: moving data directory")
+		}
+		return nil, status.Errorf(codes.InvalidArgument, "update log stream: the same replica")
+	}
 	adm.mu.Lock()
 	defer adm.mu.Unlock()
 
@@ -544,35 +552,50 @@ func (adm *Admin) updateLogStream(ctx context.Context, lsid types.LogStreamID, p
 
 	clusmeta, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Unavailable, "update log stream: %s", err.Error())
 	}
 
 	oldLSDesc, err := clusmeta.MustHaveLogStream(lsid)
-	if err != nil {
-		return nil, err
+	if err != nil || oldLSDesc.Status.Deleted() {
+		return nil, status.Errorf(codes.NotFound, "update log stream: no such log stream %d", lsid)
 	}
 
-	status := oldLSDesc.GetStatus()
-	if status.Running() || status.Deleted() {
-		return nil, errors.Errorf("invalid log stream status: %s", status)
+	if oldLSDesc.Status.Running() {
+		return nil, status.Errorf(codes.FailedPrecondition, "update log stream: invalid log stream status %s", oldLSDesc.Status)
 	}
-
-	replace := false
-	newLSDesc := proto.Clone(oldLSDesc).(*varlogpb.LogStreamDescriptor)
-	for i := range newLSDesc.Replicas {
-		// TODO - fix? poppedReplica can ignore path.
-		if newLSDesc.Replicas[i].GetStorageNodeID() == poppedReplica.GetStorageNodeID() {
-			newLSDesc.Replicas[i] = &pushedReplica
-			replace = true
-			break
+	popIdx, pushIdx := -1, -1
+	for idx := range oldLSDesc.Replicas {
+		snid := oldLSDesc.Replicas[idx].StorageNodeID
+		if snid == poppedReplica.StorageNodeID {
+			popIdx = idx
+		} else if snid == pushedReplica.StorageNodeID {
+			pushIdx = idx
 		}
 	}
-	if !replace {
-		adm.logger.Panic("logstream push/pop error")
+	if popIdx < 0 && pushIdx >= 0 { // already updated
+		return oldLSDesc, nil
+	}
+	if popIdx < 0 && pushIdx < 0 {
+		return nil, status.Errorf(
+			codes.FailedPrecondition,
+			"update log stream: no victim replica (snid=%v) in log stream %+v",
+			poppedReplica.StorageNodeID,
+			oldLSDesc.Replicas,
+		)
+	}
+	if popIdx >= 0 && pushIdx >= 0 {
+		return nil, status.Errorf(
+			codes.FailedPrecondition,
+			"update log stream: victim replica and new replica already exist in log stream %+v",
+			oldLSDesc.Replicas,
+		)
 	}
 
+	newLSDesc := proto.Clone(oldLSDesc).(*varlogpb.LogStreamDescriptor)
+	newLSDesc.Replicas[popIdx] = &pushedReplica
+
 	if err := adm.snmgr.AddLogStreamReplica(ctx, pushedReplica.GetStorageNodeID(), newLSDesc.TopicID, lsid, pushedReplica.GetPath()); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "update log stream")
 	}
 
 	// To reset the status of the log stream, set it as LogStreamStatusRunning
@@ -581,7 +604,7 @@ func (adm *Admin) updateLogStream(ctx context.Context, lsid types.LogStreamID, p
 	}()
 
 	if err := adm.mrmgr.UpdateLogStream(ctx, newLSDesc); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("update log stream: %w", err)
 	}
 
 	return newLSDesc, nil

--- a/internal/admin/mrmanager/manager.go
+++ b/internal/admin/mrmanager/manager.go
@@ -4,6 +4,7 @@ package mrmanager
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"math"
 	"sync"
@@ -12,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
-	"github.com/kakao/varlog/internal/admin/admerrors"
 	"github.com/kakao/varlog/pkg/mrc"
 	"github.com/kakao/varlog/pkg/mrc/mrconnector"
 	"github.com/kakao/varlog/pkg/types"
@@ -396,7 +396,7 @@ func (mrm *mrManager) ClusterMetadata(ctx context.Context) (*varlogpb.MetadataDe
 	if mrm.dirty || time.Since(mrm.updated) > ReloadInterval {
 		meta, err := mrm.clusterMetadata(ctx)
 		if err != nil {
-			return nil, errors.Wrap(admerrors.ErrClusterMetadataNotFetched, err.Error())
+			return nil, fmt.Errorf("cluster metadata: %w", err)
 		}
 		mrm.meta = meta
 		mrm.dirty = false

--- a/internal/storagenode/client/management_client.go
+++ b/internal/storagenode/client/management_client.go
@@ -85,7 +85,7 @@ func (c *ManagementClient) GetMetadata(ctx context.Context) (*snpb.StorageNodeMe
 
 func (c *ManagementClient) AddLogStreamReplica(ctx context.Context, tpid types.TopicID, lsid types.LogStreamID, path string) error {
 	if stringsutil.Empty(path) {
-		return errors.New("snmcl: invalid argument")
+		return errors.New("snmcl: empty path")
 	}
 	// FIXME(jun): Does the return value of AddLogStream need?
 	_, err := c.rpcClient.AddLogStreamReplica(ctx, &snpb.AddLogStreamReplicaRequest{

--- a/pkg/varlog/admin.go
+++ b/pkg/varlog/admin.go
@@ -305,7 +305,11 @@ func (c *admin) UpdateLogStream(ctx context.Context, topicID types.TopicID, logS
 		PoppedReplica: poppedReplica,
 		PushedReplica: pushedReplica,
 	})
-	return rsp.GetLogStream(), err
+	if err == nil {
+		return rsp.LogStream, nil
+	}
+	// TODO: Use gRPC's code to decide if the error is retriable or not.
+	return nil, err
 }
 
 func (c *admin) UnregisterLogStream(ctx context.Context, topicID types.TopicID, logStreamID types.LogStreamID) error {

--- a/pkg/verrors/errors.go
+++ b/pkg/verrors/errors.go
@@ -118,7 +118,7 @@ func ToStatusError(err error) error {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return ToStatusErrorWithCode(err, codes.DeadlineExceeded)
 	}
-	return ToStatusErrorWithCode(err, codes.Unknown)
+	return ToStatusErrorWithCode(err, status.Code(err))
 }
 
 func ToStatusErrorWithCode(err error, code codes.Code) error {

--- a/proto/vmspb/admin.pb.go
+++ b/proto/vmspb/admin.pb.go
@@ -2752,6 +2752,21 @@ type ClusterManagerClient interface {
 	GetLogStream(ctx context.Context, in *GetLogStreamRequest, opts ...grpc.CallOption) (*GetLogStreamResponse, error)
 	ListLogStreams(ctx context.Context, in *ListLogStreamsRequest, opts ...grpc.CallOption) (*ListLogStreamsResponse, error)
 	AddLogStream(ctx context.Context, in *AddLogStreamRequest, opts ...grpc.CallOption) (*AddLogStreamResponse, error)
+	// UpdateLogStream changes the configuration of replicas in a log stream.
+	// Its codes are defines as followings:
+	// - InvalidArgument: The client tries to swap the same replica.
+	// - Unavailable: The cluster metadata cannot be fetched from the metadata
+	// repository transiently.
+	// - NotFound: The target log stream does not exist.
+	// - FailedPrecondition: Either the target log stream is not sealed, the
+	// target log stream doesn't have a victim replica, or the target log stream
+	// already has both victim and new replica. Note that clients should not retry
+	// without any action.
+	// - Unknown: Either storage node or metadata repository returns an error.
+	//
+	// TODO: Moving the data directory within the same node is not supported yet.
+	// TODO: We will define codes for errors returned from storage nodes and
+	// metadata repository soon.
 	UpdateLogStream(ctx context.Context, in *UpdateLogStreamRequest, opts ...grpc.CallOption) (*UpdateLogStreamResponse, error)
 	UnregisterLogStream(ctx context.Context, in *UnregisterLogStreamRequest, opts ...grpc.CallOption) (*UnregisterLogStreamResponse, error)
 	RemoveLogStreamReplica(ctx context.Context, in *RemoveLogStreamReplicaRequest, opts ...grpc.CallOption) (*RemoveLogStreamReplicaResponse, error)
@@ -3036,6 +3051,21 @@ type ClusterManagerServer interface {
 	GetLogStream(context.Context, *GetLogStreamRequest) (*GetLogStreamResponse, error)
 	ListLogStreams(context.Context, *ListLogStreamsRequest) (*ListLogStreamsResponse, error)
 	AddLogStream(context.Context, *AddLogStreamRequest) (*AddLogStreamResponse, error)
+	// UpdateLogStream changes the configuration of replicas in a log stream.
+	// Its codes are defines as followings:
+	// - InvalidArgument: The client tries to swap the same replica.
+	// - Unavailable: The cluster metadata cannot be fetched from the metadata
+	// repository transiently.
+	// - NotFound: The target log stream does not exist.
+	// - FailedPrecondition: Either the target log stream is not sealed, the
+	// target log stream doesn't have a victim replica, or the target log stream
+	// already has both victim and new replica. Note that clients should not retry
+	// without any action.
+	// - Unknown: Either storage node or metadata repository returns an error.
+	//
+	// TODO: Moving the data directory within the same node is not supported yet.
+	// TODO: We will define codes for errors returned from storage nodes and
+	// metadata repository soon.
 	UpdateLogStream(context.Context, *UpdateLogStreamRequest) (*UpdateLogStreamResponse, error)
 	UnregisterLogStream(context.Context, *UnregisterLogStreamRequest) (*UnregisterLogStreamResponse, error)
 	RemoveLogStreamReplica(context.Context, *RemoveLogStreamReplicaRequest) (*RemoveLogStreamReplicaResponse, error)

--- a/proto/vmspb/admin.proto
+++ b/proto/vmspb/admin.proto
@@ -367,6 +367,21 @@ service ClusterManager {
   rpc GetLogStream(GetLogStreamRequest) returns (GetLogStreamResponse) {}
   rpc ListLogStreams(ListLogStreamsRequest) returns (ListLogStreamsResponse) {}
   rpc AddLogStream(AddLogStreamRequest) returns (AddLogStreamResponse) {}
+  // UpdateLogStream changes the configuration of replicas in a log stream.
+  // Its codes are defines as followings:
+  // - InvalidArgument: The client tries to swap the same replica.
+  // - Unavailable: The cluster metadata cannot be fetched from the metadata
+  // repository transiently.
+  // - NotFound: The target log stream does not exist.
+  // - FailedPrecondition: Either the target log stream is not sealed, the
+  // target log stream doesn't have a victim replica, or the target log stream
+  // already has both victim and new replica. Note that clients should not retry
+  // without any action.
+  // - Unknown: Either storage node or metadata repository returns an error.
+  //
+  // TODO: Moving the data directory within the same node is not supported yet.
+  // TODO: We will define codes for errors returned from storage nodes and
+  // metadata repository soon.
   rpc UpdateLogStream(UpdateLogStreamRequest)
       returns (UpdateLogStreamResponse) {}
   rpc UnregisterLogStream(UnregisterLogStreamRequest)

--- a/tests/it/admin_test.go
+++ b/tests/it/admin_test.go
@@ -1,0 +1,144 @@
+package it
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gogo/status"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	"github.com/kakao/varlog/internal/admin/mrmanager"
+	"github.com/kakao/varlog/pkg/types"
+	"github.com/kakao/varlog/pkg/varlog"
+	"github.com/kakao/varlog/proto/varlogpb"
+)
+
+func TestAdminUpdateLogStream(t *testing.T) {
+	const (
+		replicationFactor      = 3
+		numInitialStorageNodes = 3
+		numTopics              = 1
+		numLogStreams          = 1
+	)
+
+	tcs := []struct {
+		name  string
+		testf func(*testing.T, *VarlogCluster, varlog.Admin, types.TopicID, types.LogStreamID, varlogpb.ReplicaDescriptor, varlogpb.ReplicaDescriptor)
+	}{
+		{
+			name: "Succeed",
+			testf: func(t *testing.T, clus *VarlogCluster, adm varlog.Admin, tpid types.TopicID, lsid types.LogStreamID, oldReplica, newReplica varlogpb.ReplicaDescriptor) {
+				_, err := adm.Seal(context.Background(), tpid, lsid)
+				require.NoError(t, err)
+
+				_, err = adm.UpdateLogStream(context.Background(), tpid, lsid, oldReplica, newReplica)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "AlreadyUpdated",
+			testf: func(t *testing.T, clus *VarlogCluster, adm varlog.Admin, tpid types.TopicID, lsid types.LogStreamID, oldReplica, newReplica varlogpb.ReplicaDescriptor) {
+				_, err := adm.Seal(context.Background(), tpid, lsid)
+				require.NoError(t, err)
+
+				_, err = adm.UpdateLogStream(context.Background(), tpid, lsid, newReplica, oldReplica)
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "MetadataRepositoryFailure",
+			testf: func(t *testing.T, clus *VarlogCluster, adm varlog.Admin, tpid types.TopicID, lsid types.LogStreamID, oldReplica, newReplica varlogpb.ReplicaDescriptor) {
+				_, err := adm.Seal(context.Background(), tpid, lsid)
+				require.NoError(t, err)
+
+				clus.CloseMR(t, 0)
+				time.Sleep(mrmanager.ReloadInterval * 2)
+
+				_, err = adm.UpdateLogStream(context.Background(), tpid, lsid, oldReplica, newReplica)
+				require.Error(t, err)
+				require.Equal(t, codes.Unavailable, status.Convert(err).Code())
+			},
+		},
+		{
+			name: "LogStreamNotExist",
+			testf: func(t *testing.T, clus *VarlogCluster, adm varlog.Admin, tpid types.TopicID, lsid types.LogStreamID, oldReplica, newReplica varlogpb.ReplicaDescriptor) {
+				_, err := adm.UpdateLogStream(context.Background(), tpid, lsid+1, oldReplica, newReplica)
+				require.Error(t, err)
+				require.Equal(t, codes.NotFound, status.Convert(err).Code())
+			},
+		},
+		{
+			name: "LogStreamNotSealed",
+			testf: func(t *testing.T, clus *VarlogCluster, adm varlog.Admin, tpid types.TopicID, lsid types.LogStreamID, oldReplica, newReplica varlogpb.ReplicaDescriptor) {
+				_, err := adm.UpdateLogStream(context.Background(), tpid, lsid, oldReplica, newReplica)
+				require.Error(t, err)
+				require.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
+			},
+		},
+		{
+			name: "VictimReplicaNotExist",
+			testf: func(t *testing.T, clus *VarlogCluster, adm varlog.Admin, tpid types.TopicID, lsid types.LogStreamID, oldReplica, newReplica varlogpb.ReplicaDescriptor) {
+				_, err := adm.Seal(context.Background(), tpid, lsid)
+				require.NoError(t, err)
+
+				oldReplica.StorageNodeID = clus.StorageNodeIDAtIndex(t, numInitialStorageNodes) + 1
+				_, err = adm.UpdateLogStream(context.Background(), tpid, lsid, oldReplica, newReplica)
+				require.Error(t, err)
+				require.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
+			},
+		},
+		{
+			name: "VictimAndNewReplicaAlreadyExist",
+			testf: func(t *testing.T, clus *VarlogCluster, adm varlog.Admin, tpid types.TopicID, lsid types.LogStreamID, oldReplica, newReplica varlogpb.ReplicaDescriptor) {
+				lsd, err := adm.GetLogStream(context.Background(), tpid, lsid)
+				require.NoError(t, err)
+				oldReplica.StorageNodeID = lsd.Replicas[0].StorageNodeID
+				oldReplica.Path = lsd.Replicas[0].Path
+				newReplica.StorageNodeID = lsd.Replicas[1].StorageNodeID
+				newReplica.Path = lsd.Replicas[1].Path
+
+				_, err = adm.Seal(context.Background(), tpid, lsid)
+				require.NoError(t, err)
+
+				_, err = adm.UpdateLogStream(context.Background(), tpid, lsid, oldReplica, newReplica)
+				require.Error(t, err)
+				require.Equal(t, codes.FailedPrecondition, status.Convert(err).Code())
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			clus := NewVarlogCluster(t,
+				WithReplicationFactor(replicationFactor),
+				WithNumberOfStorageNodes(numInitialStorageNodes),
+				WithNumberOfTopics(numTopics),
+				WithNumberOfLogStreams(numLogStreams),
+			)
+			defer clus.Close(t)
+
+			tpid := clus.TopicIDs()[0]
+			lsid := clus.LogStreamID(t, tpid, 0)
+			adm := clus.GetVMSClient(t)
+
+			lsd, err := adm.GetLogStream(context.Background(), tpid, lsid)
+			require.NoError(t, err)
+			oldReplica := varlogpb.ReplicaDescriptor{
+				StorageNodeID: lsd.Replicas[replicationFactor-1].StorageNodeID,
+				Path:          lsd.Replicas[replicationFactor-1].Path,
+			}
+
+			newsnid := clus.AddSN(t)
+			snm, err := adm.GetStorageNode(context.Background(), newsnid)
+			require.NoError(t, err)
+			newReplica := varlogpb.ReplicaDescriptor{
+				StorageNodeID: newsnid,
+				Path:          snm.Storages[0].Path,
+			}
+
+			tc.testf(t, clus, adm, tpid, lsid, oldReplica, newReplica)
+		})
+	}
+}


### PR DESCRIPTION
### What this PR does

This patch adds gRPC codes to errors returned from RPC `proto/vmspb.UpdateLogStream. It helps
clients to clarify kind of errors and decides if it is retriable.

### Which issue(s) this PR resolves

Resolves #107

### Anything else

Refs: https://grpc.github.io/grpc/core/md_doc_statuscodes.html

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/109)
<!-- Reviewable:end -->
