### PR TITLE
test(metarepos): increase test timeout of flaky test TestMRScaleOutJoin

### DIFF
--- a/internal/metarepos/raft_metadata_repository_test.go
+++ b/internal/metarepos/raft_metadata_repository_test.go
@@ -2461,7 +2461,7 @@ func TestMRScaleOutJoin(t *testing.T) {
 			return clus.healthCheckAll()
 		}), ShouldBeTrue)
 
-		So(testutil.CompareWaitN(500, func() bool {
+		So(testutil.CompareWaitN(1000, func() bool {
 			peers := clus.getMembersFromSnapshot(0)
 			return len(peers) == nrNode
 		}), ShouldBeTrue)


### PR DESCRIPTION
### What this PR does

It increased the test timeout for TestMRScaleOutJoin to avoid intermittent failures.

