### PR TITLE
feat(storagenode): add automaxprocs to storagenode

### DIFF
--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/selector/simple"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.7.0"
+	_ "go.uber.org/automaxprocs"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"


### PR DESCRIPTION
### What this PR does

This PR adds [automaxprocs](go.uber.org/automaxprocs) to the storage node, which is already used by
admin or metadata repository. It configures GOMAXPROCS automatically.
