### PR TITLE
feat(admin): defines error codes of several RPCs in the admin server

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -2,7 +2,6 @@ package admin
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"sort"
 	"sync"
@@ -21,7 +20,6 @@ import (
 	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/kakao/varlog/internal/admin/admerrors"
 	"github.com/kakao/varlog/internal/admin/snwatcher"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/netutil"
@@ -174,7 +172,7 @@ func (adm *Admin) getStorageNode(ctx context.Context, snid types.StorageNodeID) 
 
 	md, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.Unavailable, "get storage node: cluster metadata not fetched")
+		return nil, status.Errorf(codes.Unavailable, "get storage node: %s", err.Error())
 	}
 	snd := md.GetStorageNode(snid)
 	if snd == nil {
@@ -220,7 +218,7 @@ func (adm *Admin) listStorageNodes(ctx context.Context) ([]admpb.StorageNodeMeta
 
 	md, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
-		return nil, status.Errorf(codes.Unavailable, "list storage nodes: cluster metadata not fetched")
+		return nil, status.Errorf(codes.Unavailable, "list storage nodes: %s", err.Error())
 	}
 
 	lazyInit := false
@@ -298,24 +296,25 @@ func (adm *Admin) addStorageNode(ctx context.Context, snid types.StorageNodeID, 
 
 	snmd, err := adm.snmgr.GetMetadataByAddress(ctx, snid, addr)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(status.Code(err), "add storage node: %s", err.Error())
 	}
 
 	now := time.Now().UTC()
 	snd := snmd.ToStorageNodeDescriptor()
 	snd.Status = varlogpb.StorageNodeStatusRunning
 	snd.CreateTime = now
-	if err = adm.mrmgr.RegisterStorageNode(ctx, snd); err != nil {
-		return nil, err
+	err = adm.mrmgr.RegisterStorageNode(ctx, snd)
+	if err != nil {
+		return nil, status.Errorf(status.Code(err), "add storage node: %s", err.Error())
 	}
 
 	adm.snmgr.AddStorageNode(ctx, snmd.StorageNode.StorageNodeID, addr)
 	adm.statRepository.Report(ctx, snmd, now)
 	snm, ok := adm.statRepository.GetStorageNode(snid)
 	if !ok {
-		return nil, fmt.Errorf("add storage node: temporal failure")
+		return nil, status.Error(codes.Unavailable, "add storage node: call again")
 	}
-	return snm, err
+	return snm, nil
 }
 
 func (adm *Admin) unregisterStorageNode(ctx context.Context, snid types.StorageNodeID) error {
@@ -324,7 +323,7 @@ func (adm *Admin) unregisterStorageNode(ctx context.Context, snid types.StorageN
 
 	clusmeta, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
-		return err
+		return status.Errorf(codes.Unavailable, "unregister storage node: %s", err.Error())
 	}
 
 	if clusmeta.GetStorageNode(snid) == nil {
@@ -335,13 +334,13 @@ func (adm *Admin) unregisterStorageNode(ctx context.Context, snid types.StorageN
 	for _, lsdesc := range clusmeta.GetLogStreams() {
 		for _, replica := range lsdesc.GetReplicas() {
 			if replica.GetStorageNodeID() == snid {
-				return errors.WithMessagef(admerrors.ErrNotIdleReplicas, "unregister storage node")
+				return status.Errorf(codes.FailedPrecondition, "unregister storage node: non-idle replicas: %s", replica.String())
 			}
 		}
 	}
 
 	if err := adm.mrmgr.UnregisterStorageNode(ctx, snid); err != nil {
-		return err
+		return status.Errorf(status.Code(err), "unregister storage node: %s", err.Error())
 	}
 
 	adm.snmgr.RemoveStorageNode(snid)
@@ -352,11 +351,11 @@ func (adm *Admin) unregisterStorageNode(ctx context.Context, snid types.StorageN
 func (adm *Admin) getTopic(ctx context.Context, tpid types.TopicID) (*varlogpb.TopicDescriptor, error) {
 	md, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Unavailable, "get topic: %s", err.Error())
 	}
 	td := md.GetTopic(tpid)
 	if td == nil {
-		return nil, errors.WithMessagef(admerrors.ErrNoSuchTopic, "get topic %d", int32(tpid))
+		return nil, status.Errorf(codes.NotFound, "get topic: no such topic %d", tpid)
 	}
 	return td, nil
 }
@@ -366,8 +365,8 @@ func (adm *Admin) listTopics(ctx context.Context) ([]varlogpb.TopicDescriptor, e
 	defer adm.mu.Unlock()
 
 	md, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
-	if err != nil || len(md.Topics) == 0 {
-		return nil, err
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "list topics: %s", err.Error())
 	}
 
 	tds := make([]varlogpb.TopicDescriptor, len(md.Topics))
@@ -385,7 +384,7 @@ func (adm *Admin) addTopic(ctx context.Context) (*varlogpb.TopicDescriptor, erro
 	// Note that the metadata repository accepts redundant RegisterTopic
 	// RPC only if the topic has no log streams.
 	if err := adm.mrmgr.RegisterTopic(ctx, topicID); err != nil {
-		return nil, err
+		return nil, status.Errorf(status.Code(err), "add topic: %s", err.Error())
 	}
 
 	return &varlogpb.TopicDescriptor{TopicID: topicID}, nil
@@ -397,7 +396,7 @@ func (adm *Admin) unregisterTopic(ctx context.Context, tpid types.TopicID) error
 
 	clusmeta, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
-		return err
+		return status.Errorf(codes.Unavailable, "unregister topic: %s", err.Error())
 	}
 
 	// TODO: Should it returns an error when removing the topic that has already been deleted or does not exist?
@@ -420,21 +419,21 @@ func (adm *Admin) unregisterTopic(ctx context.Context, tpid types.TopicID) error
 func (adm *Admin) getLogStream(ctx context.Context, tpid types.TopicID, lsid types.LogStreamID) (*varlogpb.LogStreamDescriptor, error) {
 	md, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
-		return nil, errors.WithMessage(err, "get log stream")
+		return nil, status.Errorf(codes.Unavailable, "get log stream: %s", err.Error())
 	}
 	td := md.GetTopic(tpid)
 	if td == nil {
-		return nil, errors.WithMessagef(admerrors.ErrNoSuchTopic, "get log stream: tpid %d", int32(tpid))
+		return nil, status.Errorf(codes.NotFound, "get log stream: no such topic: tpid %d", tpid)
 	}
 	if !td.HasLogStream(lsid) {
-		return nil, errors.WithMessagef(admerrors.ErrNoSuchLogStream, "get log stream: no log stream in topic: lsid %d", int32(lsid))
+		return nil, status.Errorf(codes.NotFound, "get log stream: no log stream in the topic: tpid %d, lsid %d", tpid, lsid)
 	}
 	lsd := md.GetLogStream(lsid)
 	if lsd == nil {
-		return nil, errors.WithMessagef(admerrors.ErrNoSuchLogStream, "get log stream: lsid %d", int32(lsid))
+		return nil, status.Errorf(codes.NotFound, "get log stream: no log stream: lsid %d", lsid)
 	}
 	if lsd.TopicID != tpid {
-		return nil, fmt.Errorf("get log stream: unexpected topic: expected %d, actual %d", int32(tpid), int32(lsd.TopicID))
+		return nil, status.Errorf(codes.Internal, "get log stream: unexpected topic: expected %d, actual %d", tpid, lsd.TopicID)
 	}
 	return lsd, nil
 }
@@ -442,11 +441,11 @@ func (adm *Admin) getLogStream(ctx context.Context, tpid types.TopicID, lsid typ
 func (adm *Admin) listLogStreams(ctx context.Context, tpid types.TopicID) ([]varlogpb.LogStreamDescriptor, error) {
 	md, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
-		return nil, errors.WithMessage(err, "list log streams")
+		return nil, status.Errorf(codes.Unavailable, "list log streams: %s", err.Error())
 	}
 	td := md.GetTopic(tpid)
 	if td == nil {
-		return nil, errors.WithMessagef(admerrors.ErrNoSuchTopic, "list log streams: tpid %d", int32(tpid))
+		return nil, status.Errorf(codes.NotFound, "list log streams: no such topic: tpid %d", tpid)
 	}
 	lsds := make([]varlogpb.LogStreamDescriptor, 0, len(td.LogStreams))
 	for _, lsid := range td.LogStreams {
@@ -455,7 +454,7 @@ func (adm *Admin) listLogStreams(ctx context.Context, tpid types.TopicID) ([]var
 			continue
 		}
 		if lsd.TopicID != tpid {
-			return nil, fmt.Errorf("list log streams: unexpected topic: expected %d, actual %d", int32(tpid), int32(lsd.TopicID))
+			return nil, status.Errorf(codes.Internal, "list log streams: unexpected topic: lsid %d, expected %d, actual %d", lsd.LogStreamID, tpid, lsd.TopicID)
 		}
 		lsds = append(lsds, *lsd)
 	}
@@ -540,17 +539,6 @@ func (adm *Admin) addLogStreamInternal(ctx context.Context, tpid types.TopicID, 
 
 	lsid := adm.lsidGen.Generate()
 
-	// duplicated by verifyLogStream
-	/*
-		if err := clusmeta.MustNotHaveLogStream(logStreamID); err != nil {
-			if e := adm.lsidGen.Refresh(ctx); e != nil {
-				err = multierr.Append(err, e)
-				adm.logger.Panic("could not refresh LogStreamIDGenerator", zap.Error(err))
-			}
-			return nil, err
-		}
-	*/
-
 	lsd := &varlogpb.LogStreamDescriptor{
 		TopicID:     tpid,
 		LogStreamID: lsid,
@@ -560,7 +548,7 @@ func (adm *Admin) addLogStreamInternal(ctx context.Context, tpid types.TopicID, 
 
 	clusmeta, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(status.Code(err), "add log stream: %s", err.Error())
 	}
 	if err := adm.verifyLogStream(clusmeta, lsd); err != nil {
 		return nil, err
@@ -569,29 +557,33 @@ func (adm *Admin) addLogStreamInternal(ctx context.Context, tpid types.TopicID, 
 	// TODO: Choose the primary - e.g., shuffle logStreamReplicaMetas
 	lsd, err = adm.snmgr.AddLogStream(ctx, lsd)
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(status.Code(err), "add log stream: %s", err.Error())
 	}
 
 	// NB: RegisterLogStream returns nil if the logstream already exists.
-	return lsd, adm.mrmgr.RegisterLogStream(ctx, lsd)
+	err = adm.mrmgr.RegisterLogStream(ctx, lsd)
+	if err != nil {
+		return nil, status.Errorf(status.Code(err), "add log stream: %s", err.Error())
+	}
+	return lsd, nil
 }
 
 func (adm *Admin) verifyLogStream(clusmeta *varlogpb.MetadataDescriptor, lsdesc *varlogpb.LogStreamDescriptor) error {
 	replicas := lsdesc.GetReplicas()
 	// the number of logstream replica
 	if uint(len(replicas)) != adm.replicationFactor {
-		return errors.Errorf("invalid number of log stream replicas: %d", len(replicas))
+		return status.Errorf(codes.FailedPrecondition, "add log stream: invalid number of log stream replicas: expected %d, actual %d", adm.replicationFactor, len(replicas))
 	}
 	// storagenode existence
 	for _, replica := range replicas {
 		if _, err := clusmeta.MustHaveStorageNode(replica.GetStorageNodeID()); err != nil {
-			return err
+			return status.Errorf(codes.FailedPrecondition, "add log stream: no such storage node: snid %d", replica.StorageNodeID)
 		}
 	}
 	// logstream existence
 	if err := clusmeta.MustNotHaveLogStream(lsdesc.GetLogStreamID()); err != nil {
 		_ = adm.lsidGen.Refresh(context.TODO())
-		return err
+		return status.Errorf(codes.FailedPrecondition, "add log stream: duplicated log stream id: %d", lsdesc.LogStreamID)
 	}
 	return nil
 }
@@ -783,14 +775,17 @@ func (adm *Admin) removeLogStreamReplica(ctx context.Context, snid types.Storage
 
 	clusmeta, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
-		return err
+		return status.Errorf(codes.Unavailable, "remove log stream replica: %s", err.Error())
 	}
 
 	if err := adm.removableLogStreamReplica(clusmeta, snid, lsid); err != nil {
 		return err
 	}
 
-	return adm.snmgr.RemoveLogStreamReplica(ctx, snid, tpid, lsid)
+	if err := adm.snmgr.RemoveLogStreamReplica(ctx, snid, tpid, lsid); err != nil {
+		return status.Errorf(status.Code(err), "remove log stream replica: %s", err.Error())
+	}
+	return nil
 }
 
 func (adm *Admin) removableLogStreamReplica(clusmeta *varlogpb.MetadataDescriptor, snid types.StorageNodeID, lsid types.LogStreamID) error {
@@ -803,7 +798,7 @@ func (adm *Admin) removableLogStreamReplica(clusmeta *varlogpb.MetadataDescripto
 	replicas := lsdesc.GetReplicas()
 	for _, replica := range replicas {
 		if replica.GetStorageNodeID() == snid {
-			return errors.Wrap(verrors.ErrState, "running log stream is not removable")
+			return status.Errorf(codes.FailedPrecondition, "remove log stream replica: appendable log stream")
 		}
 	}
 	return nil

--- a/proto/admpb/admin.proto
+++ b/proto/admpb/admin.proto
@@ -346,21 +346,40 @@ message RemoveMRPeerRequest {
 message RemoveMRPeerResponse {}
 
 service ClusterManager {
-  // GetStorageNode returns the metadata of storage node requested.
-  // It returns NotFound if the storage node does not exist.
+  // GetStorageNode returns the metadata of the storage node requested.
+  // It produces a gRPC NotFound error if the storage node does not exist. If
+  // the metadata repository cannot be reachable, it returns a gRPC Unavailable
+  // error. In this case, clients can retry with proper backoff to fix it.
   rpc GetStorageNode(GetStorageNodeRequest) returns (GetStorageNodeResponse) {}
-  // ListStorageNodes returns a list of storage nodes in the cluster.
+  // ListStorageNodes returns a list of storage nodes.
+  // If the metadata repository cannot be reachable, it returns a gRPC
+  // Unavailable error. In this case, clients can retry with proper backoff to
+  // fix it. If the metadata fetched from the metadata repository is
+  // inconsistent, it returns a gRPC Internal error.
   rpc ListStorageNodes(ListStorageNodesRequest)
     returns (ListStorageNodesResponse) {}
-  // AddStorageNode adds a new storage node to the cluster.
-  // It is idempotent, that is, adding an already added storage node is okay.
+  // AddStorageNode adds a new storage node to the cluster. It is idempotent;
+  // adding an already added storage node is okay.
+  // Note that if the admin server cannot refresh the storage node list in the
+  // memory, it returns a gRPC Unavailable error. However, the storage node
+  // could have been added, so users should call this RPC with the same
+  // parameter again.
   rpc AddStorageNode(AddStorageNodeRequest) returns (AddStorageNodeResponse) {}
   // UnregisterStorageNode unregisters the storage node specified by the
-  // request.
+  // argument snid. If users try to unregister an already non-exist node, it
+  // returns okay.
+  //
+  // It returns the following gRPC errors:
+  // - Unavailable: The metadata cannot be fetched from the metadata repository.
+  // - FailedPrecondition: The storage node still has valid log stream replicas.
   rpc UnregisterStorageNode(UnregisterStorageNodeRequest)
     returns (UnregisterStorageNodeResponse) {}
 
   // GetTopic returns the topic specified by the request.
+  //
+  // It returns the following gRPC errors:
+  // - Unavailable: The metadata cannot be fetched from the metadata repository.
+  // - NotFound: The topic doesn't exist.
   rpc GetTopic(GetTopicRequest) returns (GetTopicResponse) {}
   // DescribeTopic returns the topic specified by the request.
   // Deprecated: Use GetTopic.
@@ -368,17 +387,47 @@ service ClusterManager {
   // ListTopics returns a list of topics in the cluster.
   rpc ListTopics(ListTopicsRequest) returns (ListTopicsResponse) {}
   // AddTopic adds a new topic and returns its metadata.
+  // It produces a gRPC Internal error if the metadata rejects the request.
   rpc AddTopic(AddTopicRequest) returns (AddTopicResponse) {}
+  // UnregisterTopic unregisters the topic specified by the argument tpid.
+  // It returns a gRPC Unavailable error if the metadata cannot be fetched from
+  // the metadata repository.
+  // TODO: Its behavior is unclear if the topic has already been removed.
+  // FIXME: It overwrites the gRPC errors returned from the metadata repository,
+  // even if some may be important.
   rpc UnregisterTopic(UnregisterTopicRequest)
     returns (UnregisterTopicResponse) {}
 
+  // GetLogStream returns the metadata of the log stream specified by the
+  // arguments tpid and lsid. The metadata is the type stored in the metadata
+  // repository.
+  //
+  // It returns the following gRPC errors:
+  // - Unavailable: The metadata cannot be fetched from the metadata repository.
+  // - NotFound: Either the topic or the log stream does not exist.
+  // - Internal: The TopicID in the log stream metadata doesn't match.
   rpc GetLogStream(GetLogStreamRequest) returns (GetLogStreamResponse) {}
+  // ListLogStreams returns all log streams belonging to the topic specified by
+  // the argument tpid.
+  //
+  // It returns the following gRPC errors:
+  // - Unavailable: The metadata cannot be fetched from the metadata repository.
+  // - NotFound: The topic does not exist.
+  // - Internal: The TopicID in the log stream metadata doesn't match.
   rpc ListLogStreams(ListLogStreamsRequest) returns (ListLogStreamsResponse) {}
   // AddLogStream adds a new log stream to the cluster.
-  // The error code ResourceExhausted is returned if the number of log streams
-  // is reached the upper limit.
+  //
+  // It returns the following gRPC errors:
+  // - Unavailable: The metadata cannot be fetched from the metadata repository.
+  // - ResourceExhausted: The number of log streams is reached the upper limit.
+  // - FailedPrecondition: Replicas information in the request is invalid; for
+  // example, the number of log stream replicas in the request does not equal
+  // the replication factor, or the storage node for the replica does not exist.
+  //
+  // TODO: Not all errors are codified.
   rpc AddLogStream(AddLogStreamRequest) returns (AddLogStreamResponse) {}
   // UpdateLogStream changes the configuration of replicas in a log stream.
+  //
   // Its codes are defines as followings:
   // - InvalidArgument: The client tries to swap the same replica.
   // - Unavailable: The cluster metadata cannot be fetched from the metadata
@@ -395,9 +444,18 @@ service ClusterManager {
   // metadata repository soon.
   rpc UpdateLogStream(UpdateLogStreamRequest)
     returns (UpdateLogStreamResponse) {}
+  // UnregisterLogStream unregisters the log stream specified by the arguments
+  // tpid and lsid.
+  // TODO: It is not tested.
   rpc UnregisterLogStream(UnregisterLogStreamRequest)
     returns (UnregisterLogStreamResponse) {}
-
+  // RemoveLogStreamReplica removes the log stream replica specified by the
+  // arguments snid, tpid, and lsid.
+  //
+  // It returns the following gRPC errors:
+  // - Unavailable: The metadata cannot be fetched from the metadata repository.
+  // - FailedPrecondition: The log stream of the log stream replica can't be
+  // removable, e.g., clients still can append logs to the log stream.
   rpc RemoveLogStreamReplica(RemoveLogStreamReplicaRequest)
     returns (RemoveLogStreamReplicaResponse) {}
 


### PR DESCRIPTION
### What this PR does

This patch defines the gRPC error codes of various RPCs in the admin server. Previously, we depended
on the `verrors` package to identify the cause of errors. However, the `verrors` package is vague
and an anti-pattern. To handle errors explicitly, we are trying to adopt gRPC error codes.

Although this PR doesn't convert everything, it can be a starting point for our robust error
handling.

### Which issue(s) this PR resolves

Updates #312
