### PR TITLE
fix(storagenode): remove data directory in removing log stream replica

### DIFF
--- a/internal/storagenode/logstream/executor.go
+++ b/internal/storagenode/logstream/executor.go
@@ -557,6 +557,11 @@ func (lse *Executor) Trim(_ context.Context, glsn types.GLSN) error {
 	return nil
 }
 
+// Path returns the data directory where the replica stores its data.
+func (lse *Executor) Path() string {
+	return lse.stg.Path()
+}
+
 func (lse *Executor) Metrics() *telemetry.LogStreamMetrics {
 	return lse.lsm
 }

--- a/internal/storagenode/storagenode.go
+++ b/internal/storagenode/storagenode.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -341,12 +342,13 @@ func (sn *StorageNode) removeLogStreamReplica(_ context.Context, tpid types.Topi
 	if !loaded {
 		return verrors.ErrNotExist
 	}
-	_ = lse.Close()
+	if err := lse.Close(); err != nil {
+		sn.logger.Warn("error while closing log stream replica")
+	}
 	telemetry.UnregisterLogStreamMetrics(sn.metrics, lsid)
-	// TODO (jun): Is removing data path optional or default behavior?
-	// if err := os.RemoveAll(lse.StorageNodePath()); err != nil {
-	//	sn.logger.Warn("error while removing log stream path")
-	// }
+	if err := os.RemoveAll(lse.Path()); err != nil {
+		sn.logger.Warn("error while removing log stream path")
+	}
 	return nil
 }
 


### PR DESCRIPTION
### What this PR does

Remove the data directory when handling RemoveLogStreamReplica.

### Which issue(s) this PR resolves

Resolves #157

### Anything else

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kakao/varlog/158)
<!-- Reviewable:end -->
