### PR TITLE
test(metarepos): fix flaky test TestReportCommit

### DIFF
--- a/internal/metarepos/reportcommit_test.go
+++ b/internal/metarepos/reportcommit_test.go
@@ -329,6 +329,9 @@ func TestReportCommit(t *testing.T) {
 					knownVersions.Lock()
 					assert.Contains(t, knownVersions.vers, lsid)
 					ver := knownVersions.vers[lsid]
+					if ver >= cr.Version {
+						continue
+					}
 					assert.Equal(t, reportsCommits[lsid][ver].expectedCommit, cr)
 					knownVersions.vers[lsid] = cr.Version
 					knownVersions.Unlock()


### PR DESCRIPTION
### What this PR does

This patch fixed the flaky test TestReportCommit.
Intermittent failure of this test resulted from a lack of stale version check in the CommitBatch handler of the LogStreamReporterServer mock. This PR added the examination of the old version.

