### PR TITLE
chore(metarepos): do not use unnecessary labels

### DIFF
--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -194,7 +194,7 @@ func initTelemetry(ctx context.Context, c *cli.Context, snid types.StorageNodeID
 		resource.WithAttributes(
 			semconv.ServiceNameKey.String("sn"),
 			semconv.ServiceNamespaceKey.String("varlog"),
-			semconv.ServiceInstanceIDKey.String(snid.String()),
+			semconv.ServiceInstanceIDKey.Int64(int64(snid)),
 		))
 	if err != nil {
 		return nil, nil, err

--- a/internal/metarepos/raft.go
+++ b/internal/metarepos/raft.go
@@ -21,7 +21,6 @@ import (
 	"go.etcd.io/etcd/raft/raftpb"
 	"go.etcd.io/etcd/wal"
 	"go.etcd.io/etcd/wal/walpb"
-	"go.opentelemetry.io/otel/attribute"
 	"go.uber.org/zap"
 
 	vtypes "github.com/kakao/varlog/pkg/types"
@@ -1008,11 +1007,6 @@ func (rc *raftNode) withTelemetry(ctx context.Context, name string, h handler) (
 	st := time.Now()
 	rsp, err := h(ctx)
 
-	rc.tmStub.mb.Records(name).Record(ctx,
-		float64(time.Since(st).Nanoseconds())/float64(time.Millisecond),
-		attribute.KeyValue{
-			Key:   "nodeid",
-			Value: attribute.StringValue(rc.nodeID.String()),
-		})
+	rc.tmStub.mb.Records(name).Record(ctx, float64(time.Since(st).Nanoseconds())/float64(time.Millisecond))
 	return rsp, err
 }

--- a/internal/metarepos/report_collector.go
+++ b/internal/metarepos/report_collector.go
@@ -870,11 +870,8 @@ CatchupLoop:
 
 		min, max, recordable := lc.sampleTracer.commit(lc.lsID, cr.CommittedLLSNOffset, cr.CommittedLLSNOffset+types.LLSN(cr.CommittedGLSNLength))
 		if recordable {
-			lc.tmStub.mb.Records("mr.report_commit.delay").Record(ctx,
-				float64(time.Since(min).Nanoseconds())/float64(time.Millisecond))
-
-			lc.tmStub.mb.Records("mr.replicate.delay").Record(ctx,
-				float64(max.Sub(min).Nanoseconds())/float64(time.Millisecond))
+			lc.tmStub.mb.Records("mr.report_commit.delay").Record(ctx, float64(time.Since(min).Nanoseconds())/float64(time.Millisecond))
+			lc.tmStub.mb.Records("mr.replicate.delay").Record(ctx, float64(max.Sub(min).Nanoseconds())/float64(time.Millisecond))
 		}
 
 		lc.setSentVersion(crs.Version)


### PR DESCRIPTION
### What this PR does

Because the metadata repository sets node id as resource `service.instance.id`, it does not need to
use a redundant label - `nodeid`.

### Which issue(s) this PR resolves

Resolve #423
