### PR TITLE
test(storagenode): do not delete ".keep" file from `internal/storagenode/testdata/relative_volume`

### DIFF
--- a/internal/storagenode/storagenode_test.go
+++ b/internal/storagenode/storagenode_test.go
@@ -419,6 +419,9 @@ func TestStorageNode_MakeVolumesAbsolute(t *testing.T) {
 		ps, err := filepath.Glob("./testdata/relative_volume/*")
 		assert.NoError(t, err)
 		for _, p := range ps {
+			if filepath.Base(p) == ".keep" {
+				continue
+			}
 			_ = os.RemoveAll(p)
 		}
 	}()


### PR DESCRIPTION
### What this PR does

This patch makes test not delete `internal/storagenode/testdata/relative_volume/.keep`.
Hidden file `internal/storagenode/testdata/relative_volume/.keep` prevents
`internal/storagenode/testdata/relative_volume` from deleting since git is
ignore empty directory.

### Which issue(s) this PR resolves

### Anything else

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/123)
<!-- Reviewable:end -->
