### PR TITLE
chore(admin): remove logs for grpc_health_probe

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -76,7 +76,11 @@ func New(ctx context.Context, opts ...Option) (*Admin, error) {
 	grpcServer := grpc.NewServer(
 		grpcmiddleware.WithUnaryServerChain(
 			grpcctxtags.UnaryServerInterceptor(),
-			grpczap.UnaryServerInterceptor(cfg.logger),
+			grpczap.UnaryServerInterceptor(cfg.logger, grpczap.WithDecider(
+				func(fullMethodName string, err error) bool {
+					return err != nil || !grpcHandlerLogDenyList[fullMethodName]
+				},
+			)),
 		),
 	)
 

--- a/internal/admin/init.go
+++ b/internal/admin/init.go
@@ -1,0 +1,15 @@
+package admin
+
+var (
+	grpcHandlerLogDenyList map[string]bool
+)
+
+func init() {
+	grpcHandlerLogDenyList = make(map[string]bool)
+
+	for _, method := range []string{
+		"/grpc.health.v1.Health/Check",
+	} {
+		grpcHandlerLogDenyList[method] = true
+	}
+}


### PR DESCRIPTION
### What this PR does

This patch removes verbose logs for grpc_health_probe in the admin server.

