### PR TITLE
fix(admin): succeed to `/varlog.vmspb.ClusterManager/UpdateLogStream` when already updated

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -658,9 +658,6 @@ func (adm *Admin) updateLogStream(ctx context.Context, lsid types.LogStreamID, p
 		return nil, status.Errorf(codes.NotFound, "update log stream: no such log stream %d", lsid)
 	}
 
-	if oldLSDesc.Status.Running() {
-		return nil, status.Errorf(codes.FailedPrecondition, "update log stream: invalid log stream status %s", oldLSDesc.Status)
-	}
 	popIdx, pushIdx := -1, -1
 	for idx := range oldLSDesc.Replicas {
 		snid := oldLSDesc.Replicas[idx].StorageNodeID
@@ -687,6 +684,10 @@ func (adm *Admin) updateLogStream(ctx context.Context, lsid types.LogStreamID, p
 			"update log stream: victim replica and new replica already exist in log stream %+v",
 			oldLSDesc.Replicas,
 		)
+	}
+
+	if oldLSDesc.Status.Running() {
+		return nil, status.Errorf(codes.FailedPrecondition, "update log stream: invalid log stream status %s", oldLSDesc.Status)
 	}
 
 	newLSDesc := proto.Clone(oldLSDesc).(*varlogpb.LogStreamDescriptor)

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -1612,7 +1612,6 @@ func TestAdmin_UpdateLogStream(t *testing.T) {
 				mock.MockRepository.EXPECT().SetLogStreamStatus(lsid, varlogpb.LogStreamStatusRunning)
 			},
 		},
-		// TODO: Add more test cases, for instance, choosing the best replica automatically, ...
 		{
 			name:    "Success",
 			success: true,
@@ -1641,6 +1640,29 @@ func TestAdmin_UpdateLogStream(t *testing.T) {
 					gomock.Any(), gomock.Any(),
 				).Return(nil)
 				mock.MockRepository.EXPECT().SetLogStreamStatus(lsid, varlogpb.LogStreamStatusRunning)
+			},
+		},
+		{
+			name:    "AlreadyUpdated",
+			success: true,
+			prepare: func(mock *testMock) {
+				mock.MockClusterMetadataView.EXPECT().ClusterMetadata(gomock.Any()).Return(
+					&varlogpb.MetadataDescriptor{
+						LogStreams: []*varlogpb.LogStreamDescriptor{
+							{
+								TopicID:     tpid,
+								LogStreamID: lsid,
+								Status:      varlogpb.LogStreamStatusSealed,
+								Replicas: []*varlogpb.ReplicaDescriptor{
+									{
+										StorageNodeID:   snid2,
+										StorageNodePath: snpath2,
+									},
+								},
+							},
+						},
+					}, nil,
+				).AnyTimes()
 			},
 		},
 	}


### PR DESCRIPTION
### What this PR does

This patch makes the RPC `/varlog.vmspb.ClusterManager/UpdateLogStream` succeed
when the replicas are already updated.

### Which issue(s) this PR resolves

Resolves #126

### Anything else

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/137)
<!-- Reviewable:end -->
