### PR TITLE
test: fix bad int casting in `internal/metarepos.(*DummyStorageNodeClientFactory).GetManagementClient`

### DIFF
--- a/internal/metarepos/dummy_storagenode_client_factory_impl.go
+++ b/internal/metarepos/dummy_storagenode_client_factory_impl.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 
@@ -187,7 +186,7 @@ func (fac *DummyStorageNodeClientFactory) GetReporterClient(ctx context.Context,
 
 func (fac *DummyStorageNodeClientFactory) GetManagementClient(ctx context.Context, _ types.ClusterID, address string, _ *zap.Logger) (client.StorageNodeManagementClient, error) {
 	// cheating for test
-	snID, err := strconv.Atoi(address)
+	snID, err := types.ParseStorageNodeID(address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What this PR does

Fix CodeQL issue - fix bad integer casting.

See https://github.com/kakao/varlog/security/code-scanning/1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/151)
<!-- Reviewable:end -->
