### PR TITLE
ci: add codecov token

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,7 @@ jobs:
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.0
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out,./coverage.xml
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
### What this PR does

Uploading coverage report fails sometimes.
According to the log, this patch set a token for codecov although the token is not necessary for a public repository.

```
[2022-09-05T15:18:53.760Z] ['error'] There was an error running the uploader: Error uploading to https://codecov.io: Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/118)
<!-- Reviewable:end -->
