### PR TITLE
fix(storagenode): configure ballast by using flags

### DIFF
--- a/bin/start_varlogsn.py
+++ b/bin/start_varlogsn.py
@@ -169,6 +169,9 @@ def start(args: argparse.Namespace) -> None:
             for volume in volumes:
                 cmd.append(f"--volumes={volume}")
 
+            if args.ballast_size:
+                cmd.append(f"--ballast-size={args.ballast_size}")
+
             # grpc options
             if args.server_read_buffer_size:
                 cmd.append(

--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -38,7 +38,7 @@ func newStartCommand() *cli.Command {
 			flagStorageNodeID.StringFlag(false, types.StorageNodeID(1).String()),
 			flagListen.StringFlag(false, "127.0.0.1:9091"),
 			flagAdvertise.StringFlag(false, ""),
-			flagBallastSize.StringFlag(false, "1G"),
+			flagBallastSize.StringFlag(false, storagenode.DefaultBallastSize),
 
 			// volumes
 			flagVolumes.StringSliceFlag(true, nil),

--- a/internal/storagenode/config.go
+++ b/internal/storagenode/config.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	DefaultBallastSize                    = "0B"
 	DefaultServerReadBufferSize           = 32 << 10
 	DefaultServerWriteBufferSize          = 32 << 10
 	DefaultServerMaxRecvSize              = 4 << 20


### PR DESCRIPTION
### What this PR does

This patch fixed operation scripts `start_varlogsn.py` to configure ballast size.

