### PR TITLE
feat(storagenode): add an upper limit of log stream replicas count in a storage node

### DIFF
--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -54,6 +54,7 @@ func newStartCommand() *cli.Command {
 			flagLogStreamExecutorWriteQueueCapacity.IntFlag(false, logstream.DefaultWriteQueueCapacity),
 			flagLogStreamExecutorCommitQueueCapacity.IntFlag(false, logstream.DefaultCommitQueueCapacity),
 			flagLogStreamExecutorReplicateclientQueueCapacity.IntFlag(false, logstream.DefaultReplicateClientQueueCapacity),
+			flagMaxLogStreamReplicasCount,
 
 			// storage options
 			flagStorageDisableWAL.BoolFlag(),

--- a/cmd/varlogsn/flags.go
+++ b/cmd/varlogsn/flags.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"github.com/urfave/cli/v2"
+
 	"github.com/kakao/varlog/internal/flags"
+	"github.com/kakao/varlog/internal/storagenode"
 )
 
 var (
@@ -26,6 +29,12 @@ var (
 		Name:    "volumes",
 		Aliases: []string{"volume"},
 		Envs:    []string{"VOLUMES", "VOLUME"},
+	}
+
+	flagMaxLogStreamReplicasCount = &cli.IntFlag{
+		Name:  "max-logstream-replicas-count",
+		Usage: "The maximum number of log stream replicas in a storage node, infinity if a negative value",
+		Value: storagenode.DefaultMaxLogStreamReplicasCount,
 	}
 
 	// flags for grpc options.

--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -171,6 +171,7 @@ func start(c *cli.Context) error {
 			logstream.WithCommitQueueCapacity(c.Int(flagLogStreamExecutorCommitQueueCapacity.Name)),
 			logstream.WithReplicateClientQueueCapacity(c.Int(flagLogStreamExecutorReplicateclientQueueCapacity.Name)),
 		),
+		storagenode.WithMaxLogStreamReplicasCount(int32(c.Int(flagMaxLogStreamReplicasCount.Name))),
 		storagenode.WithDefaultStorageOptions(storageOpts...),
 		storagenode.WithLogger(logger),
 	)

--- a/internal/storagenode/client/management_client.go
+++ b/internal/storagenode/client/management_client.go
@@ -96,7 +96,7 @@ func (c *ManagementClient) AddLogStreamReplica(ctx context.Context, tpid types.T
 		StorageNodePath: snpath,
 	})
 	if err != nil {
-		return snpb.LogStreamReplicaMetadataDescriptor{}, errors.Wrap(verrors.FromStatusError(err), "snmcl")
+		return snpb.LogStreamReplicaMetadataDescriptor{}, err
 	}
 	return rsp.LogStreamReplica, nil
 }

--- a/internal/storagenode/config.go
+++ b/internal/storagenode/config.go
@@ -20,6 +20,7 @@ const (
 	DefaultServerMaxRecvSize              = 4 << 20
 	DefaultReplicateClientReadBufferSize  = 32 << 10
 	DefaultReplicateClientWriteBufferSize = 32 << 10
+	DefaultMaxLogStreamReplicasCount      = -1
 )
 
 type config struct {
@@ -33,6 +34,7 @@ type config struct {
 	grpcServerMaxRecvMsgSize        int64
 	replicateClientReadBufferSize   int64
 	replicateClientWriteBufferSize  int64
+	maxLogStreamReplicasCount       int32
 	volumes                         []string
 	defaultLogStreamExecutorOptions []logstream.ExecutorOption
 	pprofOpts                       []pprof.Option
@@ -47,6 +49,7 @@ func newConfig(opts []Option) (config, error) {
 		grpcServerMaxRecvMsgSize:       DefaultServerMaxRecvSize,
 		replicateClientReadBufferSize:  DefaultReplicateClientReadBufferSize,
 		replicateClientWriteBufferSize: DefaultReplicateClientWriteBufferSize,
+		maxLogStreamReplicasCount:      DefaultMaxLogStreamReplicasCount,
 		logger:                         zap.NewNop(),
 	}
 	for _, opt := range opts {
@@ -179,6 +182,12 @@ func WithReplicateClientWriteBufferSize(replicateClientWriteBufferSize int64) Op
 func WithDefaultLogStreamExecutorOptions(defaultLSEOptions ...logstream.ExecutorOption) Option {
 	return newFuncOption(func(cfg *config) {
 		cfg.defaultLogStreamExecutorOptions = defaultLSEOptions
+	})
+}
+
+func WithMaxLogStreamReplicasCount(maxLogStreamReplicasCount int32) Option {
+	return newFuncOption(func(cfg *config) {
+		cfg.maxLogStreamReplicasCount = maxLogStreamReplicasCount
 	})
 }
 


### PR DESCRIPTION
### What this PR does

This patch adds a new CLI flag, `--max-logstream-replicas-count,` which limits the number of log
stream replicas in a storage node. The default value is -1, meaning no upper limit, and a storage
node cannot create a log stream replica if it is zero.

A storage node keeps a count variable for the number of log stream replicas. Whenever the storage
node creates a new replica, it checks if the number of log stream replicas exceeds the upper limit.
If there is no problem, the storage node creates a new replica and increases the count variable.
Conversely, the storage node decreases the count variable whenever a log stream replica is removed.

This approach has a limitation: it cannot distinguish between standard and garbage replicas.
Fundamentally, a storage node has no method to distinguish them. So, this PR won't consider that.

### Which issue(s) this PR resolves

Resolves #293
