### PR TITLE
feat(admin): return ResourceExhausted if the log streams count overflows

### DIFF
--- a/internal/admin/mrmanager/manager.go
+++ b/internal/admin/mrmanager/manager.go
@@ -257,10 +257,10 @@ func (mrm *mrManager) RegisterLogStream(ctx context.Context, logStreamDesc *varl
 	}
 
 	if err := cli.RegisterLogStream(ctx, logStreamDesc); err != nil {
-		return multierr.Append(err, cli.Close())
+		_ = cli.Close()
+		return err
 	}
-
-	return err
+	return nil
 }
 
 func (mrm *mrManager) UnregisterLogStream(ctx context.Context, logStreamID types.LogStreamID) error {

--- a/internal/admin/server.go
+++ b/internal/admin/server.go
@@ -5,6 +5,7 @@ import (
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/verrors"
@@ -105,7 +106,11 @@ func (s *server) DescribeTopic(ctx context.Context, req *vmspb.DescribeTopicRequ
 func (s *server) AddLogStream(ctx context.Context, req *vmspb.AddLogStreamRequest) (*vmspb.AddLogStreamResponse, error) {
 	logStreamDesc, err := s.admin.addLogStream(ctx, req.GetTopicID(), req.GetReplicas())
 	if err != nil {
-		return nil, verrors.ToStatusErrorWithCode(err, codes.Unavailable)
+		code := status.Code(err)
+		if code != codes.ResourceExhausted {
+			code = codes.Unavailable
+		}
+		return nil, verrors.ToStatusErrorWithCode(err, code)
 	}
 	return &vmspb.AddLogStreamResponse{LogStream: logStreamDesc}, nil
 }

--- a/pkg/mrc/metadata_repository_client.go
+++ b/pkg/mrc/metadata_repository_client.go
@@ -129,7 +129,13 @@ func (c *metadataRepositoryClient) RegisterLogStream(ctx context.Context, ls *va
 		LogStream: ls,
 	}
 	_, err := c.client.RegisterLogStream(ctx, req)
-	return verrors.FromStatusError(errors.WithStack(err))
+	if err != nil {
+		if code := status.Code(err); code == codes.ResourceExhausted {
+			return err
+		}
+		return verrors.FromStatusError(errors.WithStack(err))
+	}
+	return nil
 }
 
 func (c *metadataRepositoryClient) UnregisterLogStream(ctx context.Context, lsID types.LogStreamID) error {

--- a/pkg/varlog/admin.go
+++ b/pkg/varlog/admin.go
@@ -100,6 +100,8 @@ type Admin interface {
 	// Deprecated: Use ListLogStreams.
 	DescribeTopic(ctx context.Context, topicID types.TopicID, opts ...AdminCallOption) (*vmspb.DescribeTopicResponse, error)
 	// AddLogStream adds a new log stream to the topic tpid.
+	// It returns the error code ResourceExhausted if the number of log streams
+	// is reached the upper limit.
 	//
 	// The admin server chooses proper replicas if the argument replicas are empty.
 	// Otherwise, if the argument replicas are defined, the admin server

--- a/proto/vmspb/admin.pb.go
+++ b/proto/vmspb/admin.pb.go
@@ -2759,6 +2759,9 @@ type ClusterManagerClient interface {
 	UnregisterTopic(ctx context.Context, in *UnregisterTopicRequest, opts ...grpc.CallOption) (*UnregisterTopicResponse, error)
 	GetLogStream(ctx context.Context, in *GetLogStreamRequest, opts ...grpc.CallOption) (*GetLogStreamResponse, error)
 	ListLogStreams(ctx context.Context, in *ListLogStreamsRequest, opts ...grpc.CallOption) (*ListLogStreamsResponse, error)
+	// AddLogStream adds a new log stream to the cluster.
+	// The error code ResourceExhausted is returned if the number of log streams
+	// is reached the upper limit.
 	AddLogStream(ctx context.Context, in *AddLogStreamRequest, opts ...grpc.CallOption) (*AddLogStreamResponse, error)
 	// UpdateLogStream changes the configuration of replicas in a log stream.
 	// Its codes are defines as followings:
@@ -3058,6 +3061,9 @@ type ClusterManagerServer interface {
 	UnregisterTopic(context.Context, *UnregisterTopicRequest) (*UnregisterTopicResponse, error)
 	GetLogStream(context.Context, *GetLogStreamRequest) (*GetLogStreamResponse, error)
 	ListLogStreams(context.Context, *ListLogStreamsRequest) (*ListLogStreamsResponse, error)
+	// AddLogStream adds a new log stream to the cluster.
+	// The error code ResourceExhausted is returned if the number of log streams
+	// is reached the upper limit.
 	AddLogStream(context.Context, *AddLogStreamRequest) (*AddLogStreamResponse, error)
 	// UpdateLogStream changes the configuration of replicas in a log stream.
 	// Its codes are defines as followings:

--- a/proto/vmspb/admin.proto
+++ b/proto/vmspb/admin.proto
@@ -374,6 +374,9 @@ service ClusterManager {
 
   rpc GetLogStream(GetLogStreamRequest) returns (GetLogStreamResponse) {}
   rpc ListLogStreams(ListLogStreamsRequest) returns (ListLogStreamsResponse) {}
+  // AddLogStream adds a new log stream to the cluster.
+  // The error code ResourceExhausted is returned if the number of log streams
+  // is reached the upper limit.
   rpc AddLogStream(AddLogStreamRequest) returns (AddLogStreamResponse) {}
   // UpdateLogStream changes the configuration of replicas in a log stream.
   // Its codes are defines as followings:


### PR DESCRIPTION
### What this PR does

The admin server and client respect the error code ResourceExhausted if the log stream count reaches
the upper limit.

### Which issue(s) this PR resolves

Updates #293, #297
