### PR TITLE
feat(storagenode): restore trimmed log stream replica

### DIFF
--- a/internal/storagenode/logstream/committer.go
+++ b/internal/storagenode/logstream/committer.go
@@ -305,7 +305,7 @@ func (cm *committer) commitInternal(cc storage.CommitContext, requireCommitWaitT
 		GLSN: cc.CommittedGLSNBegin + types.GLSN(numCommits),
 	}
 	cm.lse.decider.change(func() {
-		cm.lse.lsc.storeReportCommitBase(cc.Version, cc.HighWatermark, uncommittedBegin, false)
+		cm.lse.lsc.storeReportCommitBase(cc.Version, cc.HighWatermark, uncommittedBegin, false /*invalid*/)
 	})
 
 	for _, cwt := range committedTasks {

--- a/internal/storagenode/logstream/subscribe.go
+++ b/internal/storagenode/logstream/subscribe.go
@@ -99,7 +99,8 @@ func (lse *Executor) SubscribeWithLLSN(begin, end types.LLSN) (*SubscribeResult,
 		return nil, fmt.Errorf("log stream: invalid range: %w", verrors.ErrInvalid)
 	}
 
-	if begin < lse.lsc.localLowWatermark().LLSN {
+	localLowWatermark, _, _ := lse.lsc.localWatermarks()
+	if begin < localLowWatermark.LLSN {
 		return nil, fmt.Errorf("log stream: %w", verrors.ErrTrimmed)
 	}
 
@@ -168,7 +169,7 @@ func (lse *Executor) scanWithLLSN(ctx context.Context, begin, end types.LLSN, sr
 		}
 
 		_, globalHWM, _, _ := lse.lsc.reportCommitBase()
-		localHWM := lse.lsc.localHighWatermark()
+		_, localHWM, _ := lse.lsc.localWatermarks()
 		scanEnd := end
 		if localHWM.LLSN+1 < scanEnd {
 			scanEnd = localHWM.LLSN + 1

--- a/internal/storagenode/logstream/sync.go
+++ b/internal/storagenode/logstream/sync.go
@@ -98,7 +98,7 @@ func (lse *Executor) Sync(ctx context.Context, dstReplica varlogpb.LogStreamRepl
 		}
 	}()
 
-	localLWM, localHWM := lse.lsc.localLowWatermark(), lse.lsc.localHighWatermark()
+	localLWM, localHWM, _ := lse.lsc.localWatermarks()
 	syncRange, err := sc.syncInit(ctx, snpb.SyncRange{
 		FirstLLSN: localLWM.LLSN,
 		LastLLSN:  localHWM.LLSN,
@@ -289,7 +289,7 @@ func (lse *Executor) SyncInit(_ context.Context, srcReplica varlogpb.LogStreamRe
 	}
 
 	trimGLSN := types.InvalidGLSN
-	lwm := lse.lsc.localLowWatermark()
+	lwm, _, _ := lse.lsc.localWatermarks()
 
 	if lwm.LLSN < srcRange.FirstLLSN && srcRange.FirstLLSN <= lastCommittedLLSN {
 		// The source replica has already trimmed some prefix log
@@ -371,7 +371,7 @@ func (lse *Executor) SyncInit(_ context.Context, srcReplica varlogpb.LogStreamRe
 	lse.lsc.storeReportCommitBase(types.InvalidVersion, types.InvalidGLSN, varlogpb.LogSequenceNumber{
 		LLSN: lastCommittedLLSN + 1,
 		GLSN: uncommittedGLSNBegin,
-	}, true)
+	}, true /*invalid*/)
 
 	// learning
 	lse.resetInternalState(lastCommittedLLSN, !lse.isPrimary())


### PR DESCRIPTION
### What this PR does

This patch recovers an empty log stream replica which has been trimmed all log entries. Since the
empty log stream replica has no log entries, its local low and high watermarks are invalid. However,
its commit context has evidence to recover its state while restarting.

Soon, we will change the behavior of Trim to be able to remove all log entries from a log stream
replica. This PR prepares it.

### Which issue(s) this PR resolves

Updates #351

