### PR TITLE
fix(admin): add log stream replicas to result of ListStorageNodes

### DIFF
--- a/pkg/varlog/admin.go
+++ b/pkg/varlog/admin.go
@@ -25,17 +25,16 @@ type Admin interface {
 
 	// GetStorageNode returns the metadata of the storage node specified by the argument snid.
 	// If the admin server does not check the heartbeat of the storage node
-	// yet, some fields are zero values, for instance,
-	// LastHeartbeatTime, and Storages, LogStreamReplicas, Status, and
-	// StartTime of StorageNodeMetadataDescriptor.
+	// yet, some fields are zero values, for instance, LastHeartbeatTime,
+	// and Storages, Status, and StartTime of StorageNodeMetadataDescriptor.
 	// It returns the ErrNotExist if the storage node does not exist.
-	// It returns the ErrUnavailable if the cluster metadata cannot be fetched from the metadata repository.
+	// It returns the ErrUnavailable if the cluster metadata cannot be
+	// fetched from the metadata repository.
 	GetStorageNode(ctx context.Context, snid types.StorageNodeID) (*vmspb.StorageNodeMetadata, error)
 	// ListStorageNodes returns a list of storage node metadata.
 	// If the admin server does not check the heartbeat of the storage node
-	// yet, some fields are zero values, for instance,
-	// LastHeartbeatTime, and Storages, LogStreamReplicas, Status, and
-	// StartTime of StorageNodeMetadataDescriptor.
+	// yet, some fields are zero values, for instance, LastHeartbeatTime,
+	// and Storages, Status, and StartTime of StorageNodeMetadataDescriptor.
 	// It returns the ErrUnavailable if the cluster metadata cannot be fetched from the metadata repository.
 	//
 	// Note that it should return an empty slice rather than nil to encode
@@ -43,9 +42,8 @@ type Admin interface {
 	ListStorageNodes(ctx context.Context) ([]vmspb.StorageNodeMetadata, error)
 	// GetStorageNodes returns a map of StorageNodeIDs and their addresses.
 	// If the admin server does not check the heartbeat of the storage node
-	// yet, some fields are zero values, for instance,
-	// LastHeartbeatTime, and Storages, LogStreamReplicas, Status, and
-	// StartTime of StorageNodeMetadataDescriptor.
+	// yet, some fields are zero values, for instance, LastHeartbeatTime,
+	// and Storages, Status, and StartTime of StorageNodeMetadataDescriptor.
 	// It returns the ErrUnavailable if the cluster metadata cannot be fetched from the metadata repository.
 	//
 	// Deprecated: Use ListStorageNodes.


### PR DESCRIPTION
### What this PR does

\#110 fixed the #106. However, it might not contain the log stream replicas in the result of
ListStorageNodes when the admin has been just restarted.
This patch uses the cluster metadata even if there is no information about the storage node in the
stats repository.

### Which issue(s) this PR resolves

Resolves #106

### Anything else

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/112)
<!-- Reviewable:end -->
