### PR TITLE
ci(make): increase test timeout and reduce parallelism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ benchmark:
 
 
 # testing
-TEST_FLAGS := -race -failfast -count=1
+TEST_FLAGS := -race -failfast -count=1 -timeout=20m -p=1
 GO_COVERAGE_OUTPUT := coverage.out
 GO_COVERAGE_OUTPUT_TMP := $(GO_COVERAGE_OUTPUT).tmp
 PYTEST := pytest


### PR DESCRIPTION
### What this PR does

Recently time taking running unit tests has become longer. In addition, some flaky tests are failed
on low-performance systems. This PR increases test timeout from 10m to 20m and reduces parallelism
by specifying "-p 1".
