### PR TITLE
feat(client): add allowed logstream list option to varlog client

### DIFF
--- a/pkg/varlog/operations.go
+++ b/pkg/varlog/operations.go
@@ -29,6 +29,11 @@ func (v *logImpl) append(ctx context.Context, tpid types.TopicID, lsid types.Log
 				result.Err = multierr.Append(result.Err, err)
 				continue
 			}
+			if _, ok = appendOpts.allowLogStreams[lsid]; appendOpts.allowLogStreams != nil && !ok {
+				err := fmt.Errorf("append: not allowed lsid %d", lsid)
+				result.Err = multierr.Append(result.Err, err)
+				continue
+			}
 		}
 		res, err := v.appendTo(ctx, tpid, lsid, data)
 		if err != nil {

--- a/pkg/varlog/operations.go
+++ b/pkg/varlog/operations.go
@@ -29,7 +29,7 @@ func (v *logImpl) append(ctx context.Context, tpid types.TopicID, lsid types.Log
 				result.Err = multierr.Append(result.Err, err)
 				continue
 			}
-			if _, ok = appendOpts.allowLogStreams[lsid]; appendOpts.allowLogStreams != nil && !ok {
+			if _, ok = appendOpts.allowedLogStreams[lsid]; appendOpts.allowedLogStreams != nil && !ok {
 				err := fmt.Errorf("append: not allowed lsid %d", lsid)
 				result.Err = multierr.Append(result.Err, err)
 				continue

--- a/pkg/varlog/options.go
+++ b/pkg/varlog/options.go
@@ -6,6 +6,8 @@ import (
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/kakao/varlog/pkg/types"
 )
 
 const (
@@ -152,6 +154,7 @@ func defaultAppendOptions() appendOptions {
 type appendOptions struct {
 	retryCount      int
 	selectLogStream bool
+	allowLogStreams map[types.LogStreamID]struct{}
 }
 
 type AppendOption interface {
@@ -179,6 +182,12 @@ func WithRetryCount(retryCount int) AppendOption {
 func withoutSelectLogStream() AppendOption {
 	return newAppendOption(func(opts *appendOptions) {
 		opts.selectLogStream = false
+	})
+}
+
+func WithAllowLogStreams(logStreams map[types.LogStreamID]struct{}) AppendOption {
+	return newAppendOption(func(opts *appendOptions) {
+		opts.allowLogStreams = logStreams
 	})
 }
 

--- a/pkg/varlog/options.go
+++ b/pkg/varlog/options.go
@@ -152,9 +152,9 @@ func defaultAppendOptions() appendOptions {
 }
 
 type appendOptions struct {
-	retryCount      int
-	selectLogStream bool
-	allowLogStreams map[types.LogStreamID]struct{}
+	retryCount        int
+	selectLogStream   bool
+	allowedLogStreams map[types.LogStreamID]struct{}
 }
 
 type AppendOption interface {
@@ -185,9 +185,9 @@ func withoutSelectLogStream() AppendOption {
 	})
 }
 
-func WithAllowLogStreams(logStreams map[types.LogStreamID]struct{}) AppendOption {
+func WithAllowedLogStreams(logStreams map[types.LogStreamID]struct{}) AppendOption {
 	return newAppendOption(func(opts *appendOptions) {
-		opts.allowLogStreams = logStreams
+		opts.allowedLogStreams = logStreams
 	})
 }
 


### PR DESCRIPTION
### What this PR does

This PR allows the user to append within specific LogStreams.

### Which issue(s) this PR resolves

Resolves #171 

### Anything else

Include any links or documentation that might be helpful for reviewers.
