### PR TITLE
feat(storagenode): add gRPC error codes to the log server

### DIFF
--- a/internal/storagenode/errors/errors.go
+++ b/internal/storagenode/errors/errors.go
@@ -1,0 +1,7 @@
+package errors
+
+import stderrors "errors"
+
+var (
+	ErrNotPrimary = stderrors.New("not primary replica")
+)

--- a/internal/storagenode/log_server.go
+++ b/internal/storagenode/log_server.go
@@ -6,7 +6,10 @@ import (
 
 	pbtypes "github.com/gogo/protobuf/types"
 	"go.uber.org/multierr"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	snerrors "github.com/kakao/varlog/internal/storagenode/errors"
 	"github.com/kakao/varlog/internal/storagenode/logstream"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/verrors"
@@ -20,34 +23,62 @@ type logServer struct {
 var _ snpb.LogIOServer = (*logServer)(nil)
 
 func (ls logServer) Append(ctx context.Context, req *snpb.AppendRequest) (*snpb.AppendResponse, error) {
+	err := snpb.ValidateTopicLogStream(req)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	payload := req.GetPayload()
 	req.Payload = nil
 	lse, loaded := ls.sn.executors.Load(req.TopicID, req.LogStreamID)
 	if !loaded {
-		return nil, errors.New("storage node: no such logstream")
+		return nil, status.Error(codes.NotFound, "no such log stream")
 	}
+
 	res, err := lse.Append(ctx, payload)
 	if err != nil {
-		return nil, err
+		var code codes.Code
+		switch err {
+		case verrors.ErrSealed:
+			code = codes.FailedPrecondition
+		case snerrors.ErrNotPrimary:
+			code = codes.Unavailable
+		default:
+			code = status.FromContextError(err).Code()
+		}
+		return nil, status.Error(code, err.Error())
 	}
 	return &snpb.AppendResponse{Results: res}, nil
 }
 
 func (ls logServer) Read(context.Context, *snpb.ReadRequest) (*snpb.ReadResponse, error) {
-	panic("not implemented")
+	return nil, status.Error(codes.Unimplemented, "deprecated")
 }
 
 func (ls logServer) Subscribe(req *snpb.SubscribeRequest, stream snpb.LogIO_SubscribeServer) error {
+	if err := snpb.ValidateTopicLogStream(req); err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	lse, loaded := ls.sn.executors.Load(req.TopicID, req.LogStreamID)
 	if !loaded {
-		return errors.New("storage: no such logstream")
+		return status.Error(codes.NotFound, "no such log stream")
 	}
 
 	ctx := stream.Context()
 	sr, err := lse.SubscribeWithGLSN(req.GLSNBegin, req.GLSNEnd)
 	if err != nil {
-		// FIXME: error propagation via gRPC is awkward.
-		return verrors.ToStatusError(err)
+		var code codes.Code
+		if errors.Is(err, verrors.ErrClosed) {
+			code = codes.Unavailable
+		} else if errors.Is(err, verrors.ErrInvalid) {
+			code = codes.InvalidArgument
+		} else if errors.Is(err, verrors.ErrTrimmed) {
+			code = codes.OutOfRange
+		} else {
+			code = status.FromContextError(err).Code()
+		}
+		return verrors.ToStatusErrorWithCode(err, code)
 	}
 
 	rsp := &snpb.SubscribeResponse{}
@@ -72,19 +103,40 @@ Loop:
 	}
 	sr.Stop()
 	// FIXME: error propagation via gRPC is awkward.
-	return verrors.ToStatusError(multierr.Append(err, sr.Err()))
+	if err == nil && sr.Err() == nil {
+		return nil
+	}
+	if err != nil {
+		return status.Error(status.FromContextError(err).Code(), multierr.Append(err, sr.Err()).Error())
+	}
+	return status.Error(status.FromContextError(sr.Err()).Code(), sr.Err().Error())
 }
 
 func (ls logServer) SubscribeTo(req *snpb.SubscribeToRequest, stream snpb.LogIO_SubscribeToServer) (err error) {
+	err = snpb.ValidateTopicLogStream(req)
+	if err != nil {
+		return status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	lse, loaded := ls.sn.executors.Load(req.TopicID, req.LogStreamID)
 	if !loaded {
-		return errors.New("storage: no such logstream")
+		return status.Error(codes.NotFound, "no such log stream")
 	}
 
 	ctx := stream.Context()
 	sr, err := lse.SubscribeWithLLSN(req.LLSNBegin, req.LLSNEnd)
 	if err != nil {
-		return err
+		var code codes.Code
+		if errors.Is(err, verrors.ErrClosed) {
+			code = codes.Unavailable
+		} else if errors.Is(err, verrors.ErrInvalid) {
+			code = codes.InvalidArgument
+		} else if errors.Is(err, verrors.ErrTrimmed) {
+			code = codes.OutOfRange
+		} else {
+			code = status.FromContextError(err).Code()
+		}
+		return verrors.ToStatusErrorWithCode(err, code)
 	}
 
 	rsp := &snpb.SubscribeToResponse{}
@@ -121,14 +173,20 @@ func (ls logServer) TrimDeprecated(ctx context.Context, req *snpb.TrimDeprecated
 }
 
 func (ls logServer) LogStreamReplicaMetadata(_ context.Context, req *snpb.LogStreamReplicaMetadataRequest) (*snpb.LogStreamReplicaMetadataResponse, error) {
+	if err := snpb.ValidateTopicLogStream(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
 	lse, loaded := ls.sn.executors.Load(req.TopicID, req.LogStreamID)
 	if !loaded {
-		return nil, errors.New("storage: no such logstream")
+		return nil, status.Error(codes.NotFound, "no such log stream")
 	}
 
 	lsrmd, err := lse.Metadata()
 	if err != nil {
-		return nil, err
+		if err == verrors.ErrClosed {
+			return nil, status.Error(codes.Unavailable, err.Error())
+		}
+		return nil, status.Error(status.FromContextError(err).Code(), err.Error())
 	}
 	return &snpb.LogStreamReplicaMetadataResponse{LogStreamReplica: lsrmd}, nil
 }

--- a/internal/storagenode/logstream/append.go
+++ b/internal/storagenode/logstream/append.go
@@ -2,11 +2,11 @@ package logstream
 
 import (
 	"context"
-	"errors"
 	"sync/atomic"
 	"time"
 
 	"github.com/kakao/varlog/internal/batchlet"
+	snerrors "github.com/kakao/varlog/internal/storagenode/errors"
 	"github.com/kakao/varlog/pkg/verrors"
 	"github.com/kakao/varlog/proto/snpb"
 )
@@ -36,7 +36,7 @@ func (lse *Executor) Append(ctx context.Context, dataBatch [][]byte) ([]snpb.App
 	}
 
 	if !lse.isPrimary() {
-		return nil, errors.New("log stream: not primary")
+		return nil, snerrors.ErrNotPrimary
 	}
 
 	startTime := time.Now()

--- a/proto/snpb/log_io.go
+++ b/proto/snpb/log_io.go
@@ -1,0 +1,20 @@
+package snpb
+
+import (
+	"fmt"
+
+	"github.com/kakao/varlog/pkg/types"
+)
+
+func ValidateTopicLogStream(iface interface {
+	GetTopicID() types.TopicID
+	GetLogStreamID() types.LogStreamID
+}) error {
+	if tpid := iface.GetTopicID(); tpid.Invalid() {
+		return fmt.Errorf("invalid topic %d", tpid)
+	}
+	if lsid := iface.GetLogStreamID(); lsid.Invalid() {
+		return fmt.Errorf("invalid log stream %d", lsid)
+	}
+	return nil
+}

--- a/proto/snpb/log_io.proto
+++ b/proto/snpb/log_io.proto
@@ -176,11 +176,46 @@ message LogStreamReplicaMetadataResponse {
 }
 
 service LogIO {
+  // Append stores a list of log entries to the end of the log stream specified
+  // by AppendRequest. The log entries are appended partially; that is, some of
+  // the log entries could not be stored due to failures.
+  //
+  // It returns the following gRPC errors:
+  // - InvalidArgument: AppendRequest has invalid fields; for instance, TopicID
+  // is invalid.
+  // - NotFound: The log stream replica specified by the AppendRequest does not
+  // exist in the storage node. Note that it does not mean that the log stream
+  // does not exist in the cluster.
+  // - FailedPrecondition: The log stream may be sealed; thus, clients cannot
+  // write the log entry. Clients should unseal the log stream to append a log
+  // entry to the log stream.
+  // - Unavailable: The storage node is shutting down, or the log stream replica
+  // is not primary.
+  // - Canceled: The client canceled the request.
+  // - DeadlineExceeded: The client's timeout has expired.
+  //
+  // FIXME: Partial failures are not specified by the gRPC error codes.
   rpc Append(AppendRequest) returns (AppendResponse) {}
+  // Read reads a log entry from the log stream specified by ReadRequest.
+  // Deprecated: Use Subscribe or SubscribeTo.
   rpc Read(ReadRequest) returns (ReadResponse) {}
+  // Subscribe reads a range of log entries specified by SubscribeRequest.
+  //
+  // It returns the following gRPC errors:
+  // - NotFound: The log stream replica specified by the SubscribeRequest does
+  // not exist in the storage node. Note that it does not mean that the log
+  // stream does not exist in the cluster.
+  // - Unavailable: The storage node is shutting down.
+  // - InvalidArgument: The range is invalid; for example, the beginning of the
+  // range is greater than or equal to the end.
+  // - OutOfRange: The parts or whole range are already trimmed.
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse) {}
+  // SubscribeTo is similar to Subscribe except that it specifies the range with
+  // LLSN.
   rpc SubscribeTo(SubscribeToRequest) returns (stream SubscribeToResponse) {}
   rpc TrimDeprecated(TrimDeprecatedRequest) returns (google.protobuf.Empty) {}
+  // LogStreamReplicaMetadata returns metadata of the log stream replica
+  // specified by the LogStreamReplicaMetadataRequest.
   rpc LogStreamReplicaMetadata(LogStreamReplicaMetadataRequest)
     returns (LogStreamReplicaMetadataResponse) {}
 }


### PR DESCRIPTION
### What this PR does

This patch adds gRPC error codes to the RPCs of the log server in the storage node. Previously the
storage node had no use of gRPC error codes. Instead, it used the `verrors` package that serializes
and deserializes the error messages into and from strings.

```
+-------------+     +-------------------------+
|             |     |  Client                 |
|             |     |  Library +------------+ |                +------------+
|             |     |          |            | |                |            |
|    User     |   sentinel     |            | |  encode error  |            |
| Application |<----error------+ RPC Client |<+--message into -| RPC Server |
|             |     |          |            | |    Details     |            |
|             |     |          |            | |                |            |
|             |     |          +------------+ |                +------------+
|             |     |                         |
+-------------+     +-------------------------+
```

However, comparing strings to identify errors is an anti-pattern in Go. Moreover, the `verrors`
package has not been maintained for a long time and has no straightforward interface. So, we are
trying to adopt gRPC error codes.

```
+-------------+     +-------------------------+
|             |     |  Client                 |
|             |     |  Library +------------+ |                +------------+
|             |     |          |            | |                |            |
|    User     |   sentinel     |            | |  gRPC status   |            |
| Application |<----error------+ RPC Client |<+-----code-------| RPC Server |
|             |     |          |            | |                |            |
|             |     |          |            | |                |            |
|             |     |          +------------+ |                +------------+
|             |     |                         |
+-------------+     +-------------------------+
```

### Which issue(s) this PR resolves

Updates #312

### Anything else

For further information, I add some links for the Detail fields of gRPC.

- https://pkg.go.dev/google.golang.org/genproto/googleapis/rpc/status#Status
- https://cloud.google.com/apis/design/errors#error_details
