### PR TITLE
fix(storagenode): make volumes absolute

### DIFF
--- a/internal/storagenode/config.go
+++ b/internal/storagenode/config.go
@@ -62,7 +62,7 @@ func newConfig(opts []Option) (config, error) {
 	return cfg, nil
 }
 
-func (cfg config) validate() error {
+func (cfg *config) validate() error {
 	if cfg.snid.Invalid() {
 		return fmt.Errorf("storage node: invalid id %d", int32(cfg.snid))
 	}

--- a/internal/storagenode/storagenode_test.go
+++ b/internal/storagenode/storagenode_test.go
@@ -3,6 +3,7 @@ package storagenode
 import (
 	"math/rand"
 	"os"
+	"path/filepath"
 	"sort"
 	"sync"
 	"testing"
@@ -405,4 +406,24 @@ func TestStorageNode_InvalidConfig(t *testing.T) {
 		WithVolumes(badVolume, badVolume),
 	)
 	assert.Error(t, err)
+}
+
+func TestStorageNode_MakeVolumesAbsolute(t *testing.T) {
+	sn, err := NewStorageNode(
+		WithStorageNodeID(1),
+		WithListenAddress("127.0.0.1:0"),
+		WithVolumes("./testdata/relative_volume"),
+	)
+	assert.NoError(t, err)
+	defer func() {
+		ps, err := filepath.Glob("./testdata/relative_volume/*")
+		assert.NoError(t, err)
+		for _, p := range ps {
+			_ = os.RemoveAll(p)
+		}
+	}()
+
+	for _, volume := range sn.volumes {
+		assert.True(t, filepath.IsAbs(volume))
+	}
 }


### PR DESCRIPTION
### What this PR does

This makes all volumes of storage node absolute even if user sets the flag `--volumes` as relative.
The absolute paths make more explicit than relative path, thus storage node should manage data directories as absolute path.

### Which issue(s) this PR resolves

Resolves #116

### Anything else

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/117)
<!-- Reviewable:end -->
