### PR TITLE
perf(storagenode): wrap replicateTask slice with struct

### DIFF
--- a/internal/storagenode/logstream/append.go
+++ b/internal/storagenode/logstream/append.go
@@ -102,7 +102,7 @@ func (lse *Executor) prepareAppendContextInternal(dataBatch [][]byte, begin, end
 		rt.tpid = lse.tpid
 		rt.lsid = lse.lsid
 		rt.dataList = batchletData
-		st.rts = append(st.rts, rt)
+		st.rts.tasks = append(st.rts.tasks, rt)
 	}
 
 	// write wait group
@@ -138,7 +138,7 @@ func (lse *Executor) sendSequenceTasks(ctx context.Context, sts []*sequenceTask)
 		// _ = st.dwb.Close()
 		_ = st.wb.Close()
 		releaseCommitWaitTaskList(st.cwts)
-		releaseReplicateTasks(st.rts)
+		releaseReplicateTasks(st.rts.tasks)
 		releaseReplicateTaskSlice(st.rts)
 		st.release()
 	}

--- a/internal/storagenode/logstream/replicate_task.go
+++ b/internal/storagenode/logstream/replicate_task.go
@@ -79,17 +79,23 @@ var (
 
 const defaultLengthOfReplicationTaskSlice = 3
 
+type replicateTaskSlice struct {
+	tasks []*replicateTask
+}
+
 var replicateTaskSlicePool = sync.Pool{
 	New: func() interface{} {
-		return make([]*replicateTask, 0, defaultLengthOfReplicationTaskSlice)
+		return &replicateTaskSlice{
+			tasks: make([]*replicateTask, 0, defaultLengthOfReplicationTaskSlice),
+		}
 	},
 }
 
-func newReplicateTaskSlice() []*replicateTask {
-	return replicateTaskSlicePool.Get().([]*replicateTask)
+func newReplicateTaskSlice() *replicateTaskSlice {
+	return replicateTaskSlicePool.Get().(*replicateTaskSlice)
 }
 
-func releaseReplicateTaskSlice(rts []*replicateTask) {
-	rts = rts[0:0]
-	replicateTaskSlicePool.Put(rts) //nolint:staticcheck
+func releaseReplicateTaskSlice(rts *replicateTaskSlice) {
+	rts.tasks = rts.tasks[0:0]
+	replicateTaskSlicePool.Put(rts)
 }

--- a/internal/storagenode/logstream/sequencer_test.go
+++ b/internal/storagenode/logstream/sequencer_test.go
@@ -81,6 +81,8 @@ func testSequenceTask(stg *storage.Storage) *sequenceTask {
 	st.cwts = newListQueue()
 	st.cwts.PushFront(newCommitWaitTask(awg))
 
+	st.rts = &replicateTaskSlice{}
+
 	return st
 }
 
@@ -192,8 +194,10 @@ func TestSequencer_FailToSendToReplicateClient(t *testing.T) {
 	}
 
 	st := testSequenceTask(stg)
-	st.rts = []*replicateTask{
-		{},
+	st.rts = &replicateTaskSlice{
+		tasks: []*replicateTask{
+			{},
+		},
 	}
 	sq.sequenceLoopInternal(context.Background(), st)
 	assert.Len(t, wr.queue, 1)


### PR DESCRIPTION
### What this PR does

The `replicateTaskSlicePool` pooled slices of `replicateTask`. The function
`releaseReplicateTaskSlice` received borrowed slice and then put it into `replicateTaskSlicePool`.
However, the `sync.(Pool).Put` parameter is an interface, so the slice escaped to the heap
unnecessarily.

Not to use unnecessary heap objects, this PR wraps the `replicateTask` slice with the struct
replicateTaskSlice. 

### Which issue(s) this PR resolves

Resolves #75
