### PR TITLE
feat: unify uncommittedLLSNBegin and localHighWatermark in logStreamContext

### DIFF
--- a/internal/storagenode/logstream/executor.go
+++ b/internal/storagenode/logstream/executor.go
@@ -352,7 +352,7 @@ func (lse *Executor) Report(_ context.Context) (report snpb.LogStreamUncommitRep
 		return snpb.LogStreamUncommitReport{}, verrors.ErrClosed
 	}
 
-	version, highWatermark, uncommittedLLSNBegin, invalid := lse.lsc.reportCommitBase()
+	version, highWatermark, uncommittedBegin, invalid := lse.lsc.reportCommitBase()
 	if invalid {
 		// If it is invalid, incompatibility between the commit context
 		// and the last log entry happens. The report must contain an
@@ -363,6 +363,7 @@ func (lse *Executor) Report(_ context.Context) (report snpb.LogStreamUncommitRep
 		return report, nil
 	}
 
+	uncommittedLLSNBegin := uncommittedBegin.LLSN
 	uncommittedLLSNEnd := lse.lsc.uncommittedLLSNEnd.Load()
 	report = snpb.LogStreamUncommitReport{
 		LogStreamID:           lse.lsid,
@@ -494,19 +495,23 @@ func (lse *Executor) LogStreamMetadata() (lsd varlogpb.LogStreamDescriptor, err 
 	}
 
 	localLWM := lse.lsc.localLowWatermark()
-	localLWM.TopicID = lse.tpid
-	localLWM.LogStreamID = lse.lsid
-
 	localHWM := lse.lsc.localHighWatermark()
-	localHWM.TopicID = lse.tpid
-	localHWM.LogStreamID = lse.lsid
-
 	lsd = varlogpb.LogStreamDescriptor{
 		TopicID:     lse.tpid,
 		LogStreamID: lse.lsid,
 		Status:      status,
-		Head:        localLWM,
-		Tail:        localHWM,
+		Head: varlogpb.LogEntryMeta{
+			TopicID:     lse.tpid,
+			LogStreamID: lse.lsid,
+			LLSN:        localLWM.LLSN,
+			GLSN:        localLWM.GLSN,
+		},
+		Tail: varlogpb.LogEntryMeta{
+			TopicID:     lse.tpid,
+			LogStreamID: lse.lsid,
+			LLSN:        localHWM.LLSN,
+			GLSN:        localHWM.GLSN,
+		},
 	}
 	return lsd, nil
 }
@@ -570,7 +575,10 @@ func (lse *Executor) Trim(_ context.Context, glsn types.GLSN) error {
 	lse.globalLowWatermark.glsn = glsn + 1
 
 	// update local low watermark
-	lse.lsc.setLocalLowWatermark(nextLowWatermark.LogEntryMeta)
+	lse.lsc.setLocalLowWatermark(varlogpb.LogSequenceNumber{
+		LLSN: nextLowWatermark.LLSN,
+		GLSN: nextLowWatermark.GLSN,
+	})
 	return nil
 }
 
@@ -647,22 +655,34 @@ func (lse *Executor) restoreLogStreamContext(rp storage.RecoveryPoints) *logStre
 		restoreMode = "recovered"
 		uncommittedLLSNBegin := cc.CommittedLLSNBegin + types.LLSN(cc.CommittedGLSNEnd-cc.CommittedGLSNBegin)
 		if uncommittedLLSNBegin-1 == last.LLSN {
-			lsc.storeReportCommitBase(cc.Version, cc.HighWatermark, uncommittedLLSNBegin, false)
+			uncommittedBegin := varlogpb.LogSequenceNumber{
+				LLSN: last.LLSN + 1,
+				GLSN: last.GLSN + 1,
+			}
+			lsc.storeReportCommitBase(cc.Version, cc.HighWatermark, uncommittedBegin, false)
 			lsc.uncommittedLLSNEnd.Store(uncommittedLLSNBegin)
-			lsc.setLocalLowWatermark(*first)
-			lsc.setLocalHighWatermark(*last)
+			lsc.setLocalLowWatermark(varlogpb.LogSequenceNumber{
+				LLSN: first.LLSN,
+				GLSN: first.GLSN,
+			})
 			return lsc
 		}
 	}
 
 	// something wrong
 	restoreMode = "invalid"
-	lsc.storeReportCommitBase(types.InvalidVersion, types.InvalidGLSN, types.InvalidLLSN, true)
+	lsc.storeReportCommitBase(types.InvalidVersion, types.InvalidGLSN, varlogpb.LogSequenceNumber{}, true)
 	if last != nil {
-		lsc.storeReportCommitBase(types.InvalidVersion, types.InvalidGLSN, last.LLSN+1, true)
+		uncommittedBegin := varlogpb.LogSequenceNumber{
+			LLSN: last.LLSN + 1,
+			GLSN: last.GLSN + 1,
+		}
+		lsc.storeReportCommitBase(types.InvalidVersion, types.InvalidGLSN, uncommittedBegin, true)
 		lsc.uncommittedLLSNEnd.Store(last.LLSN + 1)
-		lsc.setLocalLowWatermark(*first)
-		lsc.setLocalHighWatermark(*last)
+		lsc.setLocalLowWatermark(varlogpb.LogSequenceNumber{
+			LLSN: first.LLSN,
+			GLSN: first.GLSN,
+		})
 	}
 	return lsc
 }

--- a/internal/storagenode/logstream/sync_test.go
+++ b/internal/storagenode/logstream/sync_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 func TestExecutor_SyncTracker(t *testing.T) {
-	first := varlogpb.LogEntryMeta{LLSN: 1, GLSN: 1}
-	last := varlogpb.LogEntryMeta{LLSN: 10, GLSN: 10}
+	first := varlogpb.LogSequenceNumber{LLSN: 1, GLSN: 1}
+	last := varlogpb.LogSequenceNumber{LLSN: 10, GLSN: 10}
 	st := newSyncTracker(first, last)
 
 	current := st.toSyncStatus().Current

--- a/proto/varlogpb/metadata.go
+++ b/proto/varlogpb/metadata.go
@@ -543,3 +543,7 @@ func (t *TopicDescriptor) HasLogStream(lsID types.LogStreamID) bool {
 	_, match := t.searchLogStream(lsID)
 	return match
 }
+
+func (lsn LogSequenceNumber) Invalid() bool {
+	return lsn.LLSN.Invalid() || lsn.GLSN.Invalid()
+}


### PR DESCRIPTION
### What this PR does

This patch unifies two similar fields -
`internal/storagenode/logstream.(reportCommitBase).uncommittedLLSNBegin` and
`internal/storagenode/logstream.(logStreamContext). localWatermarks.high`. Usually,
uncommittedLLSNBegin is the next of localHighWatermark. Thus, the uncommittedLLSNBegin can infer
the localHighWatermark. The unified field is `internal/storagenode/logstream.(reportCommitBase).uncommittedBegin`.

The reason why this patch unifies the two fields is to avoid the inconvenience of mutating two
variables at the same time. For example, a log stream replica committer should update the
uncommittedLLSNBegin and local high watermark after committing log entries. Since both are very
similar, we can simplify by merging them.

