### PR TITLE
test(e2e,local): flaky test TestVarlogEnduranceExample

### DIFF
--- a/tests/ee/cluster/config.go
+++ b/tests/ee/cluster/config.go
@@ -1,7 +1,10 @@
 package cluster
 
 import (
+	"testing"
+
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/kakao/varlog/pkg/types"
 )
@@ -20,12 +23,12 @@ type Config struct {
 	logger            *zap.Logger
 }
 
-func NewConfig(opts ...Option) (Config, error) {
+func NewConfig(t *testing.T, opts ...Option) (Config, error) {
 	cfg := Config{
 		cid:               DefaultClusterID,
 		replicationFactor: DefaultReplicationFactor,
 		numMetaRepos:      DefaultNumMetaRepos,
-		logger:            zap.NewNop(),
+		logger:            zaptest.NewLogger(t),
 	}
 	for _, opt := range opts {
 		opt.apply(&cfg)

--- a/tests/ee/cluster/local/config.go
+++ b/tests/ee/cluster/local/config.go
@@ -14,7 +14,7 @@ import (
 const (
 	defaultMRPortBase = 10001
 	defaultAdminAddr  = "127.0.0.1:9093"
-	defaultSNPortBase = 50001
+	defaultSNPortBase = 20001
 )
 
 var defaultGrpcHealthProbeExecutable = flag.String("grpc-health-probe-executable", "", "executable path for grpc_health_probe")

--- a/tests/ee/cluster/local/storagenode/config.go
+++ b/tests/ee/cluster/local/storagenode/config.go
@@ -21,6 +21,7 @@ func newConfig(opts []Option) (config, error) {
 	for _, opt := range opts {
 		opt.apply(&cfg)
 	}
+	cfg.logger = cfg.logger.With(zap.Int32("snid", int32(cfg.snid)))
 	return cfg, nil
 }
 

--- a/tests/ee/cluster_k8s.go
+++ b/tests/ee/cluster_k8s.go
@@ -13,7 +13,7 @@ import (
 )
 
 func NewCluster(t *testing.T, opts ...cluster.Option) cluster.Cluster {
-	cfg, err := cluster.NewConfig(opts...)
+	cfg, err := cluster.NewConfig(t, opts...)
 	require.NoError(t, err)
 	return k8s.New(t, k8s.WithCommonConfig(cfg))
 }

--- a/tests/ee/cluster_local.go
+++ b/tests/ee/cluster_local.go
@@ -12,7 +12,7 @@ import (
 )
 
 func NewCluster(t *testing.T, opts ...cluster.Option) cluster.Cluster {
-	cfg, err := cluster.NewConfig(opts...)
+	cfg, err := cluster.NewConfig(t, opts...)
 	require.NoError(t, err)
 	return local.New(t, local.WithCommonConfig(cfg))
 }

--- a/tests/ee/ee_test.go
+++ b/tests/ee/ee_test.go
@@ -220,7 +220,6 @@ func TestVarlogFailoverSN(t *testing.T) {
 }
 
 func TestVarlogEnduranceExample(t *testing.T) {
-	t.Skip("Skip the flaky test temporarily.")
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 	defer func() {


### PR DESCRIPTION
### What this PR does

This patch changes the following things for the local end-to-end test:

- changes logger from normal zap to zaptest
- adds the StorageNodeID tag to the storage node
- terminates storage node by sending SIGINT instead of SIGKILL
- changes the base port of the storage node from 50001 to 20001

Previously the test failed due to a bind error at port 50004. I think changing the storage node's base port is key to resolving this issue.

### Which issue(s) this PR resolves

Resolves #280
