### PR TITLE
feat(storage): metrics logging and less verbose event logging

### DIFF
--- a/bin/start_varlogsn.py
+++ b/bin/start_varlogsn.py
@@ -212,6 +212,8 @@ def start(args: argparse.Namespace) -> None:
             if args.storage_max_concurrent_compaction:
                 cmd.append(
                     f"--storage-max-concurrent-compaction={args.storage_max_concurrent_compaction}")
+            if args.storage_metrics_log_interval:
+                cmd.append(f"--storage-metrics-log-interval={args.storage_metrics_log_interval}")
             if args.storage_verbose:
                 cmd.append("--storage-verbose")
 
@@ -266,6 +268,7 @@ def main() -> None:
     parser.add_argument("--storage-mem-table-size", type=str)
     parser.add_argument("--storage-mem-table-stop-writes-threshold", type=int)
     parser.add_argument("--storage-max-concurrent-compaction", type=int)
+    parser.add_argument("--storage-metrics-log-interval", type=str)
     parser.add_argument("--storage-verbose", action="store_true")
 
     # logging options

--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -66,6 +66,7 @@ func newStartCommand() *cli.Command {
 			flagStorageMemTableSize.StringFlag(false, units.ToByteSizeString(storage.DefaultMemTableSize)),
 			flagStorageMemTableStopWritesThreshold.IntFlag(false, storage.DefaultMemTableStopWritesThreshold),
 			flagStorageMaxConcurrentCompaction.IntFlag(false, storage.DefaultMaxConcurrentCompactions),
+			flagStorageMetricsLogInterval,
 			flagStorageVerbose.BoolFlag(),
 
 			flagLogDir.StringFlag(false, ""),

--- a/cmd/varlogsn/flags.go
+++ b/cmd/varlogsn/flags.go
@@ -4,6 +4,7 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/kakao/varlog/internal/flags"
+	"github.com/kakao/varlog/internal/storage"
 	"github.com/kakao/varlog/internal/storagenode"
 )
 
@@ -121,6 +122,11 @@ var (
 	flagStorageMaxConcurrentCompaction = flags.FlagDesc{
 		Name: "storage-max-concurrent-compaction",
 		Envs: []string{"STORAGE_MAX_CONCURRENT_COMPACTION"},
+	}
+	flagStorageMetricsLogInterval = &cli.DurationFlag{
+		Name:    "storage-metrics-log-interval",
+		EnvVars: []string{"STORAGE_METRICS_LOG_INTERVAL"},
+		Value:   storage.DefaultMetricsLogInterval,
 	}
 	flagStorageVerbose = flags.FlagDesc{
 		Name: "storage-verbose",

--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -143,6 +143,7 @@ func start(c *cli.Context) error {
 		storage.WithMemTableSize(c.Int(flagStorageMemTableSize.Name)),
 		storage.WithMemTableStopWritesThreshold(c.Int(flagStorageMemTableStopWritesThreshold.Name)),
 		storage.WithMaxConcurrentCompaction(c.Int(flagStorageMaxConcurrentCompaction.Name)),
+		storage.WithMetrisLogInterval(c.Duration(flagStorageMetricsLogInterval.Name)),
 	}
 	if c.Bool(flagStorageDisableWAL.Name) {
 		storageOpts = append(storageOpts, storage.WithoutWAL())

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -16,6 +17,7 @@ const (
 	DefaultMemTableSize                = 4 << 20
 	DefaultMemTableStopWritesThreshold = 2
 	DefaultMaxConcurrentCompactions    = 1
+	DefaultMetricsLogInterval          = time.Duration(0)
 )
 
 type config struct {
@@ -31,6 +33,7 @@ type config struct {
 	memTableStopWritesThreshold int
 	maxConcurrentCompaction     int
 	verbose                     bool
+	metricsLogInterval          time.Duration
 	logger                      *zap.Logger
 
 	readOnly bool
@@ -50,7 +53,8 @@ func newConfig(opts []Option) (config, error) {
 		memTableStopWritesThreshold: DefaultMemTableStopWritesThreshold,
 		maxConcurrentCompaction:     DefaultMaxConcurrentCompactions,
 
-		logger: zap.NewNop(),
+		metricsLogInterval: DefaultMetricsLogInterval,
+		logger:             zap.NewNop(),
 	}
 	for _, opt := range opts {
 		opt.apply(&cfg)
@@ -150,6 +154,12 @@ func WithMaxConcurrentCompaction(maxConcurrentCompaction int) Option {
 func WithVerboseLogging() Option {
 	return newFuncOption(func(cfg *config) {
 		cfg.verbose = true
+	})
+}
+
+func WithMetrisLogInterval(metricsLogInterval time.Duration) Option {
+	return newFuncOption(func(cfg *config) {
+		cfg.metricsLogInterval = metricsLogInterval
 	})
 }
 


### PR DESCRIPTION
### What this PR does

This patch changes logging for storage:

- Make event logging less verbose, which enables only logs for errors and slow I/O.
- Add metrics logging to the storage for investigating details.
