### PR TITLE
fix(metarepos): fix race in TestReportCommit

### DIFF
--- a/internal/metarepos/reportcommit_test.go
+++ b/internal/metarepos/reportcommit_test.go
@@ -330,6 +330,7 @@ func TestReportCommit(t *testing.T) {
 					assert.Contains(t, knownVersions.vers, lsid)
 					ver := knownVersions.vers[lsid]
 					if ver >= cr.Version {
+						knownVersions.Unlock()
 						continue
 					}
 					assert.Equal(t, reportsCommits[lsid][ver].expectedCommit, cr)


### PR DESCRIPTION
### What this PR does

It fixes a race problem in `TestReportCommit` caused by #379.

### Which issue(s) this PR resolves

Updates #379
