### PR TITLE
fix(storagenode): set the flag --storage-mem-table-size correctly

### DIFF
--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -63,7 +63,7 @@ func newStartCommand() *cli.Command {
 			flagStorageL0StopWritesThreshold.IntFlag(false, storage.DefaultL0StopWritesThreshold),
 			flagStorageLBaseMaxBytes.StringFlag(false, units.ToByteSizeString(storage.DefaultLBaseMaxBytes)),
 			flagStorageMaxOpenFiles.IntFlag(false, storage.DefaultMaxOpenFiles),
-			flagStorageMemTableSize.StringFlag(false, units.ToByteSizeString(storage.DefaultMemTableSize)),
+			flagStorageMemTableSize,
 			flagStorageMemTableStopWritesThreshold.IntFlag(false, storage.DefaultMemTableStopWritesThreshold),
 			flagStorageMaxConcurrentCompaction.IntFlag(false, storage.DefaultMaxConcurrentCompactions),
 			flagStorageMetricsLogInterval,

--- a/cmd/varlogsn/flags.go
+++ b/cmd/varlogsn/flags.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kakao/varlog/internal/flags"
 	"github.com/kakao/varlog/internal/storage"
 	"github.com/kakao/varlog/internal/storagenode"
+	"github.com/kakao/varlog/pkg/util/units"
 )
 
 var (
@@ -109,10 +110,11 @@ var (
 		Name: "storage-max-open-files",
 		Envs: []string{"STORAGE_MAX_OPEN_FILES"},
 	}
-	flagStorageMemTableSize = flags.FlagDesc{
+	flagStorageMemTableSize = &cli.StringFlag{
 		Name:    "storage-mem-table-size",
 		Aliases: []string{"storage-memtable-size"},
-		Envs:    []string{"STORAGE_MEM_TABLE_SIZE", "STORAGE_MEMTABLE_SIZE"},
+		EnvVars: []string{"STORAGE_MEM_TABLE_SIZE", "STORAGE_MEMTABLE_SIZE"},
+		Value:   units.ToByteSizeString(storage.DefaultMemTableSize),
 	}
 	flagStorageMemTableStopWritesThreshold = flags.FlagDesc{
 		Name:    "storage-mem-table-stop-writes-threshold",

--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -135,12 +135,17 @@ func start(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	memTableSize, err := units.FromByteSizeString(c.String(flagStorageMemTableSize.Name))
+	if err != nil {
+		return err
+	}
+
 	storageOpts := []storage.Option{
 		storage.WithL0CompactionThreshold(c.Int(flagStorageL0CompactionThreshold.Name)),
 		storage.WithL0StopWritesThreshold(c.Int(flagStorageL0StopWritesThreshold.Name)),
 		storage.WithLBaseMaxBytes(lbaseMaxBytes),
 		storage.WithMaxOpenFiles(c.Int(flagStorageMaxOpenFiles.Name)),
-		storage.WithMemTableSize(c.Int(flagStorageMemTableSize.Name)),
+		storage.WithMemTableSize(int(memTableSize)),
 		storage.WithMemTableStopWritesThreshold(c.Int(flagStorageMemTableStopWritesThreshold.Name)),
 		storage.WithMaxConcurrentCompaction(c.Int(flagStorageMaxConcurrentCompaction.Name)),
 		storage.WithMetrisLogInterval(c.Duration(flagStorageMetricsLogInterval.Name)),


### PR DESCRIPTION
### What this PR does

This PR fixed setting the flag `--storage-mem-table-size` correctly in the storage node.

