### PR TITLE
refactor(storage): use ErrNoCommitContext instead of ErrNotFound

### DIFF
--- a/internal/storage/recovery_points.go
+++ b/internal/storage/recovery_points.go
@@ -39,7 +39,7 @@ func (s *Storage) ReadRecoveryPoints() (rp RecoveryPoints, err error) {
 func (s *Storage) readLastCommitContext() (*CommitContext, error) {
 	cc, err := s.ReadCommitContext()
 	if err != nil {
-		if errors.Is(err, pebble.ErrNotFound) {
+		if errors.Is(err, ErrNoCommitContext) {
 			return nil, nil
 		}
 		return nil, err

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -173,6 +173,9 @@ func (s *Storage) readLLSN(llsn types.LLSN) (le varlogpb.LogEntry, err error) {
 func (s *Storage) ReadCommitContext() (cc CommitContext, err error) {
 	buf, closer, err := s.db.Get(commitContextKey)
 	if err != nil {
+		if err == pebble.ErrNotFound {
+			err = ErrNoCommitContext
+		}
 		return
 	}
 	defer func() {


### PR DESCRIPTION
### What this PR does

This PR changes that the `internal/storage.(*Storage).ReadCommitContext` uses `ErrNoCommitContext` instead of `pebble.ErrNotFound`. It makes the error more illustrative.

