### PR TITLE
feat(storagenode): remove bad data dirs and deprecate `--data-dirs` and `--volume-strict-check`

### DIFF
--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -42,8 +42,6 @@ func newStartCommand() *cli.Command {
 
 			// volumes
 			flagVolumes.StringSliceFlag(true, nil),
-			flagDataDirs.StringSliceFlag(false, nil),
-			flagVolumeStrictCheck.BoolFlag(),
 
 			flagServerReadBufferSize.StringFlag(false, units.ToByteSizeString(storagenode.DefaultServerReadBufferSize)),
 			flagServerWriteBufferSize.StringFlag(false, units.ToByteSizeString(storagenode.DefaultServerWriteBufferSize)),

--- a/cmd/varlogsn/flags.go
+++ b/cmd/varlogsn/flags.go
@@ -27,14 +27,6 @@ var (
 		Aliases: []string{"volume"},
 		Envs:    []string{"VOLUMES", "VOLUME"},
 	}
-	flagDataDirs = flags.FlagDesc{
-		Name:    "datadirs",
-		Aliases: []string{"datadir", "data-dirs", "data-dir"},
-		Envs:    []string{"DATADIRS", "DATA_DIRS"},
-	}
-	flagVolumeStrictCheck = flags.FlagDesc{
-		Name: "volume-strict-check",
-	}
 
 	// flags for grpc options.
 	flagServerReadBufferSize = flags.FlagDesc{

--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -160,8 +160,6 @@ func start(c *cli.Context) error {
 		storagenode.WithAdvertiseAddress(c.String(flagAdvertise.Name)),
 		storagenode.WithBallastSize(ballastSize),
 		storagenode.WithVolumes(c.StringSlice(flagVolumes.Name)...),
-		storagenode.WithDataDirs(c.StringSlice(flagDataDirs.Name)...),
-		storagenode.WithVolumeStrictCheck(c.Bool(flagVolumeStrictCheck.Name)),
 		storagenode.WithGRPCServerReadBufferSize(readBufferSize),
 		storagenode.WithGRPCServerWriteBufferSize(writeBufferSize),
 		storagenode.WithGRPCServerMaxRecvMsgSize(maxRecvMsgSize),

--- a/internal/storagenode/config.go
+++ b/internal/storagenode/config.go
@@ -34,8 +34,6 @@ type config struct {
 	replicateClientReadBufferSize   int64
 	replicateClientWriteBufferSize  int64
 	volumes                         []string
-	dataDirs                        []string
-	volumeStrictCheck               bool
 	defaultLogStreamExecutorOptions []logstream.ExecutorOption
 	pprofOpts                       []pprof.Option
 	defaultStorageOptions           []storage.Option
@@ -75,9 +73,6 @@ func (cfg *config) validate() error {
 	if err := cfg.validateVolumes(); err != nil {
 		return fmt.Errorf("storage node: invalid volume: %w", err)
 	}
-	if err := cfg.validateDataDirs(); err != nil {
-		return fmt.Errorf("storage node: invalid data directory: %w", err)
-	}
 	return nil
 }
 
@@ -102,26 +97,6 @@ func (cfg *config) validateVolumes() error {
 		volumes = append(volumes, norm)
 	}
 	cfg.volumes = volumes
-	return nil
-}
-
-func (cfg *config) validateDataDirs() error {
-	volumes := make(map[string]bool, len(cfg.volumes))
-	for _, vol := range cfg.volumes {
-		volumes[vol] = true
-	}
-	for _, dir := range cfg.dataDirs {
-		dd, err := volume.ParseDataDir(dir)
-		if err != nil {
-			return err
-		}
-		if err := dd.Valid(cfg.cid, cfg.snid); err != nil {
-			return err
-		}
-		if !volumes[dd.Volume] {
-			return fmt.Errorf("unexpected volume %s", dir)
-		}
-	}
 	return nil
 }
 
@@ -210,18 +185,6 @@ func WithDefaultLogStreamExecutorOptions(defaultLSEOptions ...logstream.Executor
 func WithVolumes(volumes ...string) Option {
 	return newFuncOption(func(cfg *config) {
 		cfg.volumes = volumes
-	})
-}
-
-func WithDataDirs(dataDirs ...string) Option {
-	return newFuncOption(func(cfg *config) {
-		cfg.dataDirs = dataDirs
-	})
-}
-
-func WithVolumeStrictCheck(strict bool) Option {
-	return newFuncOption(func(cfg *config) {
-		cfg.volumeStrictCheck = strict
 	})
 }
 


### PR DESCRIPTION
### What this PR does

This patch deprecates a storage node's `-data-dirs` and `-volume-strict-check` flags. Instead, the
operational script - `start_varlogsn.py` removes data directories not registered to the cluster.

### Which issue(s) this PR resolves

Resolves #215
