### PR TITLE
fix(storagenode): fix error-prone state management of SyncInit and Report

### DIFF
--- a/internal/storagenode/logstream/executor_test.go
+++ b/internal/storagenode/logstream/executor_test.go
@@ -1449,10 +1449,12 @@ func TestExecutorSyncInit(t *testing.T) {
 					LastLLSN:  dstLast + 10,
 				}, syncRange)
 
-				_, _, uncommittedLLSNBegin = dst.lsc.reportCommitBase()
-				uncommittedLLSNEnd = dst.lsc.uncommittedLLSNEnd.Load()
+				ver, hwm, uncommittedLLSNBegin := dst.lsc.reportCommitBase()
+				assert.Zero(t, ver)
+				assert.Zero(t, hwm)
+				assert.Zero(t, uncommittedLLSNBegin)
 
-				assert.Equal(t, dstLast+5, uncommittedLLSNBegin)
+				uncommittedLLSNEnd = dst.lsc.uncommittedLLSNEnd.Load()
 				assert.Equal(t, dstLast+5, uncommittedLLSNEnd)
 
 				lsrmd, err := dst.Metadata()


### PR DESCRIPTION
### What this PR does

When a log stream replica handles SyncInit, it can be prone to mutate the replica's state too early.
It should change the state after checking a valid sync range. It also updates the version, high
watermark, and uncommittedLLSNBegin with zeros to denote that the replica sends an invalid report
while the learning phase.
The replica checks whether it is in the learning phase at the end of method
`internal/storagenode/logstream.(*Executor).Report` to minimize the probability of concurrency
issues mentioned in #159.

### Anything else

Refs
- https://github.com/kakao/varlog/pull/159#issuecomment-1254917165
