### PR TITLE
feat(admin): reject UpdateLogStream if there is no sealed Replica

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -698,7 +698,7 @@ func (adm *Admin) updateLogStream(ctx context.Context, lsid types.LogStreamID, p
 	newLSDesc.Replicas[popIdx] = &pushedReplica
 
 	if !adm.hasSealedReplica(ctx, newLSDesc) {
-		return nil, status.Errorf(codes.FailedPrecondition, "update log stream: does not have sealed replica")
+		return nil, status.Errorf(codes.FailedPrecondition, "update log stream: no sealed replica")
 	}
 
 	lsrmd, err := adm.snmgr.AddLogStreamReplica(ctx, pushedReplica.GetStorageNodeID(), newLSDesc.TopicID, lsid, pushedReplica.GetStorageNodePath())

--- a/internal/admin/admin_test.go
+++ b/internal/admin/admin_test.go
@@ -1555,6 +1555,43 @@ func TestAdmin_UpdateLogStream(t *testing.T) {
 			},
 		},
 		{
+			name: "DoesNotHaveSealedReplica",
+			prepare: func(mock *testMock) {
+				mock.MockClusterMetadataView.EXPECT().ClusterMetadata(gomock.Any()).Return(
+					&varlogpb.MetadataDescriptor{
+						LogStreams: []*varlogpb.LogStreamDescriptor{
+							{
+								TopicID:     tpid,
+								LogStreamID: lsid,
+								Status:      varlogpb.LogStreamStatusSealed,
+								Replicas: []*varlogpb.ReplicaDescriptor{
+									{
+										StorageNodeID:   snid1,
+										StorageNodePath: snpath1,
+									},
+								},
+							},
+						},
+					}, nil,
+				).AnyTimes()
+				mock.MockStorageNodeManager.EXPECT().GetMetadata(
+					gomock.Any(), gomock.Any(),
+				).Return(&snpb.StorageNodeMetadataDescriptor{
+					LogStreamReplicas: []snpb.LogStreamReplicaMetadataDescriptor{
+						{
+							LogStreamReplica: varlogpb.LogStreamReplica{
+								TopicLogStream: varlogpb.TopicLogStream{
+									TopicID:     tpid,
+									LogStreamID: lsid,
+								},
+							},
+							Status: varlogpb.LogStreamStatusSealing,
+						},
+					},
+				}, nil).AnyTimes()
+			},
+		},
+		{
 			name: "AddLogStreamReplicaError",
 			prepare: func(mock *testMock) {
 				mock.MockClusterMetadataView.EXPECT().ClusterMetadata(gomock.Any()).Return(
@@ -1574,6 +1611,23 @@ func TestAdmin_UpdateLogStream(t *testing.T) {
 						},
 					}, nil,
 				).AnyTimes()
+
+				mock.MockStorageNodeManager.EXPECT().GetMetadata(
+					gomock.Any(), gomock.Any(),
+				).Return(&snpb.StorageNodeMetadataDescriptor{
+					LogStreamReplicas: []snpb.LogStreamReplicaMetadataDescriptor{
+						{
+							LogStreamReplica: varlogpb.LogStreamReplica{
+								TopicLogStream: varlogpb.TopicLogStream{
+									TopicID:     tpid,
+									LogStreamID: lsid,
+								},
+							},
+							Status: varlogpb.LogStreamStatusSealed,
+						},
+					},
+				}, nil).AnyTimes()
+
 				mock.MockStorageNodeManager.EXPECT().AddLogStreamReplica(
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(snpb.LogStreamReplicaMetadataDescriptor{}, errors.New("error"))
@@ -1599,12 +1653,31 @@ func TestAdmin_UpdateLogStream(t *testing.T) {
 						},
 					}, nil,
 				).AnyTimes()
+
+				mock.MockStorageNodeManager.EXPECT().GetMetadata(
+					gomock.Any(), gomock.Any(),
+				).Return(&snpb.StorageNodeMetadataDescriptor{
+					LogStreamReplicas: []snpb.LogStreamReplicaMetadataDescriptor{
+						{
+							LogStreamReplica: varlogpb.LogStreamReplica{
+								TopicLogStream: varlogpb.TopicLogStream{
+									TopicID:     tpid,
+									LogStreamID: lsid,
+								},
+							},
+							Status: varlogpb.LogStreamStatusSealed,
+						},
+					},
+				}, nil).AnyTimes()
+
 				mock.MockStorageNodeManager.EXPECT().AddLogStreamReplica(
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(snpb.LogStreamReplicaMetadataDescriptor{}, nil)
+
 				mock.MockMetadataRepositoryManager.EXPECT().UpdateLogStream(
 					gomock.Any(), gomock.Any(),
 				).Return(errors.New("error"))
+
 				mock.MockRepository.EXPECT().SetLogStreamStatus(lsid, varlogpb.LogStreamStatusRunning)
 			},
 		},
@@ -1629,12 +1702,31 @@ func TestAdmin_UpdateLogStream(t *testing.T) {
 						},
 					}, nil,
 				).AnyTimes()
+
+				mock.MockStorageNodeManager.EXPECT().GetMetadata(
+					gomock.Any(), gomock.Any(),
+				).Return(&snpb.StorageNodeMetadataDescriptor{
+					LogStreamReplicas: []snpb.LogStreamReplicaMetadataDescriptor{
+						{
+							LogStreamReplica: varlogpb.LogStreamReplica{
+								TopicLogStream: varlogpb.TopicLogStream{
+									TopicID:     tpid,
+									LogStreamID: lsid,
+								},
+							},
+							Status: varlogpb.LogStreamStatusSealed,
+						},
+					},
+				}, nil).AnyTimes()
+
 				mock.MockStorageNodeManager.EXPECT().AddLogStreamReplica(
 					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(snpb.LogStreamReplicaMetadataDescriptor{}, nil)
+
 				mock.MockMetadataRepositoryManager.EXPECT().UpdateLogStream(
 					gomock.Any(), gomock.Any(),
 				).Return(nil)
+
 				mock.MockRepository.EXPECT().SetLogStreamStatus(lsid, varlogpb.LogStreamStatusRunning)
 			},
 		},


### PR DESCRIPTION
### What this PR does

Even if metarepos controls UpdateLogStream, admin should also reject UpdateLogStream that do not meet the conditions in order not to create unnecessary replicas. The admin collects the replica status of the requested UpdateLogStream from storageNode and decides whether to perform it.

### Which issue(s) this PR resolves

Resolves #303 

### Anything else

Include any links or documentation that might be helpful for reviewers.
