### PR TITLE
test(e2e,local): Skip the flaky test - TestVarlogEnduranceExample

### DIFF
--- a/tests/ee/ee_test.go
+++ b/tests/ee/ee_test.go
@@ -220,6 +220,7 @@ func TestVarlogFailoverSN(t *testing.T) {
 }
 
 func TestVarlogEnduranceExample(t *testing.T) {
+	t.Skip("Skip the flaky test temporarily.")
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 	defer func() {


### PR DESCRIPTION
### What this PR does

This patch lets the local e2e test skip the flaky test - TestVarlogEnduranceExample.

