### PR TITLE
feat(storagenode): trim API with no safety gap

### DIFF
--- a/internal/reportcommitter/testing.go
+++ b/internal/reportcommitter/testing.go
@@ -24,6 +24,12 @@ func TestCommit(t *testing.T, addr string, cr snpb.CommitRequest) {
 	assert.NoError(t, client.Commit(cr))
 }
 
+func TestCommitBatch(t *testing.T, addr string, cb snpb.CommitBatchRequest) {
+	client, closer := TestNewClient(t, addr)
+	defer closer()
+	assert.NoError(t, client.CommitBatch(cb))
+}
+
 func TestGetReport(t *testing.T, addr string) []snpb.LogStreamUncommitReport {
 	client, closer := TestNewClient(t, addr)
 	defer closer()

--- a/vendor/golang.org/x/exp/maps/maps.go
+++ b/vendor/golang.org/x/exp/maps/maps.go
@@ -1,0 +1,94 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package maps defines various functions useful with maps of any type.
+package maps
+
+// Keys returns the keys of the map m.
+// The keys will be in an indeterminate order.
+func Keys[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}
+
+// Values returns the values of the map m.
+// The values will be in an indeterminate order.
+func Values[M ~map[K]V, K comparable, V any](m M) []V {
+	r := make([]V, 0, len(m))
+	for _, v := range m {
+		r = append(r, v)
+	}
+	return r
+}
+
+// Equal reports whether two maps contain the same key/value pairs.
+// Values are compared using ==.
+func Equal[M1, M2 ~map[K]V, K, V comparable](m1 M1, m2 M2) bool {
+	if len(m1) != len(m2) {
+		return false
+	}
+	for k, v1 := range m1 {
+		if v2, ok := m2[k]; !ok || v1 != v2 {
+			return false
+		}
+	}
+	return true
+}
+
+// EqualFunc is like Equal, but compares values using eq.
+// Keys are still compared with ==.
+func EqualFunc[M1 ~map[K]V1, M2 ~map[K]V2, K comparable, V1, V2 any](m1 M1, m2 M2, eq func(V1, V2) bool) bool {
+	if len(m1) != len(m2) {
+		return false
+	}
+	for k, v1 := range m1 {
+		if v2, ok := m2[k]; !ok || !eq(v1, v2) {
+			return false
+		}
+	}
+	return true
+}
+
+// Clear removes all entries from m, leaving it empty.
+func Clear[M ~map[K]V, K comparable, V any](m M) {
+	for k := range m {
+		delete(m, k)
+	}
+}
+
+// Clone returns a copy of m.  This is a shallow clone:
+// the new keys and values are set using ordinary assignment.
+func Clone[M ~map[K]V, K comparable, V any](m M) M {
+	// Preserve nil in case it matters.
+	if m == nil {
+		return nil
+	}
+	r := make(M, len(m))
+	for k, v := range m {
+		r[k] = v
+	}
+	return r
+}
+
+// Copy copies all key/value pairs in src adding them to dst.
+// When a key in src is already present in dst,
+// the value in dst will be overwritten by the value associated
+// with the key in src.
+func Copy[M1 ~map[K]V, M2 ~map[K]V, K comparable, V any](dst M1, src M2) {
+	for k, v := range src {
+		dst[k] = v
+	}
+}
+
+// DeleteFunc deletes any key/value pairs from m for which del returns true.
+func DeleteFunc[M ~map[K]V, K comparable, V any](m M, del func(K, V) bool) {
+	for k, v := range m {
+		if del(k, v) {
+			delete(m, k)
+		}
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -435,6 +435,7 @@ go.uber.org/zap/zaptest
 # golang.org/x/exp v0.0.0-20221114191408-850992195362
 ## explicit; go 1.18
 golang.org/x/exp/constraints
+golang.org/x/exp/maps
 golang.org/x/exp/rand
 golang.org/x/exp/slices
 golang.org/x/exp/slog


### PR DESCRIPTION
### What this PR does

This patch changes the Trim API of the log stream. Previously, the Trim API does not remove all logs
because of some historical reason (#351). However, it has no reason to do that anymore.

This PR also contains some changes for Subscribe API to handle trimmed log streams.

### Which issue(s) this PR resolves

Resolves #351

### Anything else

Varlog's Trim API has some limitations.
Trim API removes prefix log entries of only log stream replica in the APPENDABLE status, and I will
fix it soon.
In addition, the log stream can't know the global low watermark after a restart because it keeps it
in memory. Therefore, Subscribe API can't decide whether it returns an empty result or error
indicating that the log entries are already trimmed, and it needs some discussion for a design
decision.
