### PR TITLE
feat(storagenode): add gRPC error codes to the admin service

### DIFF
--- a/internal/storagenode/admin_server.go
+++ b/internal/storagenode/admin_server.go
@@ -4,7 +4,10 @@ import (
 	"context"
 
 	pbtypes "github.com/gogo/protobuf/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
+	snerrors "github.com/kakao/varlog/internal/storagenode/errors"
 	"github.com/kakao/varlog/proto/snpb"
 	"github.com/kakao/varlog/proto/varlogpb"
 )
@@ -17,36 +20,97 @@ var _ snpb.ManagementServer = (*adminServer)(nil)
 
 func (as *adminServer) GetMetadata(ctx context.Context, _ *snpb.GetMetadataRequest) (*snpb.GetMetadataResponse, error) {
 	snmd, err := as.sn.getMetadata(ctx)
-	return &snpb.GetMetadataResponse{StorageNodeMetadata: snmd}, err
+	if err != nil {
+		var code codes.Code
+		switch err {
+		case snerrors.ErrClosed:
+			code = codes.Unavailable
+		default:
+			code = status.FromContextError(err).Code()
+		}
+		return nil, status.Error(code, err.Error())
+	}
+	return &snpb.GetMetadataResponse{StorageNodeMetadata: snmd}, nil
 }
 
 func (as *adminServer) AddLogStreamReplica(ctx context.Context, req *snpb.AddLogStreamReplicaRequest) (*snpb.AddLogStreamReplicaResponse, error) {
 	lsrmd, err := as.sn.addLogStreamReplica(ctx, req.TopicID, req.LogStreamID, req.StorageNodePath)
 	if err != nil {
-		return nil, err
+		var code codes.Code
+		switch err {
+		case snerrors.ErrTooManyReplicas:
+			code = codes.ResourceExhausted
+		default:
+			code = status.FromContextError(err).Code()
+		}
+		return nil, status.Error(code, err.Error())
 	}
 	rsp := &snpb.AddLogStreamReplicaResponse{
 		LogStreamReplica: lsrmd,
 	}
-	return rsp, err
+	return rsp, nil
 }
 
 func (as *adminServer) RemoveLogStream(ctx context.Context, req *snpb.RemoveLogStreamRequest) (*pbtypes.Empty, error) {
 	err := as.sn.removeLogStreamReplica(ctx, req.TopicID, req.LogStreamID)
-	return &pbtypes.Empty{}, err
+	if err != nil {
+		var code codes.Code
+		switch err {
+		case snerrors.ErrClosed:
+			code = codes.Unavailable
+		case snerrors.ErrNotExist:
+			code = codes.NotFound
+		default:
+			code = status.FromContextError(err).Code()
+		}
+		return nil, status.Error(code, err.Error())
+	}
+	return &pbtypes.Empty{}, nil
 }
 
 func (as *adminServer) Seal(ctx context.Context, req *snpb.SealRequest) (*snpb.SealResponse, error) {
-	status, localHWM, err := as.sn.seal(ctx, req.TopicID, req.LogStreamID, req.LastCommittedGLSN)
+	if err := snpb.ValidateTopicLogStream(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	lss, localHWM, err := as.sn.seal(ctx, req.TopicID, req.LogStreamID, req.LastCommittedGLSN)
+	if err != nil {
+		var code codes.Code
+		switch err {
+		case snerrors.ErrClosed:
+			code = codes.Unavailable
+		case snerrors.ErrNotExist:
+			code = codes.NotFound
+		default:
+			code = status.FromContextError(err).Code()
+		}
+		return nil, status.Error(code, err.Error())
+	}
 	return &snpb.SealResponse{
-		Status:            status,
+		Status:            lss,
 		LastCommittedGLSN: localHWM,
-	}, err
+	}, nil
 }
 
 func (as *adminServer) Unseal(ctx context.Context, req *snpb.UnsealRequest) (*pbtypes.Empty, error) {
+	if err := snpb.ValidateTopicLogStream(req); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
 	err := as.sn.unseal(ctx, req.TopicID, req.LogStreamID, req.Replicas)
-	return &pbtypes.Empty{}, err
+	if err != nil {
+		var code codes.Code
+		switch err {
+		case snerrors.ErrClosed:
+			code = codes.Unavailable
+		case snerrors.ErrNotExist:
+			code = codes.NotFound
+		default:
+			code = status.FromContextError(err).Code()
+		}
+		return nil, status.Error(code, err.Error())
+	}
+	return &pbtypes.Empty{}, nil
 }
 
 func (as *adminServer) Sync(ctx context.Context, req *snpb.SyncRequest) (*snpb.SyncResponse, error) {
@@ -60,7 +124,19 @@ func (as *adminServer) Sync(ctx context.Context, req *snpb.SyncRequest) (*snpb.S
 			LogStreamID: req.LogStreamID,
 		},
 	})
-	return &snpb.SyncResponse{Status: syncStatus}, err
+	if err != nil {
+		var code codes.Code
+		switch err {
+		case snerrors.ErrClosed:
+			code = codes.Unavailable
+		case snerrors.ErrNotExist:
+			code = codes.NotFound
+		default:
+			code = status.FromContextError(err).Code()
+		}
+		return nil, status.Error(code, err.Error())
+	}
+	return &snpb.SyncResponse{Status: syncStatus}, nil
 }
 
 func (as *adminServer) Trim(ctx context.Context, req *snpb.TrimRequest) (*snpb.TrimResponse, error) {

--- a/internal/storagenode/errors/errors.go
+++ b/internal/storagenode/errors/errors.go
@@ -3,5 +3,8 @@ package errors
 import stderrors "errors"
 
 var (
-	ErrNotPrimary = stderrors.New("not primary replica")
+	ErrNotPrimary      = stderrors.New("not primary replica")
+	ErrClosed          = stderrors.New("closed")
+	ErrTooManyReplicas = stderrors.New("too many log stream replicas")
+	ErrNotExist        = stderrors.New("not exist")
 )

--- a/internal/storagenode/logstream/executor.go
+++ b/internal/storagenode/logstream/executor.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/kakao/varlog/internal/storage"
+	snerrors "github.com/kakao/varlog/internal/storagenode/errors"
 	"github.com/kakao/varlog/internal/storagenode/telemetry"
 	"github.com/kakao/varlog/pkg/rpc"
 	"github.com/kakao/varlog/pkg/types"
@@ -222,7 +223,7 @@ func (lse *Executor) Seal(_ context.Context, lastCommittedGLSN types.GLSN) (stat
 
 	if lse.esm.load() == executorStateClosed {
 		// FIXME: strange logstream status
-		err = verrors.ErrClosed
+		err = snerrors.ErrClosed
 		return
 	}
 

--- a/internal/storagenode/logstream/executor_test.go
+++ b/internal/storagenode/logstream/executor_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/kakao/varlog/internal/batchlet"
 	"github.com/kakao/varlog/internal/storage"
+	snerrors "github.com/kakao/varlog/internal/storagenode/errors"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/verrors"
 	"github.com/kakao/varlog/proto/snpb"
@@ -88,7 +89,7 @@ func TestExecutor_Closed(t *testing.T) {
 	assert.ErrorIs(t, err, verrors.ErrClosed)
 
 	_, _, err = lse.Seal(context.Background(), types.MinGLSN)
-	assert.ErrorIs(t, err, verrors.ErrClosed)
+	assert.ErrorIs(t, err, snerrors.ErrClosed)
 
 	err = lse.Unseal(context.Background(), []varlogpb.LogStreamReplica{
 		{

--- a/proto/snpb/management.pb.go
+++ b/proto/snpb/management.pb.go
@@ -879,19 +879,61 @@ const _ = grpc.SupportPackageIsVersion4
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type ManagementClient interface {
-	// GetMetadata returns metadata of StorageNode.
+	// GetMetadata returns the metadata of the storage node. It produces a gRPC
+	// Unavailable error if the storage node is shutting down.
 	GetMetadata(ctx context.Context, in *GetMetadataRequest, opts ...grpc.CallOption) (*GetMetadataResponse, error)
 	// AddLogStreamReplica adds a new log stream replica to a storage node.
+	//
+	// It returns the following gRPC errors:
+	// - Unavailable: The storage node is shutting down.
+	// - ResourceExhausted: The number of log stream replicas in the storage node
+	// reaches the upper limit.
+	// - Canceled: The client canceled the request.
+	// DeadlineExceeded: The client's timeout has expired.
 	AddLogStreamReplica(ctx context.Context, in *AddLogStreamReplicaRequest, opts ...grpc.CallOption) (*AddLogStreamReplicaResponse, error)
-	// RemoveLogStream removes a LogStream from StorageNode.
+	// RemoveLogStream removes a log stream replica from the storage node.
+	//
+	// It returns the following gRPC errors:
+	// - Unavailable: The storage node is shutting down.
+	// - NotFound: The log stream replica does not exist.
+	// - Canceled: The client canceled the request.
+	// - DeadlineExceeded: The client's timeout has expired.
+	//
+	// TODO: It should be renamed to RemoveLogStreamReplica to represent its
+	// purpose precisely.
 	RemoveLogStream(ctx context.Context, in *RemoveLogStreamRequest, opts ...grpc.CallOption) (*types.Empty, error)
-	// Seal changes the status of LogStreamExecutor to LogStreamStatusSealing or
-	// LogStreamStatusSealed.
+	// Seal changes the status of the log stream replica to LogStreamStatusSealing
+	// or LogStreamStatusSealed.
+	//
+	// It returns the following gRPC errors:
+	// - InvalidArgument: SealRequest has invalid fields; for instance, TopicID
+	// is invalid.
+	// - Unavailable: The storage node is shutting down.
+	// - NotFound: The log stream replica does not exist.
+	// - Canceled: The client canceled the request.
+	// - DeadlineExceeded: The client's timeout has expired.
 	Seal(ctx context.Context, in *SealRequest, opts ...grpc.CallOption) (*SealResponse, error)
-	// Unseal changes the status of LogStreamExecutor to LogStreamStatusRunning.
+	// Unseal changes the status of the log stream replica to
+	// LogStreamStatusRunning.
+	//
+	// It returns the following gRPC errors:
+	// - InvalidArgument: UnsealRequest has invalid fields; for instance, TopicID
+	// is invalid.
+	// - Unavailable: The storage node is shutting down.
+	// - NotFound: The log stream replica does not exist.
+	// - Canceled: The client canceled the request.
+	// - DeadlineExceeded: The client's timeout has expired.
 	Unseal(ctx context.Context, in *UnsealRequest, opts ...grpc.CallOption) (*types.Empty, error)
-	// Sync starts mirroring between two StorageNodes.
+	// Sync duplicates log entries from the source log stream replica to the
+	// destination log stream replica.
+	//
+	// It returns the following gRPC errors:
+	// - Unavailable: The storage node is shutting down.
+	// - NotFound: The log stream replica does not exist.
+	// - Canceled: The client canceled the request.
+	// - DeadlineExceeded: The client's timeout has expired.
 	Sync(ctx context.Context, in *SyncRequest, opts ...grpc.CallOption) (*SyncResponse, error)
+	// Trim removes prefix log entries from each log stream replica in the topic.
 	Trim(ctx context.Context, in *TrimRequest, opts ...grpc.CallOption) (*TrimResponse, error)
 }
 
@@ -968,19 +1010,61 @@ func (c *managementClient) Trim(ctx context.Context, in *TrimRequest, opts ...gr
 
 // ManagementServer is the server API for Management service.
 type ManagementServer interface {
-	// GetMetadata returns metadata of StorageNode.
+	// GetMetadata returns the metadata of the storage node. It produces a gRPC
+	// Unavailable error if the storage node is shutting down.
 	GetMetadata(context.Context, *GetMetadataRequest) (*GetMetadataResponse, error)
 	// AddLogStreamReplica adds a new log stream replica to a storage node.
+	//
+	// It returns the following gRPC errors:
+	// - Unavailable: The storage node is shutting down.
+	// - ResourceExhausted: The number of log stream replicas in the storage node
+	// reaches the upper limit.
+	// - Canceled: The client canceled the request.
+	// DeadlineExceeded: The client's timeout has expired.
 	AddLogStreamReplica(context.Context, *AddLogStreamReplicaRequest) (*AddLogStreamReplicaResponse, error)
-	// RemoveLogStream removes a LogStream from StorageNode.
+	// RemoveLogStream removes a log stream replica from the storage node.
+	//
+	// It returns the following gRPC errors:
+	// - Unavailable: The storage node is shutting down.
+	// - NotFound: The log stream replica does not exist.
+	// - Canceled: The client canceled the request.
+	// - DeadlineExceeded: The client's timeout has expired.
+	//
+	// TODO: It should be renamed to RemoveLogStreamReplica to represent its
+	// purpose precisely.
 	RemoveLogStream(context.Context, *RemoveLogStreamRequest) (*types.Empty, error)
-	// Seal changes the status of LogStreamExecutor to LogStreamStatusSealing or
-	// LogStreamStatusSealed.
+	// Seal changes the status of the log stream replica to LogStreamStatusSealing
+	// or LogStreamStatusSealed.
+	//
+	// It returns the following gRPC errors:
+	// - InvalidArgument: SealRequest has invalid fields; for instance, TopicID
+	// is invalid.
+	// - Unavailable: The storage node is shutting down.
+	// - NotFound: The log stream replica does not exist.
+	// - Canceled: The client canceled the request.
+	// - DeadlineExceeded: The client's timeout has expired.
 	Seal(context.Context, *SealRequest) (*SealResponse, error)
-	// Unseal changes the status of LogStreamExecutor to LogStreamStatusRunning.
+	// Unseal changes the status of the log stream replica to
+	// LogStreamStatusRunning.
+	//
+	// It returns the following gRPC errors:
+	// - InvalidArgument: UnsealRequest has invalid fields; for instance, TopicID
+	// is invalid.
+	// - Unavailable: The storage node is shutting down.
+	// - NotFound: The log stream replica does not exist.
+	// - Canceled: The client canceled the request.
+	// - DeadlineExceeded: The client's timeout has expired.
 	Unseal(context.Context, *UnsealRequest) (*types.Empty, error)
-	// Sync starts mirroring between two StorageNodes.
+	// Sync duplicates log entries from the source log stream replica to the
+	// destination log stream replica.
+	//
+	// It returns the following gRPC errors:
+	// - Unavailable: The storage node is shutting down.
+	// - NotFound: The log stream replica does not exist.
+	// - Canceled: The client canceled the request.
+	// - DeadlineExceeded: The client's timeout has expired.
 	Sync(context.Context, *SyncRequest) (*SyncResponse, error)
+	// Trim removes prefix log entries from each log stream replica in the topic.
 	Trim(context.Context, *TrimRequest) (*TrimResponse, error)
 }
 

--- a/proto/snpb/management.proto
+++ b/proto/snpb/management.proto
@@ -174,19 +174,61 @@ message TrimResponse {
 
 // Management defines the public APIs for managing StorageNode.
 service Management {
-  // GetMetadata returns metadata of StorageNode.
+  // GetMetadata returns the metadata of the storage node. It produces a gRPC
+  // Unavailable error if the storage node is shutting down.
   rpc GetMetadata(GetMetadataRequest) returns (GetMetadataResponse) {}
   // AddLogStreamReplica adds a new log stream replica to a storage node.
+  //
+  // It returns the following gRPC errors:
+  // - Unavailable: The storage node is shutting down.
+  // - ResourceExhausted: The number of log stream replicas in the storage node
+  // reaches the upper limit.
+  // - Canceled: The client canceled the request.
+  // DeadlineExceeded: The client's timeout has expired.
   rpc AddLogStreamReplica(AddLogStreamReplicaRequest)
     returns (AddLogStreamReplicaResponse) {}
-  // RemoveLogStream removes a LogStream from StorageNode.
+  // RemoveLogStream removes a log stream replica from the storage node.
+  //
+  // It returns the following gRPC errors:
+  // - Unavailable: The storage node is shutting down.
+  // - NotFound: The log stream replica does not exist.
+  // - Canceled: The client canceled the request.
+  // - DeadlineExceeded: The client's timeout has expired.
+  //
+  // TODO: It should be renamed to RemoveLogStreamReplica to represent its
+  // purpose precisely.
   rpc RemoveLogStream(RemoveLogStreamRequest) returns (google.protobuf.Empty) {}
-  // Seal changes the status of LogStreamExecutor to LogStreamStatusSealing or
-  // LogStreamStatusSealed.
+  // Seal changes the status of the log stream replica to LogStreamStatusSealing
+  // or LogStreamStatusSealed.
+  //
+  // It returns the following gRPC errors:
+  // - InvalidArgument: SealRequest has invalid fields; for instance, TopicID
+  // is invalid.
+  // - Unavailable: The storage node is shutting down.
+  // - NotFound: The log stream replica does not exist.
+  // - Canceled: The client canceled the request.
+  // - DeadlineExceeded: The client's timeout has expired.
   rpc Seal(SealRequest) returns (SealResponse) {}
-  // Unseal changes the status of LogStreamExecutor to LogStreamStatusRunning.
+  // Unseal changes the status of the log stream replica to
+  // LogStreamStatusRunning.
+  //
+  // It returns the following gRPC errors:
+  // - InvalidArgument: UnsealRequest has invalid fields; for instance, TopicID
+  // is invalid.
+  // - Unavailable: The storage node is shutting down.
+  // - NotFound: The log stream replica does not exist.
+  // - Canceled: The client canceled the request.
+  // - DeadlineExceeded: The client's timeout has expired.
   rpc Unseal(UnsealRequest) returns (google.protobuf.Empty) {}
-  // Sync starts mirroring between two StorageNodes.
+  // Sync duplicates log entries from the source log stream replica to the
+  // destination log stream replica.
+  //
+  // It returns the following gRPC errors:
+  // - Unavailable: The storage node is shutting down.
+  // - NotFound: The log stream replica does not exist.
+  // - Canceled: The client canceled the request.
+  // - DeadlineExceeded: The client's timeout has expired.
   rpc Sync(SyncRequest) returns (SyncResponse) {}
+  // Trim removes prefix log entries from each log stream replica in the topic.
   rpc Trim(TrimRequest) returns (TrimResponse) {}
 }


### PR DESCRIPTION
### What this PR does

This patch adds gRPC error codes to the RPCs of the admin service in the storage node.

### Which issue(s) this PR resolves

Updates #312
