### PR TITLE
perf(metarepos): add mrpb.StorageNodeUncommitReport pool

### DIFF
--- a/proto/mrpb/raft_metadata_repository.go
+++ b/proto/mrpb/raft_metadata_repository.go
@@ -2,6 +2,7 @@ package mrpb
 
 import (
 	"sort"
+	"sync"
 
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/proto/snpb"
@@ -73,6 +74,24 @@ func (crs *LogStreamCommitResults) getCommitResultByIdx(idx int) (snpb.LogStream
 
 func (l *LogStreamUncommitReports) Deleted() bool {
 	return l.Status == varlogpb.LogStreamStatusDeleted
+}
+
+var storageNodeUncommitReportPool = sync.Pool{
+	New: func() any {
+		return new(StorageNodeUncommitReport)
+	},
+}
+
+func NewStoragenodeUncommitReport(snid types.StorageNodeID) *StorageNodeUncommitReport {
+	r := storageNodeUncommitReportPool.Get().(*StorageNodeUncommitReport)
+	r.StorageNodeID = snid
+	return r
+}
+
+func (l *StorageNodeUncommitReport) Release() {
+	l.StorageNodeID = types.StorageNodeID(0)
+	l.UncommitReports = nil
+	storageNodeUncommitReportPool.Put(l)
 }
 
 func (l *StorageNodeUncommitReport) Len() int {


### PR DESCRIPTION
### What this PR does

This patch adds an `mrpb.StorageNodeUncommitReport` pool, which is
`proto/mrpb.storageNodeUncommitReportPool`. It reduces heap objects allocated repeatedly whenever
processing reports received from storage nodes.

Below heap profiling is the previous result.

```
      flat  flat%   sum%        cum   cum%
  70865580  8.38% 44.73%   71293773  8.43%  github.com/kakao/varlog/internal/metarepos.(*reportCollectExecutor).processReport
```

Now here it is after applying this patch.

```
      flat  flat%   sum%        cum   cum%
  20734504  2.10% 75.92%   42122814  4.26%  github.com/kakao/varlog/internal/metarepos.(*reportCollectExecutor).processReport
```

