### PR TITLE
feat(client): add PeekLogStream to the client

### DIFF
--- a/pkg/varlog/log.go
+++ b/pkg/varlog/log.go
@@ -44,13 +44,22 @@ type Log interface {
 	// It returns an error if the log stream does not exist or fails to
 	// fetch metadata from all replicas.
 	//
-	// Deprecated: Use LogStreamReplicaMetdata.
+	// Deprecated: Use PeekLogStream
 	LogStreamMetadata(ctx context.Context, tpid types.TopicID, lsid types.LogStreamID) (varlogpb.LogStreamDescriptor, error)
 
 	// LogStreamReplicaMetadata returns metadata of log stream replica
 	// specified by the arguments tpid and lsid. It returns the first
 	// successful result among all replicas.
+	//
+	// Deprecated: Use PeekLogStream
 	LogStreamReplicaMetadata(ctx context.Context, tpid types.TopicID, lsid types.LogStreamID) (snpb.LogStreamReplicaMetadataDescriptor, error)
+
+	// PeekLogStream returns the log sequence numbers at the first and the
+	// last. It fetches the metadata for each replica of a log stream lsid
+	// concurrently and takes a result from either appendable or sealed
+	// replica. If none of the replicas' statuses is either appendable or
+	// sealed, it returns an error.
+	PeekLogStream(ctx context.Context, tpid types.TopicID, lsid types.LogStreamID) (first varlogpb.LogSequenceNumber, last varlogpb.LogSequenceNumber, err error)
 }
 
 type AppendResult struct {
@@ -188,6 +197,10 @@ func (v *logImpl) LogStreamMetadata(ctx context.Context, tpid types.TopicID, lsi
 
 func (v *logImpl) LogStreamReplicaMetadata(ctx context.Context, tpid types.TopicID, lsid types.LogStreamID) (snpb.LogStreamReplicaMetadataDescriptor, error) {
 	return v.logStreamReplicaMetadata(ctx, tpid, lsid)
+}
+
+func (v *logImpl) PeekLogStream(ctx context.Context, tpid types.TopicID, lsid types.LogStreamID) (first varlogpb.LogSequenceNumber, last varlogpb.LogSequenceNumber, err error) {
+	return v.peekLogStream(ctx, tpid, lsid)
 }
 
 func (v *logImpl) Close() (err error) {


### PR DESCRIPTION
### What this PR does

This patch adds a new API called PeekLogStream to the client. The PeekLogStream returns sequence
numbers at the first and last log entries. Users using LogStreamMetadata or LogStreamReplicaMetadata
to fetch the sequence numbers should use PeekLogStream.

PeekLogStream has the benefits over the ogStreamMetadata or LogStreamReplicaMetadata.

- It does not send users useless and complex information about log stream replicas.
- It prevents users from getting too detailed information about log stream replicas.
- It takes accounts for the status of log stream replicas; thus, it returns more accurate first and last
  log sequence numbers of the log stream.

### Which issue(s) this PR resolves

Resolves #239
