### PR TITLE
style(test): do not log verbosely in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ benchmark:
 
 
 # testing
-TEST_FLAGS := -v -race -failfast -count=1
+TEST_FLAGS := -race -failfast -count=1
 GO_COVERAGE_OUTPUT := coverage.out
 GO_COVERAGE_OUTPUT_TMP := $(GO_COVERAGE_OUTPUT).tmp
 PYTEST := pytest

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.2 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -546,10 +546,6 @@ func TestAdmin_AddStorageNode(t *testing.T) {
 	}
 }
 
-func TestAdmin_UnregisterStorageNode(t *testing.T) {
-	t.Skip()
-}
-
 func TestAdmin_GetTopic(t *testing.T) {
 	const tpid = types.TopicID(1)
 

--- a/internal/admin/replica_selector_test.go
+++ b/internal/admin/replica_selector_test.go
@@ -120,10 +120,7 @@ func testUtilizationBalance(t *testing.T, paths, replicas map[types.StorageNodeI
 	}
 	sort.Float64s(us)
 	min, max := us[0], us[len(us)-1]
-	if !assert.LessOrEqual(t, max/min, tolerance) {
-		t.Logf("paths: %+v", paths)
-		t.Logf("replicas: %+v", replicas)
-	}
+	require.LessOrEqual(t, max/min, tolerance)
 }
 
 func testPrimariesBalance(t *testing.T, primaries map[types.StorageNodeID]int, tolerance float64) {

--- a/internal/metarepos/report_collector_test.go
+++ b/internal/metarepos/report_collector_test.go
@@ -615,7 +615,7 @@ func TestReportCollectorSeal(t *testing.T) {
 		mr := NewDummyMetadataRepository(a)
 		cc := newDummyCommitContext()
 
-		logger, _ := zap.NewDevelopment()
+		logger := zap.NewNop()
 		reportCollector := NewReportCollector(mr, DefaultRPCTimeout, newNopTelmetryStub(), logger)
 		reportCollector.Run() //nolint:errcheck,revive // TODO:: Handle an error returned.
 		Reset(func() {
@@ -891,7 +891,6 @@ func TestCommit(t *testing.T) {
 				// wait for prev catchup job to finish
 				time.Sleep(time.Second)
 				mr.trimGLS(trimVer)
-				logger.Debug("trimGLS", zap.Any("knowVer", knownVer), zap.Any("trimVer", trimVer), zap.Any("result", len(mr.m)))
 
 				Convey("ReportCollector should send proper commit against new StorageNode", func() {
 					snID := types.MinStorageNodeID + types.StorageNodeID(nrStorage)

--- a/internal/metarepos/storage_test.go
+++ b/internal/metarepos/storage_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"go.etcd.io/etcd/raft/raftpb"
+	"go.uber.org/zap"
 
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/testutil"
@@ -22,7 +23,7 @@ import (
 
 func TestStorageRegisterSN(t *testing.T) {
 	Convey("SN should be registered", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 		snID := types.StorageNodeID(time.Now().UnixNano())
 		sn := &varlogpb.StorageNodeDescriptor{
 			StorageNode: varlogpb.StorageNode{
@@ -53,7 +54,7 @@ func TestStorageRegisterSN(t *testing.T) {
 
 func TestStoragUnregisterSN(t *testing.T) {
 	Convey("Given a MetadataStorage", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 		snID := types.StorageNodeID(time.Now().UnixNano())
 
 		Convey("When SN is not exist", func(ctx C) {
@@ -124,7 +125,7 @@ func TestStoragUnregisterSN(t *testing.T) {
 
 func TestStoragGetAllSN(t *testing.T) {
 	Convey("Given a MetadataStorage", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		Convey("When SN is not exist", func(ctx C) {
 			Convey("Then it returns nil", func(ctx C) {
@@ -195,7 +196,7 @@ func TestStoragGetAllSN(t *testing.T) {
 
 func TestStoragGetAllLS(t *testing.T) {
 	Convey("Given a MetadataStorage", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		Convey("When LS is not exist", func(ctx C) {
 			Convey("Then it returns nil", func(ctx C) {
@@ -288,7 +289,7 @@ func TestStoragGetAllLS(t *testing.T) {
 
 func TestStorageRegisterLS(t *testing.T) {
 	Convey("LS which has no SN should not be registered", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		err := ms.registerTopic(&varlogpb.TopicDescriptor{TopicID: types.TopicID(1)})
 		So(err, ShouldBeNil)
@@ -301,7 +302,7 @@ func TestStorageRegisterLS(t *testing.T) {
 	})
 
 	Convey("LS should not be registered if not exist proper SN", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		rep := 2
 
@@ -356,7 +357,7 @@ func TestStorageRegisterLS(t *testing.T) {
 
 func TestStoragUnregisterLS(t *testing.T) {
 	Convey("LS which is not exist should not be unregistered", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		lsID := types.LogStreamID(time.Now().UnixNano())
 
@@ -415,7 +416,7 @@ func TestStoragUnregisterLS(t *testing.T) {
 
 func TestStorageUpdateLS(t *testing.T) {
 	Convey("LS should not be updated if not exist proper SN", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 		ms.Run()
 		Reset(func() {
 			ms.Close()
@@ -504,7 +505,7 @@ func TestStorageUpdateLS(t *testing.T) {
 
 func TestStorageUpdateLSUnderCOW(t *testing.T) {
 	Convey("update LS to COW storage should applyed after merge", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		rep := 2
 
@@ -582,7 +583,7 @@ func TestStorageUpdateLSUnderCOW(t *testing.T) {
 
 func TestStorageSealLS(t *testing.T) {
 	Convey("LS should not be sealed if not exist", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		lsID := types.LogStreamID(time.Now().UnixNano())
 		err := ms.SealLogStream(lsID, 0, 0)
@@ -590,7 +591,7 @@ func TestStorageSealLS(t *testing.T) {
 	})
 
 	Convey("For resigtered LS", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 		ms.Run()
 		Reset(func() {
 			ms.Close()
@@ -690,7 +691,7 @@ func TestStorageSealLS(t *testing.T) {
 
 func TestStorageSealLSUnderCOW(t *testing.T) {
 	Convey("seal LS to COW storage should applyed after merge", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		rep := 2
 
@@ -754,7 +755,7 @@ func TestStorageSealLSUnderCOW(t *testing.T) {
 
 func TestStorageUnsealLS(t *testing.T) {
 	Convey("Storage should return ErrNotExsit if Unseal to not exist LS", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		lsID := types.LogStreamID(time.Now().UnixNano())
 		err := ms.UnsealLogStream(lsID, 0, 0)
@@ -762,7 +763,7 @@ func TestStorageUnsealLS(t *testing.T) {
 	})
 
 	Convey("For resigtered LS", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 		ms.Run()
 		Reset(func() {
 			ms.Close()
@@ -843,7 +844,7 @@ func TestStorageUnsealLS(t *testing.T) {
 
 func TestStorageTrim(t *testing.T) {
 	Convey("Given a GlobalLogStreams", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		for ver := types.MinVersion; ver < types.Version(1024); ver++ {
 			gls := &mrpb.LogStreamCommitResults{
@@ -873,7 +874,7 @@ func TestStorageTrim(t *testing.T) {
 
 func TestStorageReport(t *testing.T) {
 	Convey("storage should not apply report if not registered LS", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		rep := 2
 		lsID := types.LogStreamID(time.Now().UnixNano())
@@ -940,7 +941,7 @@ func TestStorageReport(t *testing.T) {
 
 func TestStorageCopyOnWrite(t *testing.T) {
 	Convey("storage should returns different stateMachine while copyOnWrite", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		pre, cur := ms.getStateMachine()
 		So(pre == cur, ShouldBeTrue)
@@ -952,7 +953,7 @@ func TestStorageCopyOnWrite(t *testing.T) {
 	})
 
 	Convey("update matadata should make storage copyOnWrite", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 		ms.Run()
 		Reset(func() {
 			ms.Close()
@@ -972,7 +973,7 @@ func TestStorageCopyOnWrite(t *testing.T) {
 	})
 
 	Convey("copyOnWrite storage should give the same response for registerStorageNode", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 		ms.Run()
 		Reset(func() {
 			ms.Close()
@@ -1019,7 +1020,7 @@ func TestStorageCopyOnWrite(t *testing.T) {
 	})
 
 	Convey("copyOnWrite storage should give the same response for createLogStream", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		rep := 2
 		lsID := types.LogStreamID(time.Now().UnixNano())
@@ -1065,7 +1066,7 @@ func TestStorageCopyOnWrite(t *testing.T) {
 	})
 
 	Convey("update UncommitReport does not make storage copyOnWrite", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 		ms.Run()
 		Reset(func() {
 			ms.Close()
@@ -1124,7 +1125,7 @@ func TestStorageCopyOnWrite(t *testing.T) {
 	})
 
 	Convey("update GlobalLogStream does not make storage copyOnWrite", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		gls := &mrpb.LogStreamCommitResults{
 			Version: types.Version(2),
@@ -1172,7 +1173,7 @@ func TestStorageMetadataCache(t *testing.T) {
 	Convey("metadata storage returns empty cache, when it has no metadata", t, func(ctx C) {
 		cb := func(uint64, uint64, error) {}
 
-		ms := NewMetadataStorage(cb, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(cb, DefaultSnapshotCount, zap.NewNop())
 		ms.Run()
 		Reset(func() {
 			ms.Close()
@@ -1191,7 +1192,7 @@ func TestStorageMetadataCache(t *testing.T) {
 			ch <- struct{}{}
 		}
 
-		ms := NewMetadataStorage(cb, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(cb, DefaultSnapshotCount, zap.NewNop())
 		ms.Run()
 		Reset(func() {
 			ms.Close()
@@ -1234,7 +1235,7 @@ func TestStorageMetadataCache(t *testing.T) {
 			}
 		}
 
-		ms := NewMetadataStorage(cb, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(cb, DefaultSnapshotCount, zap.NewNop())
 
 		snID := types.StorageNodeID(time.Now().UnixNano())
 		sn := &varlogpb.StorageNodeDescriptor{
@@ -1296,7 +1297,7 @@ func TestStorageStateMachineMerge(t *testing.T) {
 			}
 		}
 
-		ms := NewMetadataStorage(cb, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(cb, DefaultSnapshotCount, zap.NewNop())
 
 		snID := types.StorageNodeID(time.Now().UnixNano())
 		sn := &varlogpb.StorageNodeDescriptor{
@@ -1354,7 +1355,7 @@ func TestStorageStateMachineMerge(t *testing.T) {
 	})
 
 	Convey("merge performance:: # of UncommitReports:1024. RepFactor:3:: ", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		for i := 0; i < 1024; i++ {
 			lsID := types.LogStreamID(i)
@@ -1392,9 +1393,7 @@ func TestStorageStateMachineMerge(t *testing.T) {
 
 		ms.releaseCopyOnWrite()
 
-		st := time.Now()
 		ms.mergeStateMachine()
-		t.Log(time.Since(st))
 	})
 }
 
@@ -1405,7 +1404,7 @@ func TestStorageSnapshot(t *testing.T) {
 			ch <- struct{}{}
 		}
 
-		ms := NewMetadataStorage(cb, 1, nil)
+		ms := NewMetadataStorage(cb, 1, zap.NewNop())
 		ms.Run()
 		Reset(func() {
 			ms.Close()
@@ -1490,7 +1489,7 @@ func TestStorageApplySnapshot(t *testing.T) {
 			ch <- struct{}{}
 		}
 
-		ms := NewMetadataStorage(cb, 1, nil)
+		ms := NewMetadataStorage(cb, 1, zap.NewNop())
 		ms.Run()
 		Reset(func() {
 			ms.Close()
@@ -1545,7 +1544,7 @@ func TestStorageApplySnapshot(t *testing.T) {
 		So(snapIndex, ShouldEqual, appliedIndex)
 
 		Convey("When new MetadataStorage which load snapshot", func(ctx C) {
-			loaded := NewMetadataStorage(cb, DefaultSnapshotCount, nil)
+			loaded := NewMetadataStorage(cb, DefaultSnapshotCount, zap.NewNop())
 			So(loaded.ApplySnapshot(snap, confState, snapIndex), ShouldBeNil)
 			Reset(func() {
 				loaded.Close()
@@ -1566,7 +1565,7 @@ func TestStorageApplySnapshot(t *testing.T) {
 
 func TestStorageSnapshotRace(t *testing.T) {
 	Convey("create snapshot", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 		ms.snapCount = uint64(100 + rand.Int31n(64))
 
 		ms.Run()
@@ -1695,7 +1694,7 @@ func TestStorageSnapshotRace(t *testing.T) {
 
 func TestStorageVerifyReport(t *testing.T) {
 	Convey("Given MetadataStorage which has GlobalLogSteams with HWM [10,15,20]", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		lsID := types.LogStreamID(time.Now().UnixNano())
 
@@ -1768,7 +1767,7 @@ func TestStorageRecoverStateMachine(t *testing.T) {
 			ch <- struct{}{}
 		}
 
-		ms := NewMetadataStorage(cb, 1, nil)
+		ms := NewMetadataStorage(cb, 1, zap.NewNop())
 
 		appliedIndex := uint64(0)
 
@@ -1838,7 +1837,7 @@ func TestStorageRecoverStateMachine(t *testing.T) {
 
 func TestStorageRegisterTopic(t *testing.T) {
 	Convey("Topic should be registered if not existed", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		err := ms.registerTopic(&varlogpb.TopicDescriptor{TopicID: types.TopicID(1)})
 		So(err, ShouldBeNil)
@@ -1851,7 +1850,7 @@ func TestStorageRegisterTopic(t *testing.T) {
 
 	Convey("LS should not be registered if not exist topic", t, func(ctx C) {
 		rep := 2
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		lsID := types.LogStreamID(time.Now().UnixNano())
 		tmp := types.StorageNodeID(time.Now().UnixNano())
@@ -1900,14 +1899,14 @@ func TestStorageRegisterTopic(t *testing.T) {
 
 func TestStoragUnregisterTopic(t *testing.T) {
 	Convey("unregister non-exist topic should return ErrNotExist", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		err := ms.unregisterTopic(types.TopicID(1))
 		So(err, ShouldResemble, verrors.ErrNotExist)
 	})
 
 	Convey("unregister exist topic", t, func(ctx C) {
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		err := ms.registerTopic(&varlogpb.TopicDescriptor{TopicID: types.TopicID(1)})
 		So(err, ShouldBeNil)
@@ -1930,7 +1929,7 @@ func TestStorageSortedTopicLogStreamIDs(t *testing.T) {
 		nrLS := 4
 		nrTopic := 2
 
-		ms := NewMetadataStorage(nil, DefaultSnapshotCount, nil)
+		ms := NewMetadataStorage(nil, DefaultSnapshotCount, zap.NewNop())
 
 		snID := types.StorageNodeID(0)
 		snIDs := make([]types.StorageNodeID, 1)

--- a/internal/storagenode/logstream/executor_test.go
+++ b/internal/storagenode/logstream/executor_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
-	"go.uber.org/zap"
 
 	"github.com/kakao/varlog/internal/batchlet"
 	"github.com/kakao/varlog/internal/storage"
@@ -1312,7 +1311,6 @@ func TestExecutor_Recover(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer func() {
-				// t.Logf("stopping clients %d", i)
 				wg.Done()
 			}()
 			for {
@@ -1336,7 +1334,6 @@ func TestExecutor_Recover(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer func() {
-			// t.Logf("stopping mr simulator")
 			wg.Done()
 		}()
 
@@ -2489,16 +2486,9 @@ func TestExecutorRestore(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			logger, err := zap.NewDevelopment()
-			assert.NoError(t, err)
-			defer func() {
-				_ = logger.Sync()
-			}()
-
 			stg := storage.TestNewStorage(t, storage.WithPath(tc.golden), storage.ReadOnly())
 			lse, err := NewExecutor(
 				WithStorage(stg),
-				WithLogger(logger),
 			)
 			require.NoError(t, err)
 			defer func() {
@@ -2648,12 +2638,6 @@ func TestExecutorResotre_Invalid(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			logger, err := zap.NewDevelopment()
-			assert.NoError(t, err)
-			defer func() {
-				_ = logger.Sync()
-			}()
-
 			stgOpts := []storage.Option{storage.WithPath(tc.golden)}
 
 			if *update {
@@ -2669,7 +2653,6 @@ func TestExecutorResotre_Invalid(t *testing.T) {
 			stg := storage.TestNewStorage(t, stgOpts...)
 			lse, err := NewExecutor(
 				WithStorage(stg),
-				WithLogger(logger),
 			)
 			require.NoError(t, err)
 			defer func() {

--- a/internal/storagenode/storagenode_test.go
+++ b/internal/storagenode/storagenode_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 
 	"github.com/kakao/varlog/internal/reportcommitter"
 	"github.com/kakao/varlog/internal/storage"
@@ -28,13 +27,6 @@ import (
 func TestStorageNode(t *testing.T) {
 	// TODO: uncomment it
 	// defer goleak.VerifyNone(t)
-
-	logger, err := zap.NewProduction()
-	require.NoError(t, err)
-	defer func() {
-		_ = logger.Sync()
-	}()
-
 	const (
 		cid       = types.ClusterID(1)
 		snid1     = types.StorageNodeID(1)
@@ -70,7 +62,6 @@ func TestStorageNode(t *testing.T) {
 		WithClusterID(cid),
 		WithStorageNodeID(snid2),
 		WithVolumes(path2),
-		WithLogger(logger),
 	)
 	wg.Add(1)
 	go func() {
@@ -787,7 +778,6 @@ func TestStorageNode_Sync(t *testing.T) {
 						StorageNodeID: dst.snid,
 						Address:       dst.advertise,
 					})
-					t.Logf("syncStatus: %s", syncStatus.String())
 					return syncStatus.State == snpb.SyncStateComplete
 				}, 10*time.Second, 100*time.Millisecond)
 
@@ -829,7 +819,6 @@ func TestStorageNode_Sync(t *testing.T) {
 						StorageNodeID: dst.snid,
 						Address:       dst.advertise,
 					})
-					t.Logf("syncStatus: %s", syncStatus.String())
 					return syncStatus.State == snpb.SyncStateComplete
 				}, 10*time.Second, 100*time.Millisecond)
 
@@ -909,7 +898,6 @@ func TestStorageNode_Sync(t *testing.T) {
 						StorageNodeID: dst.snid,
 						Address:       dst.advertise,
 					})
-					t.Logf("syncStatus: %s", syncStatus.String())
 					return syncStatus.State == snpb.SyncStateComplete
 				}, 3*time.Second, 100*time.Millisecond)
 
@@ -952,7 +940,6 @@ func TestStorageNode_Sync(t *testing.T) {
 						StorageNodeID: dst.snid,
 						Address:       dst.advertise,
 					})
-					t.Logf("syncStatus: %s", syncStatus.String())
 					return syncStatus.State == snpb.SyncStateComplete
 				}, 10*time.Second, 100*time.Millisecond)
 
@@ -995,7 +982,6 @@ func TestStorageNode_Sync(t *testing.T) {
 						StorageNodeID: dst.snid,
 						Address:       dst.advertise,
 					})
-					t.Logf("syncStatus: %s", syncStatus.String())
 					return syncStatus.State == snpb.SyncStateComplete
 				}, 10*time.Second, 100*time.Millisecond)
 
@@ -1039,7 +1025,6 @@ func TestStorageNode_Sync(t *testing.T) {
 						StorageNodeID: dst.snid,
 						Address:       dst.advertise,
 					})
-					t.Logf("syncStatus: %s", syncStatus.String())
 					return syncStatus.State == snpb.SyncStateComplete
 				}, 10*time.Second, 100*time.Millisecond)
 
@@ -1083,7 +1068,6 @@ func TestStorageNode_Sync(t *testing.T) {
 						StorageNodeID: dst.snid,
 						Address:       dst.advertise,
 					})
-					t.Logf("syncStatus: %s", syncStatus.String())
 					return syncStatus.State == snpb.SyncStateComplete
 				}, 10*time.Second, 100*time.Millisecond)
 

--- a/pkg/util/fputil/dirsize_test.go
+++ b/pkg/util/fputil/dirsize_test.go
@@ -23,7 +23,6 @@ func TestDirectorySize(t *testing.T) {
 }
 
 func TestDiskSize(t *testing.T) {
-	all, used, err := DiskSize("/")
+	_, _, err := DiskSize("/")
 	assert.NoError(t, err)
-	t.Logf("all=%d, free=%d, used=%d", all, all-used, used)
 }

--- a/pkg/util/netutil/netutil_test.go
+++ b/pkg/util/netutil/netutil_test.go
@@ -53,27 +53,23 @@ func TestGetListenerAddr(t *testing.T) {
 				t.Error(err)
 			}
 			if len(tt.out) == 0 {
-				t.Logf("-> %v", addrs)
-				if len(addrs) < tt.minOutLen {
-					t.Errorf("%s error: %v", tt.in, addrs)
+				require.GreaterOrEqual(t, len(addrs), tt.minOutLen)
+				return
+			}
+
+			if tt.minOutLen <= len(addrs) {
+				if len(addrs) == 0 {
+					return
 				}
-			} else {
-				if tt.minOutLen <= len(addrs) {
-					if len(addrs) == 0 {
-						t.Logf("%s expected_minoutlen=%d actual_outlen=%d",
-							tt.in, tt.minOutLen, len(addrs))
+
+				for _, addr := range addrs {
+					if addr == tt.out {
 						return
 					}
-
-					for _, addr := range addrs {
-						if addr == tt.out {
-							return
-						}
-					}
 				}
-
-				t.Errorf("%s expected=%s actual=%s", tt.in, tt.out, addrs)
 			}
+
+			t.Errorf("%s expected=%s actual=%s", tt.in, tt.out, addrs)
 		})
 	}
 }
@@ -97,25 +93,20 @@ func TestIPs(t *testing.T) {
 }
 
 func TestAdvertisableIPs(t *testing.T) {
-	uniIps, err := AdvertisableIPs()
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Log(uniIps)
+	_, err := AdvertisableIPs()
+	require.NoError(t, err)
 }
 
 func TestNodeIDGen(t *testing.T) {
 	const port = 10000
 
 	ips, err := IPs()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	for _, ip := range ips {
 		addr := ip.String() + ":" + strconv.Itoa(port)
 		nodeID := types.NewNodeID(addr)
-		t.Logf("addr=%v nodeid=%v", addr, nodeID)
+		require.NotEqual(t, types.InvalidNodeID, nodeID)
 	}
 }
 

--- a/pkg/varlog/allowlist_test.go
+++ b/pkg/varlog/allowlist_test.go
@@ -1,7 +1,6 @@
 package varlog
 
 import (
-	"log"
 	"testing"
 	"time"
 
@@ -170,7 +169,6 @@ func TestAllowlistExpire(t *testing.T) {
 		So(picked, ShouldBeFalse)
 
 		// wait for some expiration loops
-		log.Println("after deny")
 		time.Sleep(3 * time.Second)
 
 		_, picked = allowlist.Pick(topicID)

--- a/tests/it/cluster/client_test.go
+++ b/tests/it/cluster/client_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"sync"
 	"testing"
 	"time"
@@ -320,7 +319,6 @@ func TestClientSubscribe(t *testing.T) {
 		}
 		res := client.Append(context.TODO(), topicID, batch)
 		require.NoError(t, res.Err)
-		log.Printf("append: %+v", res)
 		require.Len(t, res.Metadata, batchSize)
 		require.Equal(t, issuedGLSN, res.Metadata[len(res.Metadata)-1].GLSN)
 		require.Equal(t, issuedGLSN-types.GLSN(batchSize)+1, res.Metadata[0].GLSN)

--- a/tests/it/cluster/cluster_test.go
+++ b/tests/it/cluster/cluster_test.go
@@ -56,7 +56,6 @@ func TestAppendLogs(t *testing.T) {
 				}
 				max = res.Metadata[0].GLSN
 			}
-			t.Logf("[%d] Append completed", idx)
 
 			muMaxGLSN.Lock()
 			defer muMaxGLSN.Unlock()
@@ -115,10 +114,8 @@ func TestReadSealedLogStream(t *testing.T) {
 			topicID := clus.TopicIDs()[0]
 			client := clus.ClientAtIndex(t, idx)
 			for {
-				t.Logf("[%d] appending", idx)
 				res := client.Append(context.Background(), topicID, [][]byte{[]byte("foo")})
 				if res.Err != nil {
-					t.Logf("[%d] append error: %+v", idx, res.Err)
 					assert.ErrorIs(t, res.Err, verrors.ErrSealed)
 					errC <- res.Err
 					break
@@ -141,11 +138,9 @@ func TestReadSealedLogStream(t *testing.T) {
 				rsp, err := clus.GetVMSClient(t).Seal(context.Background(), topicID, lsID)
 				require.NoError(t, err)
 				sealedGLSN = rsp.GetSealedGLSN()
-				t.Logf("SealedGLSN: %v", sealedGLSN)
 			}
 		case err := <-errC:
 			numSealedErr++
-			t.Logf("%d sealed errors", numSealedErr)
 			require.ErrorIs(t, err, verrors.ErrSealed)
 		}
 	}

--- a/tests/it/config.go
+++ b/tests/it/config.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/kakao/varlog/internal/admin"
 	"github.com/kakao/varlog/internal/admin/mrmanager"
@@ -62,7 +63,7 @@ func newConfig(t *testing.T, opts []Option) config {
 		unsafeNoWAL:       defaultUnsafeNoWAL,
 		reporterClientFac: defaultReportClientFactory(),
 		VMSOpts:           NewTestVMSOptions(),
-		logger:            zap.NewNop(),
+		logger:            zaptest.NewLogger(t),
 		portBase:          defaultPortBase,
 		vmsPortOffset:     defaultVMSPortOffset,
 		startVMS:          defaultStartVMS,

--- a/tests/it/failover/failover_test.go
+++ b/tests/it/failover/failover_test.go
@@ -259,7 +259,6 @@ func TestVarlogFailoverSNBackupFail(t *testing.T) {
 					assert.NoError(t, err)
 					sealedGLSN := rsp.GetSealedGLSN()
 					assert.GreaterOrEqual(t, sealedGLSN, maxGLSN)
-					t.Logf("SealedGLSN=%d", sealedGLSN)
 
 					primarySNID := env.PrimaryStorageNodeIDOf(t, lsID)
 					snmd, err := env.SNClientOf(t, primarySNID).GetMetadata(context.Background())

--- a/tests/it/management/management_test.go
+++ b/tests/it/management/management_test.go
@@ -827,17 +827,13 @@ func TestAddTopic(t *testing.T) {
 				}
 				defer cl.Close()
 
-				var glsn types.GLSN
 				for gctx.Err() == nil {
 					res := cl.Append(context.Background(), tid, [][]byte{[]byte("foo")})
 					if res.Err != nil {
 						err = fmt.Errorf("topic=%v,err=%v", tid, res.Err)
 						break
 					}
-					glsn = res.Metadata[0].GLSN
 				}
-
-				t.Logf("topic=%v, glsn:%v\n", tid, glsn)
 				return
 			})
 		}
@@ -863,17 +859,13 @@ func TestAddTopic(t *testing.T) {
 				}
 				defer cl.Close()
 
-				var glsn types.GLSN
 				for gctx.Err() == nil {
 					res := cl.Append(context.Background(), addTopicID, [][]byte{[]byte("foo")})
 					if res.Err != nil {
 						err = fmt.Errorf("topic=%v,err=%v", addTopicID, res.Err)
 						break
 					}
-					glsn = res.Metadata[0].GLSN
 				}
-
-				t.Logf("topic=%v, glsn:%v\n", addTopicID, glsn)
 				return
 			})
 

--- a/tests/it/mrconnector/mr_connector_test.go
+++ b/tests/it/mrconnector/mr_connector_test.go
@@ -54,7 +54,6 @@ func TestMRConnectorWithoutRemoveMRPeer(t *testing.T) {
 	for i := 1; i < env.NumberOfMetadataRepositories(); i++ {
 		require.NoError(t, env.GetMRByIndex(t, i).Close())
 		env.CloseMRClientAt(t, i)
-		t.Logf("close MR[%d]", i)
 	}
 
 	// NOTE: The number of active MRs should be three because there were no RemoveMRPeer RPCs.
@@ -85,7 +84,6 @@ func TestMRConnectorWithoutRemoveMRPeer(t *testing.T) {
 		}
 		return true
 	}, 5*time.Second, 100*time.Millisecond)
-	t.Logf("restart MR[0]")
 
 	// Close MR: MR[0]
 	require.NoError(t, env.GetMRByIndex(t, 0).Close())

--- a/tests/marshal_test.go
+++ b/tests/marshal_test.go
@@ -1,13 +1,10 @@
 package tests
 
 import (
-	"log"
 	"testing"
-	"time"
-
-	"go.uber.org/goleak"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
 
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/proto/mrpb"
@@ -34,12 +31,8 @@ func TestSnapshotMarshal(t *testing.T) {
 		smr.LogStream.CommitHistory = append(smr.LogStream.CommitHistory, gls)
 	}
 
-	st := time.Now()
-
 	_, err := smr.Marshal()
 	require.NoError(t, err)
-
-	log.Println(time.Since(st))
 }
 
 func TestGlobalLogStreamMarshal(t *testing.T) {
@@ -54,12 +47,9 @@ func TestGlobalLogStreamMarshal(t *testing.T) {
 
 		gls.CommitResults = append(gls.CommitResults, lls)
 	}
-	st := time.Now()
 
 	_, err := gls.Marshal()
 	require.NoError(t, err)
-
-	log.Println(time.Since(st))
 }
 
 func TestMain(m *testing.M) {

--- a/vendor/github.com/benbjohnson/clock/LICENSE
+++ b/vendor/github.com/benbjohnson/clock/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Ben Johnson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/benbjohnson/clock/README.md
+++ b/vendor/github.com/benbjohnson/clock/README.md
@@ -1,0 +1,105 @@
+clock
+=====
+
+[![go.dev reference](https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white&style=flat-square)](https://pkg.go.dev/mod/github.com/benbjohnson/clock)
+
+Clock is a small library for mocking time in Go. It provides an interface
+around the standard library's [`time`][time] package so that the application
+can use the realtime clock while tests can use the mock clock.
+
+The module is currently maintained by @djmitche.
+
+[time]: https://pkg.go.dev/github.com/benbjohnson/clock
+
+## Usage
+
+### Realtime Clock
+
+Your application can maintain a `Clock` variable that will allow realtime and
+mock clocks to be interchangeable. For example, if you had an `Application` type:
+
+```go
+import "github.com/benbjohnson/clock"
+
+type Application struct {
+	Clock clock.Clock
+}
+```
+
+You could initialize it to use the realtime clock like this:
+
+```go
+var app Application
+app.Clock = clock.New()
+...
+```
+
+Then all timers and time-related functionality should be performed from the
+`Clock` variable.
+
+
+### Mocking time
+
+In your tests, you will want to use a `Mock` clock:
+
+```go
+import (
+	"testing"
+
+	"github.com/benbjohnson/clock"
+)
+
+func TestApplication_DoSomething(t *testing.T) {
+	mock := clock.NewMock()
+	app := Application{Clock: mock}
+	...
+}
+```
+
+Now that you've initialized your application to use the mock clock, you can
+adjust the time programmatically. The mock clock always starts from the Unix
+epoch (midnight UTC on Jan 1, 1970).
+
+
+### Controlling time
+
+The mock clock provides the same functions that the standard library's `time`
+package provides. For example, to find the current time, you use the `Now()`
+function:
+
+```go
+mock := clock.NewMock()
+
+// Find the current time.
+mock.Now().UTC() // 1970-01-01 00:00:00 +0000 UTC
+
+// Move the clock forward.
+mock.Add(2 * time.Hour)
+
+// Check the time again. It's 2 hours later!
+mock.Now().UTC() // 1970-01-01 02:00:00 +0000 UTC
+```
+
+Timers and Tickers are also controlled by this same mock clock. They will only
+execute when the clock is moved forward:
+
+```go
+mock := clock.NewMock()
+count := 0
+
+// Kick off a timer to increment every 1 mock second.
+go func() {
+    ticker := mock.Ticker(1 * time.Second)
+    for {
+        <-ticker.C
+        count++
+    }
+}()
+runtime.Gosched()
+
+// Move the clock forward 10 seconds.
+mock.Add(10 * time.Second)
+
+// This prints 10.
+fmt.Println(count)
+```

--- a/vendor/github.com/benbjohnson/clock/clock.go
+++ b/vendor/github.com/benbjohnson/clock/clock.go
@@ -1,0 +1,378 @@
+package clock
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+)
+
+// Re-export of time.Duration
+type Duration = time.Duration
+
+// Clock represents an interface to the functions in the standard library time
+// package. Two implementations are available in the clock package. The first
+// is a real-time clock which simply wraps the time package's functions. The
+// second is a mock clock which will only change when
+// programmatically adjusted.
+type Clock interface {
+	After(d time.Duration) <-chan time.Time
+	AfterFunc(d time.Duration, f func()) *Timer
+	Now() time.Time
+	Since(t time.Time) time.Duration
+	Until(t time.Time) time.Duration
+	Sleep(d time.Duration)
+	Tick(d time.Duration) <-chan time.Time
+	Ticker(d time.Duration) *Ticker
+	Timer(d time.Duration) *Timer
+	WithDeadline(parent context.Context, d time.Time) (context.Context, context.CancelFunc)
+	WithTimeout(parent context.Context, t time.Duration) (context.Context, context.CancelFunc)
+}
+
+// New returns an instance of a real-time clock.
+func New() Clock {
+	return &clock{}
+}
+
+// clock implements a real-time clock by simply wrapping the time package functions.
+type clock struct{}
+
+func (c *clock) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+func (c *clock) AfterFunc(d time.Duration, f func()) *Timer {
+	return &Timer{timer: time.AfterFunc(d, f)}
+}
+
+func (c *clock) Now() time.Time { return time.Now() }
+
+func (c *clock) Since(t time.Time) time.Duration { return time.Since(t) }
+
+func (c *clock) Until(t time.Time) time.Duration { return time.Until(t) }
+
+func (c *clock) Sleep(d time.Duration) { time.Sleep(d) }
+
+func (c *clock) Tick(d time.Duration) <-chan time.Time { return time.Tick(d) }
+
+func (c *clock) Ticker(d time.Duration) *Ticker {
+	t := time.NewTicker(d)
+	return &Ticker{C: t.C, ticker: t}
+}
+
+func (c *clock) Timer(d time.Duration) *Timer {
+	t := time.NewTimer(d)
+	return &Timer{C: t.C, timer: t}
+}
+
+func (c *clock) WithDeadline(parent context.Context, d time.Time) (context.Context, context.CancelFunc) {
+	return context.WithDeadline(parent, d)
+}
+
+func (c *clock) WithTimeout(parent context.Context, t time.Duration) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(parent, t)
+}
+
+// Mock represents a mock clock that only moves forward programmically.
+// It can be preferable to a real-time clock when testing time-based functionality.
+type Mock struct {
+	mu     sync.Mutex
+	now    time.Time   // current time
+	timers clockTimers // tickers & timers
+}
+
+// NewMock returns an instance of a mock clock.
+// The current time of the mock clock on initialization is the Unix epoch.
+func NewMock() *Mock {
+	return &Mock{now: time.Unix(0, 0)}
+}
+
+// Add moves the current time of the mock clock forward by the specified duration.
+// This should only be called from a single goroutine at a time.
+func (m *Mock) Add(d time.Duration) {
+	// Calculate the final current time.
+	t := m.now.Add(d)
+
+	// Continue to execute timers until there are no more before the new time.
+	for {
+		if !m.runNextTimer(t) {
+			break
+		}
+	}
+
+	// Ensure that we end with the new time.
+	m.mu.Lock()
+	m.now = t
+	m.mu.Unlock()
+
+	// Give a small buffer to make sure that other goroutines get handled.
+	gosched()
+}
+
+// Set sets the current time of the mock clock to a specific one.
+// This should only be called from a single goroutine at a time.
+func (m *Mock) Set(t time.Time) {
+	// Continue to execute timers until there are no more before the new time.
+	for {
+		if !m.runNextTimer(t) {
+			break
+		}
+	}
+
+	// Ensure that we end with the new time.
+	m.mu.Lock()
+	m.now = t
+	m.mu.Unlock()
+
+	// Give a small buffer to make sure that other goroutines get handled.
+	gosched()
+}
+
+// runNextTimer executes the next timer in chronological order and moves the
+// current time to the timer's next tick time. The next time is not executed if
+// its next time is after the max time. Returns true if a timer was executed.
+func (m *Mock) runNextTimer(max time.Time) bool {
+	m.mu.Lock()
+
+	// Sort timers by time.
+	sort.Sort(m.timers)
+
+	// If we have no more timers then exit.
+	if len(m.timers) == 0 {
+		m.mu.Unlock()
+		return false
+	}
+
+	// Retrieve next timer. Exit if next tick is after new time.
+	t := m.timers[0]
+	if t.Next().After(max) {
+		m.mu.Unlock()
+		return false
+	}
+
+	// Move "now" forward and unlock clock.
+	m.now = t.Next()
+	m.mu.Unlock()
+
+	// Execute timer.
+	t.Tick(m.now)
+	return true
+}
+
+// After waits for the duration to elapse and then sends the current time on the returned channel.
+func (m *Mock) After(d time.Duration) <-chan time.Time {
+	return m.Timer(d).C
+}
+
+// AfterFunc waits for the duration to elapse and then executes a function.
+// A Timer is returned that can be stopped.
+func (m *Mock) AfterFunc(d time.Duration, f func()) *Timer {
+	t := m.Timer(d)
+	t.C = nil
+	t.fn = f
+	return t
+}
+
+// Now returns the current wall time on the mock clock.
+func (m *Mock) Now() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.now
+}
+
+// Since returns time since `t` using the mock clock's wall time.
+func (m *Mock) Since(t time.Time) time.Duration {
+	return m.Now().Sub(t)
+}
+
+// Until returns time until `t` using the mock clock's wall time.
+func (m *Mock) Until(t time.Time) time.Duration {
+	return t.Sub(m.Now())
+}
+
+// Sleep pauses the goroutine for the given duration on the mock clock.
+// The clock must be moved forward in a separate goroutine.
+func (m *Mock) Sleep(d time.Duration) {
+	<-m.After(d)
+}
+
+// Tick is a convenience function for Ticker().
+// It will return a ticker channel that cannot be stopped.
+func (m *Mock) Tick(d time.Duration) <-chan time.Time {
+	return m.Ticker(d).C
+}
+
+// Ticker creates a new instance of Ticker.
+func (m *Mock) Ticker(d time.Duration) *Ticker {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ch := make(chan time.Time, 1)
+	t := &Ticker{
+		C:    ch,
+		c:    ch,
+		mock: m,
+		d:    d,
+		next: m.now.Add(d),
+	}
+	m.timers = append(m.timers, (*internalTicker)(t))
+	return t
+}
+
+// Timer creates a new instance of Timer.
+func (m *Mock) Timer(d time.Duration) *Timer {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ch := make(chan time.Time, 1)
+	t := &Timer{
+		C:       ch,
+		c:       ch,
+		mock:    m,
+		next:    m.now.Add(d),
+		stopped: false,
+	}
+	m.timers = append(m.timers, (*internalTimer)(t))
+	return t
+}
+
+func (m *Mock) removeClockTimer(t clockTimer) {
+	for i, timer := range m.timers {
+		if timer == t {
+			copy(m.timers[i:], m.timers[i+1:])
+			m.timers[len(m.timers)-1] = nil
+			m.timers = m.timers[:len(m.timers)-1]
+			break
+		}
+	}
+	sort.Sort(m.timers)
+}
+
+// clockTimer represents an object with an associated start time.
+type clockTimer interface {
+	Next() time.Time
+	Tick(time.Time)
+}
+
+// clockTimers represents a list of sortable timers.
+type clockTimers []clockTimer
+
+func (a clockTimers) Len() int           { return len(a) }
+func (a clockTimers) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a clockTimers) Less(i, j int) bool { return a[i].Next().Before(a[j].Next()) }
+
+// Timer represents a single event.
+// The current time will be sent on C, unless the timer was created by AfterFunc.
+type Timer struct {
+	C       <-chan time.Time
+	c       chan time.Time
+	timer   *time.Timer // realtime impl, if set
+	next    time.Time   // next tick time
+	mock    *Mock       // mock clock, if set
+	fn      func()      // AfterFunc function, if set
+	stopped bool        // True if stopped, false if running
+}
+
+// Stop turns off the ticker.
+func (t *Timer) Stop() bool {
+	if t.timer != nil {
+		return t.timer.Stop()
+	}
+
+	t.mock.mu.Lock()
+	registered := !t.stopped
+	t.mock.removeClockTimer((*internalTimer)(t))
+	t.stopped = true
+	t.mock.mu.Unlock()
+	return registered
+}
+
+// Reset changes the expiry time of the timer
+func (t *Timer) Reset(d time.Duration) bool {
+	if t.timer != nil {
+		return t.timer.Reset(d)
+	}
+
+	t.mock.mu.Lock()
+	t.next = t.mock.now.Add(d)
+	defer t.mock.mu.Unlock()
+
+	registered := !t.stopped
+	if t.stopped {
+		t.mock.timers = append(t.mock.timers, (*internalTimer)(t))
+	}
+
+	t.stopped = false
+	return registered
+}
+
+type internalTimer Timer
+
+func (t *internalTimer) Next() time.Time { return t.next }
+func (t *internalTimer) Tick(now time.Time) {
+	// a gosched() after ticking, to allow any consequences of the
+	// tick to complete
+	defer gosched()
+
+	t.mock.mu.Lock()
+	if t.fn != nil {
+		// defer function execution until the lock is released, and
+		defer t.fn()
+	} else {
+		t.c <- now
+	}
+	t.mock.removeClockTimer((*internalTimer)(t))
+	t.stopped = true
+	t.mock.mu.Unlock()
+}
+
+// Ticker holds a channel that receives "ticks" at regular intervals.
+type Ticker struct {
+	C      <-chan time.Time
+	c      chan time.Time
+	ticker *time.Ticker  // realtime impl, if set
+	next   time.Time     // next tick time
+	mock   *Mock         // mock clock, if set
+	d      time.Duration // time between ticks
+}
+
+// Stop turns off the ticker.
+func (t *Ticker) Stop() {
+	if t.ticker != nil {
+		t.ticker.Stop()
+	} else {
+		t.mock.mu.Lock()
+		t.mock.removeClockTimer((*internalTicker)(t))
+		t.mock.mu.Unlock()
+	}
+}
+
+// Reset resets the ticker to a new duration.
+func (t *Ticker) Reset(dur time.Duration) {
+	if t.ticker != nil {
+		t.ticker.Reset(dur)
+		return
+	}
+
+	t.mock.mu.Lock()
+	defer t.mock.mu.Unlock()
+
+	t.d = dur
+	t.next = t.mock.now.Add(dur)
+}
+
+type internalTicker Ticker
+
+func (t *internalTicker) Next() time.Time { return t.next }
+func (t *internalTicker) Tick(now time.Time) {
+	select {
+	case t.c <- now:
+	default:
+	}
+	t.next = now.Add(t.d)
+	gosched()
+}
+
+// Sleep momentarily so that other goroutines can process.
+func gosched() { time.Sleep(1 * time.Millisecond) }
+
+var (
+	// type checking
+	_ Clock = &Mock{}
+)

--- a/vendor/github.com/benbjohnson/clock/context.go
+++ b/vendor/github.com/benbjohnson/clock/context.go
@@ -1,0 +1,86 @@
+package clock
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+)
+
+func (m *Mock) WithTimeout(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	return m.WithDeadline(parent, m.Now().Add(timeout))
+}
+
+func (m *Mock) WithDeadline(parent context.Context, deadline time.Time) (context.Context, context.CancelFunc) {
+	if cur, ok := parent.Deadline(); ok && cur.Before(deadline) {
+		// The current deadline is already sooner than the new one.
+		return context.WithCancel(parent)
+	}
+	ctx := &timerCtx{clock: m, parent: parent, deadline: deadline, done: make(chan struct{})}
+	propagateCancel(parent, ctx)
+	dur := m.Until(deadline)
+	if dur <= 0 {
+		ctx.cancel(context.DeadlineExceeded) // deadline has already passed
+		return ctx, func() {}
+	}
+	ctx.Lock()
+	defer ctx.Unlock()
+	if ctx.err == nil {
+		ctx.timer = m.AfterFunc(dur, func() {
+			ctx.cancel(context.DeadlineExceeded)
+		})
+	}
+	return ctx, func() { ctx.cancel(context.Canceled) }
+}
+
+// propagateCancel arranges for child to be canceled when parent is.
+func propagateCancel(parent context.Context, child *timerCtx) {
+	if parent.Done() == nil {
+		return // parent is never canceled
+	}
+	go func() {
+		select {
+		case <-parent.Done():
+			child.cancel(parent.Err())
+		case <-child.Done():
+		}
+	}()
+}
+
+type timerCtx struct {
+	sync.Mutex
+
+	clock    Clock
+	parent   context.Context
+	deadline time.Time
+	done     chan struct{}
+
+	err   error
+	timer *Timer
+}
+
+func (c *timerCtx) cancel(err error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.err != nil {
+		return // already canceled
+	}
+	c.err = err
+	close(c.done)
+	if c.timer != nil {
+		c.timer.Stop()
+		c.timer = nil
+	}
+}
+
+func (c *timerCtx) Deadline() (deadline time.Time, ok bool) { return c.deadline, true }
+
+func (c *timerCtx) Done() <-chan struct{} { return c.done }
+
+func (c *timerCtx) Err() error { return c.err }
+
+func (c *timerCtx) Value(key interface{}) interface{} { return c.parent.Value(key) }
+
+func (c *timerCtx) String() string {
+	return fmt.Sprintf("clock.WithDeadline(%s [%s])", c.deadline, c.deadline.Sub(c.clock.Now()))
+}

--- a/vendor/go.uber.org/zap/internal/ztest/clock.go
+++ b/vendor/go.uber.org/zap/internal/ztest/clock.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"time"
+
+	"github.com/benbjohnson/clock"
+)
+
+// MockClock provides control over the time.
+type MockClock struct{ m *clock.Mock }
+
+// NewMockClock builds a new mock clock that provides control of time.
+func NewMockClock() *MockClock {
+	return &MockClock{clock.NewMock()}
+}
+
+// Now reports the current time.
+func (c *MockClock) Now() time.Time {
+	return c.m.Now()
+}
+
+// NewTicker returns a time.Ticker that ticks at the specified frequency.
+func (c *MockClock) NewTicker(d time.Duration) *time.Ticker {
+	return &time.Ticker{C: c.m.Ticker(d).C}
+}
+
+// Add progresses time by the given duration.
+func (c *MockClock) Add(d time.Duration) {
+	c.m.Add(d)
+}

--- a/vendor/go.uber.org/zap/internal/ztest/doc.go
+++ b/vendor/go.uber.org/zap/internal/ztest/doc.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package ztest provides low-level helpers for testing log output. These
+// utilities are helpful in zap's own unit tests, but any assertions using
+// them are strongly coupled to a single encoding.
+package ztest // import "go.uber.org/zap/internal/ztest"

--- a/vendor/go.uber.org/zap/internal/ztest/timeout.go
+++ b/vendor/go.uber.org/zap/internal/ztest/timeout.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"log"
+	"os"
+	"strconv"
+	"time"
+)
+
+var _timeoutScale = 1.0
+
+// Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.
+func Timeout(base time.Duration) time.Duration {
+	return time.Duration(float64(base) * _timeoutScale)
+}
+
+// Sleep scales the sleep duration by $TEST_TIMEOUT_SCALE.
+func Sleep(base time.Duration) {
+	time.Sleep(Timeout(base))
+}
+
+// Initialize checks the environment and alters the timeout scale accordingly.
+// It returns a function to undo the scaling.
+func Initialize(factor string) func() {
+	fv, err := strconv.ParseFloat(factor, 64)
+	if err != nil {
+		panic(err)
+	}
+	original := _timeoutScale
+	_timeoutScale = fv
+	return func() { _timeoutScale = original }
+}
+
+func init() {
+	if v := os.Getenv("TEST_TIMEOUT_SCALE"); v != "" {
+		Initialize(v)
+		log.Printf("Scaling timeouts by %vx.\n", _timeoutScale)
+	}
+}

--- a/vendor/go.uber.org/zap/internal/ztest/writer.go
+++ b/vendor/go.uber.org/zap/internal/ztest/writer.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+)
+
+// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
+type Syncer struct {
+	err    error
+	called bool
+}
+
+// SetError sets the error that the Sync method will return.
+func (s *Syncer) SetError(err error) {
+	s.err = err
+}
+
+// Sync records that it was called, then returns the user-supplied error (if
+// any).
+func (s *Syncer) Sync() error {
+	s.called = true
+	return s.err
+}
+
+// Called reports whether the Sync method was called.
+func (s *Syncer) Called() bool {
+	return s.called
+}
+
+// A Discarder sends all writes to io.Discard.
+type Discarder struct{ Syncer }
+
+// Write implements io.Writer.
+func (d *Discarder) Write(b []byte) (int, error) {
+	return io.Discard.Write(b)
+}
+
+// FailWriter is a WriteSyncer that always returns an error on writes.
+type FailWriter struct{ Syncer }
+
+// Write implements io.Writer.
+func (w FailWriter) Write(b []byte) (int, error) {
+	return len(b), errors.New("failed")
+}
+
+// ShortWriter is a WriteSyncer whose write method never fails, but
+// nevertheless fails to the last byte of the input.
+type ShortWriter struct{ Syncer }
+
+// Write implements io.Writer.
+func (w ShortWriter) Write(b []byte) (int, error) {
+	return len(b) - 1, nil
+}
+
+// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
+// a bytes.Buffer. It has convenience methods to split the accumulated buffer
+// on newlines.
+type Buffer struct {
+	bytes.Buffer
+	Syncer
+}
+
+// Lines returns the current buffer contents, split on newlines.
+func (b *Buffer) Lines() []string {
+	output := strings.Split(b.String(), "\n")
+	return output[:len(output)-1]
+}
+
+// Stripped returns the current buffer contents with the last trailing newline
+// stripped.
+func (b *Buffer) Stripped() string {
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/vendor/go.uber.org/zap/zaptest/doc.go
+++ b/vendor/go.uber.org/zap/zaptest/doc.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package zaptest provides a variety of helpers for testing log output.
+package zaptest // import "go.uber.org/zap/zaptest"

--- a/vendor/go.uber.org/zap/zaptest/logger.go
+++ b/vendor/go.uber.org/zap/zaptest/logger.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import (
+	"bytes"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// LoggerOption configures the test logger built by NewLogger.
+type LoggerOption interface {
+	applyLoggerOption(*loggerOptions)
+}
+
+type loggerOptions struct {
+	Level      zapcore.LevelEnabler
+	zapOptions []zap.Option
+}
+
+type loggerOptionFunc func(*loggerOptions)
+
+func (f loggerOptionFunc) applyLoggerOption(opts *loggerOptions) {
+	f(opts)
+}
+
+// Level controls which messages are logged by a test Logger built by
+// NewLogger.
+func Level(enab zapcore.LevelEnabler) LoggerOption {
+	return loggerOptionFunc(func(opts *loggerOptions) {
+		opts.Level = enab
+	})
+}
+
+// WrapOptions adds zap.Option's to a test Logger built by NewLogger.
+func WrapOptions(zapOpts ...zap.Option) LoggerOption {
+	return loggerOptionFunc(func(opts *loggerOptions) {
+		opts.zapOptions = zapOpts
+	})
+}
+
+// NewLogger builds a new Logger that logs all messages to the given
+// testing.TB.
+//
+//	logger := zaptest.NewLogger(t)
+//
+// Use this with a *testing.T or *testing.B to get logs which get printed only
+// if a test fails or if you ran go test -v.
+//
+// The returned logger defaults to logging debug level messages and above.
+// This may be changed by passing a zaptest.Level during construction.
+//
+//	logger := zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
+//
+// You may also pass zap.Option's to customize test logger.
+//
+//	logger := zaptest.NewLogger(t, zaptest.WrapOptions(zap.AddCaller()))
+func NewLogger(t TestingT, opts ...LoggerOption) *zap.Logger {
+	cfg := loggerOptions{
+		Level: zapcore.DebugLevel,
+	}
+	for _, o := range opts {
+		o.applyLoggerOption(&cfg)
+	}
+
+	writer := newTestingWriter(t)
+	zapOptions := []zap.Option{
+		// Send zap errors to the same writer and mark the test as failed if
+		// that happens.
+		zap.ErrorOutput(writer.WithMarkFailed(true)),
+	}
+	zapOptions = append(zapOptions, cfg.zapOptions...)
+
+	return zap.New(
+		zapcore.NewCore(
+			zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+			writer,
+			cfg.Level,
+		),
+		zapOptions...,
+	)
+}
+
+// testingWriter is a WriteSyncer that writes to the given testing.TB.
+type testingWriter struct {
+	t TestingT
+
+	// If true, the test will be marked as failed if this testingWriter is
+	// ever used.
+	markFailed bool
+}
+
+func newTestingWriter(t TestingT) testingWriter {
+	return testingWriter{t: t}
+}
+
+// WithMarkFailed returns a copy of this testingWriter with markFailed set to
+// the provided value.
+func (w testingWriter) WithMarkFailed(v bool) testingWriter {
+	w.markFailed = v
+	return w
+}
+
+func (w testingWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+
+	// Strip trailing newline because t.Log always adds one.
+	p = bytes.TrimRight(p, "\n")
+
+	// Note: t.Log is safe for concurrent use.
+	w.t.Logf("%s", p)
+	if w.markFailed {
+		w.t.Fail()
+	}
+
+	return n, nil
+}
+
+func (w testingWriter) Sync() error {
+	return nil
+}

--- a/vendor/go.uber.org/zap/zaptest/testingt.go
+++ b/vendor/go.uber.org/zap/zaptest/testingt.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+// TestingT is a subset of the API provided by all *testing.T and *testing.B
+// objects.
+type TestingT interface {
+	// Logs the given message without failing the test.
+	Logf(string, ...interface{})
+
+	// Logs the given message and marks the test as failed.
+	Errorf(string, ...interface{})
+
+	// Marks the test as failed.
+	Fail()
+
+	// Returns true if the test has been marked as failed.
+	Failed() bool
+
+	// Returns the name of the test.
+	Name() string
+
+	// Marks the test as failed and stops execution of that test.
+	FailNow()
+}
+
+// Note: We currently only rely on Logf. We are including Errorf and FailNow
+// in the interface in anticipation of future need since we can't extend the
+// interface without a breaking change.

--- a/vendor/go.uber.org/zap/zaptest/timeout.go
+++ b/vendor/go.uber.org/zap/zaptest/timeout.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import (
+	"time"
+
+	"go.uber.org/zap/internal/ztest"
+)
+
+// Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.
+//
+// Deprecated: This function is intended for internal testing and shouldn't be
+// used outside zap itself. It was introduced before Go supported internal
+// packages.
+func Timeout(base time.Duration) time.Duration {
+	return ztest.Timeout(base)
+}
+
+// Sleep scales the sleep duration by $TEST_TIMEOUT_SCALE.
+//
+// Deprecated: This function is intended for internal testing and shouldn't be
+// used outside zap itself. It was introduced before Go supported internal
+// packages.
+func Sleep(base time.Duration) {
+	ztest.Sleep(base)
+}

--- a/vendor/go.uber.org/zap/zaptest/writer.go
+++ b/vendor/go.uber.org/zap/zaptest/writer.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import "go.uber.org/zap/internal/ztest"
+
+type (
+	// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
+	Syncer = ztest.Syncer
+
+	// A Discarder sends all writes to io.Discard.
+	Discarder = ztest.Discarder
+
+	// FailWriter is a WriteSyncer that always returns an error on writes.
+	FailWriter = ztest.FailWriter
+
+	// ShortWriter is a WriteSyncer whose write method never returns an error,
+	// but always reports that it wrote one byte less than the input slice's
+	// length (thus, a "short write").
+	ShortWriter = ztest.ShortWriter
+
+	// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
+	// a bytes.Buffer. It has convenience methods to split the accumulated buffer
+	// on newlines.
+	Buffer = ztest.Buffer
+)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,6 +10,9 @@ github.com/PuerkitoBio/urlesc
 # github.com/StackExchange/wmi v1.2.1
 ## explicit; go 1.13
 github.com/StackExchange/wmi
+# github.com/benbjohnson/clock v1.3.0
+## explicit; go 1.15
+github.com/benbjohnson/clock
 # github.com/beorn7/perks v1.0.1
 ## explicit; go 1.11
 github.com/beorn7/perks/quantile
@@ -414,7 +417,9 @@ go.uber.org/zap/internal
 go.uber.org/zap/internal/bufferpool
 go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
+go.uber.org/zap/internal/ztest
 go.uber.org/zap/zapcore
+go.uber.org/zap/zaptest
 # golang.org/x/exp v0.0.0-20200513190911-00229845015e
 ## explicit; go 1.12
 golang.org/x/exp/rand


### PR DESCRIPTION
### What this PR does

This patch makes unit tests less verbose. It also provides an example using zaptest module in `tests/it`.
