### PR TITLE
feat(admin): add a name to the replica selector

### DIFF
--- a/internal/admin/replica_selector.go
+++ b/internal/admin/replica_selector.go
@@ -17,9 +17,12 @@ import (
 )
 
 // ReplicaSelector selects storage nodes and volumes to store data for replicas of a new log stream.
-// This method returns a slice of `varlogpb.ReplicaDescriptor` and its length should be equal to the
-// replication factor.
 type ReplicaSelector interface {
+	// Name returns the name of the replica selector, and it should be unique
+	// among all replica selectors.
+	Name() string
+	// Select returns a slice of `varlogpb.ReplicaDescriptor`; its length
+	// should equal the replication factor.
 	Select(ctx context.Context) ([]*varlogpb.ReplicaDescriptor, error)
 }
 
@@ -47,6 +50,10 @@ func newBalancedReplicaSelector(cmView mrmanager.ClusterMetadataView, replicatio
 		replicationFactor: replicationFactor,
 	}
 	return sel, nil
+}
+
+func (sel *balancedReplicaSelector) Name() string {
+	return "balanced"
 }
 
 func (sel *balancedReplicaSelector) Select(ctx context.Context) ([]*varlogpb.ReplicaDescriptor, error) {

--- a/internal/admin/replica_selector_mock.go
+++ b/internal/admin/replica_selector_mock.go
@@ -36,6 +36,20 @@ func (m *MockReplicaSelector) EXPECT() *MockReplicaSelectorMockRecorder {
 	return m.recorder
 }
 
+// Name mocks base method.
+func (m *MockReplicaSelector) Name() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Name")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Name indicates an expected call of Name.
+func (mr *MockReplicaSelectorMockRecorder) Name() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockReplicaSelector)(nil).Name))
+}
+
 // Select mocks base method.
 func (m *MockReplicaSelector) Select(arg0 context.Context) ([]*varlogpb.ReplicaDescriptor, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
### What this PR does

It adds a new method `Name() string` to the replica selector interface
`internal/admin.(ReplicaSelector)`. We can set a unique name for each replica selector, and
therefore, we can use a necessary replica selection algorithm by specifying the name.

### Which issue(s) this PR resolves

Updates #393
