### PR TITLE
refactor(benchmark): add a reporter to the benchmark

### DIFF
--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -42,9 +42,10 @@ func New(opts ...Option) (bm *Benchmark, err error) {
 		}
 	}()
 
-	for idx, target := range bm.targets {
+	for idx := range bm.targets {
 		var loader *Loader
-		loaderMetrics := &LoaderMetrics{idx: idx}
+		target := bm.targets[idx]
+		loaderMetrics := &LoaderMetrics{tgt: target}
 		loader, err = NewLoader(loaderConfig{
 			Target:  target,
 			cid:     bm.cid,

--- a/internal/benchmark/report.go
+++ b/internal/benchmark/report.go
@@ -1,0 +1,41 @@
+package benchmark
+
+import (
+	"time"
+)
+
+type AppendReport struct {
+	RequestsPerSecond float64
+	BytesPerSecond    float64
+	Duration          float64
+}
+
+type SubscribeReport struct {
+	LogsPerSecond  float64
+	BytesPerSecond float64
+}
+
+type EndToEndReport struct {
+	Latency float64
+}
+
+type Report struct {
+	AppendReport
+	SubscribeReport
+	EndToEndReport
+}
+
+func NewAppendReportFromMetrics(metrics AppendMetrics, interval time.Duration) AppendReport {
+	return AppendReport{
+		RequestsPerSecond: float64(metrics.requests) / interval.Seconds(),
+		BytesPerSecond:    float64(metrics.bytes) / interval.Seconds(),
+		Duration:          float64(metrics.durationMS / metrics.requests),
+	}
+}
+
+func NewSubscribeReportFromMetrics(metrics SubscribeMetrics, interval time.Duration) SubscribeReport {
+	return SubscribeReport{
+		LogsPerSecond:  float64(metrics.logs) / interval.Seconds(),
+		BytesPerSecond: float64(metrics.bytes) / interval.Seconds(),
+	}
+}

--- a/internal/benchmark/target.go
+++ b/internal/benchmark/target.go
@@ -28,3 +28,13 @@ func (tgt *Target) Valid() error {
 	}
 	return nil
 }
+
+func (tgt Target) String() string {
+	ret := tgt.TopicID.String()
+	if tgt.LogStreamID.Invalid() {
+		ret += ":*"
+	} else {
+		ret += ":" + tgt.LogStreamID.String()
+	}
+	return ret
+}


### PR DESCRIPTION
### What this PR does

This patch adds a reporter to the benchmark and prints out metrics while executing the benchmark.
Below are the sample metrics:

```
___tgt__arpsR__arpsT_______abpsR_______abpsT__adurR__adurT__slpsR__slpsT_______sbpsR_______sbpsT__eelatR__eelatT
   1:*   77.3   77.3  96.65KiB/s  96.65KiB/s   12.0   12.0    0.0    0.0        0B/s        0B/s     0.0     0.0
   1:1   77.7   77.7  97.07KiB/s  97.07KiB/s   12.0   12.0    0.0    0.0        0B/s        0B/s     0.0     0.0
___tgt__arpsR__arpsT_______abpsR_______abpsT__adurR__adurT__slpsR__slpsT_______sbpsR_______sbpsT__eelatR__eelatT
   1:*   76.3   76.8  95.42KiB/s  96.04KiB/s   12.0   12.0    0.0    0.0        0B/s        0B/s     0.0     0.0
   1:1   77.0   77.3  96.25KiB/s  96.66KiB/s   12.0   12.0    0.0    0.0        0B/s        0B/s     0.0     0.0
___tgt__arpsR__arpsT_______abpsR_______abpsT__adurR__adurT__slpsR__slpsT_______sbpsR_______sbpsT__eelatR__eelatT
   1:*   77.0   76.9  96.25KiB/s  96.11KiB/s   12.0   12.0    0.0    0.0        0B/s        0B/s     0.0     0.0
   1:1   77.3   77.3  96.66KiB/s  96.66KiB/s   12.0   12.0    0.0    0.0        0B/s        0B/s     0.0     0.0
___tgt__arpsR__arpsT_______abpsR_______abpsT__adurR__adurT__slpsR__slpsT_______sbpsR_______sbpsT__eelatR__eelatT
   1:*   62.0   73.2  77.51KiB/s  91.46KiB/s   15.0   13.0    0.0    0.0        0B/s        0B/s     0.0     0.0
   1:1   65.3   74.3  81.68KiB/s  92.92KiB/s   14.0   12.0    0.0    0.0        0B/s        0B/s     0.0     0.0
```

Here is legend of the table:

- arps: appended requests per second
- abps: appended bytes per second
- adur: append duration in milliseconds
- slps: subscribed logs per second
- sbps: subscribed bytes per second
- eelat: end-to-end latency in milliseconds

