### PR TITLE
feat: add a helper package to manipulate processes

### DIFF
--- a/pkg/process/example_test.go
+++ b/pkg/process/example_test.go
@@ -1,0 +1,36 @@
+package process_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kakao/varlog/pkg/process"
+)
+
+func ExampleProcess() {
+	proc, err := process.New(context.Background(), "sh", "-c", "echo stdout1; echo stdout2; echo 1>&2 stderr1; echo 1>&2 stderr2")
+	if err != nil {
+		panic(err)
+	}
+
+	if err := proc.Start(); err != nil {
+		panic(err)
+	}
+
+	for line := range proc.Stderr() {
+		fmt.Println(line)
+	}
+	for line := range proc.Stdout() {
+		fmt.Println(line)
+	}
+
+	if err := proc.Wait(); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// stderr1
+	// stderr2
+	// stdout1
+	// stdout2
+}

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -1,0 +1,117 @@
+package process
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"os/exec"
+	"sync"
+)
+
+// Process wraps exec.Cmd providing channels for stdout and stderr.
+type Process struct {
+	cmd *exec.Cmd
+
+	wg     sync.WaitGroup
+	cancel context.CancelFunc
+	done   <-chan struct{}
+	stdout *reader
+	stderr *reader
+}
+
+// New returns the Process struct to execute a program specified by the
+// arguments.
+func New(ctx context.Context, name string, arg ...string) (*Process, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	cmd := exec.CommandContext(ctx, name, arg...)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		cancel()
+		_ = stdout.Close()
+		return nil, err
+	}
+
+	p := new(Process)
+	p.cmd = cmd
+	p.cancel = cancel
+	p.done = ctx.Done()
+	p.stdout = &reader{reader: stdout, ch: make(chan string)}
+	p.stderr = &reader{reader: stderr, ch: make(chan string)}
+
+	return p, nil
+}
+
+// Start starts the process, and it does not wait for the completion of the
+// process. Users should call the Wait method to release system resources if it
+// returns a nil result.
+func (p *Process) Start() error {
+	p.wg.Add(2)
+	go func() {
+		defer p.wg.Done()
+		p.stdout.read(p.done)
+	}()
+	go func() {
+		defer p.wg.Done()
+		p.stderr.read(p.done)
+	}()
+
+	if err := p.cmd.Start(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Stdout returns a channel for stdout strings.
+func (p *Process) Stdout() <-chan string {
+	return p.stdout.ch
+}
+
+// Stderr returns a channel for stderr strings.
+func (p *Process) Stderr() <-chan string {
+	return p.stderr.ch
+}
+
+// String returns a description of the process. Do not depend on its content.
+func (p *Process) String() string {
+	return p.cmd.String()
+}
+
+// Stop stops the process forcefully.
+func (p *Process) Stop() {
+	p.cancel()
+	_ = p.stdout.reader.Close()
+	_ = p.stderr.reader.Close()
+}
+
+// Wait waits for the process to complete.
+func (p *Process) Wait() error {
+	err := p.cmd.Wait()
+	p.Stop()
+	p.wg.Wait()
+	return err
+}
+
+type reader struct {
+	reader io.ReadCloser
+	ch     chan string
+}
+
+func (rc *reader) read(done <-chan struct{}) {
+	defer func() {
+		close(rc.ch)
+	}()
+	scanner := bufio.NewScanner(rc.reader)
+	for scanner.Scan() {
+		select {
+		case rc.ch <- scanner.Text():
+		case <-done:
+			return
+		}
+	}
+}

--- a/pkg/process/process_test.go
+++ b/pkg/process/process_test.go
@@ -1,0 +1,103 @@
+package process_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kakao/varlog/pkg/process"
+)
+
+func TestProcess(t *testing.T) {
+	tcs := []struct {
+		name  string
+		testf func(*testing.T)
+	}{
+		{
+			name: "ExitZero",
+			testf: func(t *testing.T) {
+				p, err := process.New(context.Background(), "sh", "-c", "ls", "-a")
+				require.NoError(t, err)
+				require.NotEmpty(t, p.String())
+
+				require.NoError(t, p.Start())
+				defer func() {
+					assert.NoError(t, p.Wait())
+				}()
+			},
+		},
+		{
+			name: "ExitNonZero",
+			testf: func(t *testing.T) {
+				p, err := process.New(context.Background(), "sh", "-c", "exit 1")
+				require.NoError(t, err)
+
+				require.NoError(t, p.Start())
+				defer func() {
+					assert.Error(t, p.Wait())
+				}()
+			},
+		},
+		{
+			name: "InvalidArgument",
+			testf: func(t *testing.T) {
+				p, err := process.New(context.Background(), "")
+				require.NoError(t, err)
+
+				require.Error(t, p.Start())
+			},
+		},
+		{
+			name: "ContextTimeout",
+			testf: func(*testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+				defer cancel()
+
+				p, err := process.New(ctx, "sh", "-c", "yes")
+				require.NoError(t, err)
+
+				require.NoError(t, p.Start())
+				require.Error(t, p.Wait())
+			},
+		},
+		{
+			name: "Stop",
+			testf: func(*testing.T) {
+				p, err := process.New(context.Background(), "sh", "-c", "yes")
+				require.NoError(t, err)
+
+				require.NoError(t, p.Start())
+				defer func() {
+					require.Error(t, p.Wait())
+				}()
+
+				var wg sync.WaitGroup
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					for i := 0; i < 100; i++ {
+						<-p.Stdout()
+					}
+					p.Stop()
+
+				}()
+				go func() {
+					defer wg.Done()
+					for stderr := range p.Stderr() {
+						assert.Failf(t, "unexpected stderr", "stderr: %s", stderr)
+						return
+					}
+				}()
+				wg.Wait()
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, tc.testf)
+	}
+}


### PR DESCRIPTION
### What this PR does

This patch adds a new package - `pkg/process`. It spawns a new process and provides channels for
listening stdout and stderr. We can use this package to test end-to-end tests locally.

### Which issue(s) this PR resolves

Updates #184
