### PR TITLE
fix(admin): contains all storage nodes registered to the cluster

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/status"
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpczap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
 	grpcctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
@@ -16,6 +17,7 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
@@ -163,17 +165,57 @@ func (adm *Admin) Metadata(ctx context.Context) (*varlogpb.MetadataDescriptor, e
 }
 
 func (adm *Admin) getStorageNode(ctx context.Context, snid types.StorageNodeID) (*vmspb.StorageNodeMetadata, error) {
-	snm, ok := adm.statRepository.GetStorageNode(snid)
-	if !ok {
-		return nil, errors.WithMessagef(admerrors.ErrNoSuchStorageNode, "get storage node %d", int32(snid))
+	adm.mu.RLock()
+	defer adm.mu.RUnlock()
+
+	md, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "get storage node: cluster metadata not fetched")
 	}
-	return snm, nil
+	snd := md.GetStorageNode(snid)
+	if snd == nil {
+		return nil, status.Errorf(codes.NotFound, "get storage node: %d", int32(snid))
+	}
+	if snm, ok := adm.statRepository.GetStorageNode(snid); ok {
+		return snm, nil
+	}
+	return &vmspb.StorageNodeMetadata{
+		StorageNodeMetadataDescriptor: snpb.StorageNodeMetadataDescriptor{
+			ClusterID:   adm.cid,
+			StorageNode: snd.StorageNode,
+		},
+		CreateTime: snd.CreateTime,
+	}, nil
 }
 
 func (adm *Admin) listStorageNodes(ctx context.Context) ([]vmspb.StorageNodeMetadata, error) {
 	adm.mu.RLock()
 	defer adm.mu.RUnlock()
-	return adm.statRepository.ListStorageNodes(), nil
+
+	md, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "list storage nodes: cluster metadata not fetched")
+	}
+
+	snms := make([]vmspb.StorageNodeMetadata, 0, len(md.StorageNodes))
+	snmsMap := adm.statRepository.ListStorageNodes()
+	for _, snd := range md.StorageNodes {
+		if snm, ok := snmsMap[snd.StorageNodeID]; ok {
+			snms = append(snms, *snm)
+			continue
+		}
+		snms = append(snms, vmspb.StorageNodeMetadata{
+			StorageNodeMetadataDescriptor: snpb.StorageNodeMetadataDescriptor{
+				ClusterID:   adm.cid,
+				StorageNode: snd.StorageNode,
+			},
+			CreateTime: snd.CreateTime,
+		})
+	}
+	sort.Slice(snms, func(i, j int) bool {
+		return snms[i].StorageNode.StorageNodeID < snms[j].StorageNode.StorageNodeID
+	})
+	return snms, nil
 }
 
 // addStorageNode adds a new storage node to the cluster.

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -141,7 +141,6 @@ func TestAdmin_GetStorageNode(t *testing.T) {
 				mock.MockClusterMetadataView.EXPECT().ClusterMetadata(gomock.Any()).Return(
 					&varlogpb.MetadataDescriptor{}, nil,
 				).AnyTimes()
-				mock.MockRepository.EXPECT().GetStorageNode(snid).Return(nil, false)
 			},
 		},
 		{
@@ -149,7 +148,15 @@ func TestAdmin_GetStorageNode(t *testing.T) {
 			success: true,
 			prepare: func(mock *testMock) {
 				mock.MockClusterMetadataView.EXPECT().ClusterMetadata(gomock.Any()).Return(
-					&varlogpb.MetadataDescriptor{}, nil,
+					&varlogpb.MetadataDescriptor{
+						StorageNodes: []*varlogpb.StorageNodeDescriptor{
+							{
+								StorageNode: varlogpb.StorageNode{
+									StorageNodeID: snid,
+								},
+							},
+						},
+					}, nil,
 				).AnyTimes()
 				mock.MockRepository.EXPECT().GetStorageNode(snid).Return(&vmspb.StorageNodeMetadata{
 					StorageNodeMetadataDescriptor: snpb.StorageNodeMetadataDescriptor{
@@ -158,6 +165,24 @@ func TestAdmin_GetStorageNode(t *testing.T) {
 						},
 					},
 				}, true)
+			},
+		},
+		{
+			name:    "Success without exact status",
+			success: true,
+			prepare: func(mock *testMock) {
+				mock.MockClusterMetadataView.EXPECT().ClusterMetadata(gomock.Any()).Return(
+					&varlogpb.MetadataDescriptor{
+						StorageNodes: []*varlogpb.StorageNodeDescriptor{
+							{
+								StorageNode: varlogpb.StorageNode{
+									StorageNodeID: snid,
+								},
+							},
+						},
+					}, nil,
+				).AnyTimes()
+				mock.MockRepository.EXPECT().GetStorageNode(snid).Return(nil, false)
 			},
 		},
 	}
@@ -350,8 +375,8 @@ func TestAdmin_ListStorageNodes(t *testing.T) {
 					}, nil,
 				).AnyTimes()
 				mock.MockRepository.EXPECT().ListStorageNodes().Return(
-					[]vmspb.StorageNodeMetadata{
-						{
+					map[types.StorageNodeID]*vmspb.StorageNodeMetadata{
+						snid: {
 							StorageNodeMetadataDescriptor: snpb.StorageNodeMetadataDescriptor{
 								StorageNode: varlogpb.StorageNode{
 									StorageNodeID: snid,

--- a/internal/admin/stats/repository_mock.go
+++ b/internal/admin/stats/repository_mock.go
@@ -70,10 +70,10 @@ func (mr *MockRepositoryMockRecorder) GetStorageNode(arg0 interface{}) *gomock.C
 }
 
 // ListStorageNodes mocks base method.
-func (m *MockRepository) ListStorageNodes() []vmspb.StorageNodeMetadata {
+func (m *MockRepository) ListStorageNodes() map[types.StorageNodeID]*vmspb.StorageNodeMetadata {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListStorageNodes")
-	ret0, _ := ret[0].([]vmspb.StorageNodeMetadata)
+	ret0, _ := ret[0].(map[types.StorageNodeID]*vmspb.StorageNodeMetadata)
 	return ret0
 }
 

--- a/pkg/verrors/errors.go
+++ b/pkg/verrors/errors.go
@@ -34,11 +34,12 @@ var (
 )
 
 var (
-	ErrInvalid  = errors.New("invalid argument")
-	ErrExist    = errors.New("already exists")
-	ErrNotExist = errors.New("not exist")
-	ErrState    = errors.New("invalid state")
-	ErrClosed   = errors.New("closed")
+	ErrInvalid     = errors.New("invalid argument")
+	ErrExist       = errors.New("already exists")
+	ErrNotExist    = errors.New("not exist")
+	ErrUnavailable = errors.New("unavailable")
+	ErrState       = errors.New("invalid state")
+	ErrClosed      = errors.New("closed")
 
 	ErrIgnore     = errors.New("ignore")
 	ErrInprogress = errors.New("inprogress")

--- a/proto/vmspb/admin.pb.go
+++ b/proto/vmspb/admin.pb.go
@@ -37,10 +37,18 @@ var _ = time.Kitchen
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
+// StorageNodeMetadata represents the current status of the storage node.
 type StorageNodeMetadata struct {
 	snpb.StorageNodeMetadataDescriptor `protobuf:"bytes,1,opt,name=storage_node,json=storageNode,proto3,embedded=storage_node" json:""`
-	CreateTime                         time.Time `protobuf:"bytes,2,opt,name=create_time,json=createTime,proto3,stdtime" json:"createTime"`
-	LastHeartbeatTime                  time.Time `protobuf:"bytes,3,opt,name=last_heartbeat_time,json=lastHeartbeatTime,proto3,stdtime" json:"lastHeartbeatTime"`
+	// CreateTime is the time when the storage node is created and registered to
+	// the metadata repository.
+	CreateTime time.Time `protobuf:"bytes,2,opt,name=create_time,json=createTime,proto3,stdtime" json:"createTime"`
+	// LastHeartbeatTime is the time when the admin server checked the liveness of
+	// the storage node. A zero value indicates that the admin server does not
+	// check the storage node. Typically, since the storage node is just
+	// registered, the admin server does not know the field. It is also possible
+	// that the admin server is just restarted.
+	LastHeartbeatTime time.Time `protobuf:"bytes,3,opt,name=last_heartbeat_time,json=lastHeartbeatTime,proto3,stdtime" json:"lastHeartbeatTime"`
 }
 
 func (m *StorageNodeMetadata) Reset()         { *m = StorageNodeMetadata{} }

--- a/proto/vmspb/admin.proto
+++ b/proto/vmspb/admin.proto
@@ -18,6 +18,7 @@ option (gogoproto.goproto_unkeyed_all) = false;
 option (gogoproto.goproto_unrecognized_all) = false;
 option (gogoproto.goproto_sizecache_all) = false;
 
+// StorageNodeMetadata represents the current status of the storage node.
 message StorageNodeMetadata {
   option (gogoproto.equal) = true;
 
@@ -26,11 +27,18 @@ message StorageNodeMetadata {
     (gogoproto.embed) = true,
     (gogoproto.jsontag) = ""
   ];
+  // CreateTime is the time when the storage node is created and registered to
+  // the metadata repository.
   google.protobuf.Timestamp create_time = 2 [
     (gogoproto.stdtime) = true,
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "createTime"
   ];
+  // LastHeartbeatTime is the time when the admin server checked the liveness of
+  // the storage node. A zero value indicates that the admin server does not
+  // check the storage node. Typically, since the storage node is just
+  // registered, the admin server does not know the field. It is also possible
+  // that the admin server is just restarted.
   google.protobuf.Timestamp last_heartbeat_time = 3 [
     (gogoproto.stdtime) = true,
     (gogoproto.nullable) = false,

--- a/tests/it/management/management_test.go
+++ b/tests/it/management/management_test.go
@@ -95,7 +95,7 @@ func TestUnregisterInactiveStorageNode(t *testing.T) {
 	err := clus.GetVMSClient(t).UnregisterStorageNode(context.Background(), snID)
 	require.NoError(t, err)
 
-	snMap, err := clus.GetVMSClient(t).GetStorageNodes(context.Background())
+	snMap, err := clus.GetVMSClient(t).ListStorageNodes(context.Background())
 	require.NoError(t, err)
 	require.Len(t, snMap, 0)
 }

--- a/tests/it/testenv.go
+++ b/tests/it/testenv.go
@@ -1193,6 +1193,22 @@ func (clus *VarlogCluster) StartVMS(t *testing.T) {
 	clus.initVMS(t)
 }
 
+func (clus *VarlogCluster) RestartVMS(t *testing.T) {
+	clus.muVMS.Lock()
+	defer clus.muVMS.Unlock()
+
+	require.NotNil(t, clus.vmsServer)
+	require.NoError(t, clus.vmsServer.Close())
+	clus.wgVms.Wait()
+
+	clus.initVMS(t)
+
+	if clus.vmsCL != nil {
+		require.NoError(t, clus.vmsCL.Close())
+	}
+	clus.initVMSClient(t)
+}
+
 func (clus *VarlogCluster) GetVMSClient(t *testing.T) varlog.Admin {
 	clus.muVMS.Lock()
 	defer clus.muVMS.Unlock()


### PR DESCRIPTION
### What this PR does

RPCs GetStorageNode and ListStorageNodes should contain all storage nodes registered to the cluster
even if the admin server is just restarted.
Previously, if the admin server was restarted the stats repository of the admin was flushed, thus,
it had a problem that the RPCs do not return all storage nodes after restarting.
This patch fixes the problem by using the cluster metadata fetched from the metadata repository. If
the metadata repository is not reachable transiently, the RPCs return an error with the status code
`Unavailable`.

### Which issue(s) this PR resolves

Resolves #106

### Anything else

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/110)
<!-- Reviewable:end -->
