### PR TITLE
refactor(all): use atomic types

### DIFF
--- a/internal/metarepos/raft_metadata_repository_test.go
+++ b/internal/metarepos/raft_metadata_repository_test.go
@@ -6,7 +6,6 @@ import (
 	"net"
 	"os"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -878,7 +877,7 @@ func TestMRRequestMap(t *testing.T) {
 			},
 		}
 
-		requestNum := atomic.LoadUint64(&mr.requestNum)
+		requestNum := mr.requestNum.Load()
 
 		var wg sync.WaitGroup
 		var st sync.WaitGroup
@@ -962,7 +961,7 @@ func TestMRRequestMap(t *testing.T) {
 		rctx, cancel := context.WithTimeout(context.Background(), vtesting.TimeoutUnitTimesFactor(1))
 		defer cancel()
 
-		requestNum := atomic.LoadUint64(&mr.requestNum)
+		requestNum := mr.requestNum.Load()
 		err := mr.RegisterStorageNode(rctx, sn)
 		So(err, ShouldNotBeNil)
 
@@ -992,7 +991,7 @@ func TestMRRequestMap(t *testing.T) {
 			},
 		}
 
-		requestNum := atomic.LoadUint64(&mr.requestNum)
+		requestNum := mr.requestNum.Load()
 		err := mr.RegisterStorageNode(context.TODO(), sn)
 		So(err, ShouldBeNil)
 

--- a/internal/storagenode/logstream/backup_writer_test.go
+++ b/internal/storagenode/logstream/backup_writer_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,7 +90,7 @@ func TestBackupWriter_Drain(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.EqualValues(t, numTasks, atomic.LoadInt64(&bw.inflight))
+	assert.EqualValues(t, numTasks, bw.inflight.Load())
 	assert.Len(t, bw.queue, numTasks)
 
 	var wg sync.WaitGroup
@@ -104,7 +103,7 @@ func TestBackupWriter_Drain(t *testing.T) {
 	bw.waitForDrainage(true)
 	wg.Wait()
 
-	assert.Zero(t, atomic.LoadInt64(&bw.inflight))
+	assert.Zero(t, bw.inflight.Load())
 	assert.Empty(t, bw.queue)
 }
 

--- a/internal/storagenode/logstream/committer.go
+++ b/internal/storagenode/logstream/committer.go
@@ -21,10 +21,10 @@ type committer struct {
 	committerConfig
 
 	commitWaitQ        *commitWaitQueue
-	inflightCommitWait int64
+	inflightCommitWait atomic.Int64
 
 	commitQueue    chan *commitTask
-	inflightCommit int64
+	inflightCommit atomic.Int64
 
 	runner *runner.Runner
 }
@@ -59,10 +59,10 @@ func (cm *committer) sendCommitWaitTask(_ context.Context, cwts *listQueue) (err
 		panic("log stream: committer: commit wait task list is empty")
 	}
 
-	inflight := atomic.AddInt64(&cm.inflightCommitWait, int64(cnt))
+	inflight := cm.inflightCommitWait.Add(int64(cnt))
 	defer func() {
 		if err != nil {
-			inflight = atomic.AddInt64(&cm.inflightCommitWait, -int64(cnt))
+			inflight = cm.inflightCommitWait.Add(-int64(cnt))
 		}
 		if ce := cm.logger.Check(zap.DebugLevel, "send committer commit wait tasks"); ce != nil {
 			ce.Write(
@@ -90,10 +90,10 @@ func (cm *committer) sendCommitWaitTask(_ context.Context, cwts *listQueue) (err
 // The commit task is pushed into commitQueue in the committer.
 // The Commit RPC handler calls this method to push commit request to the committer.
 func (cm *committer) sendCommitTask(ctx context.Context, ct *commitTask) (err error) {
-	atomic.AddInt64(&cm.inflightCommit, 1)
+	cm.inflightCommit.Add(1)
 	defer func() {
 		if err != nil {
-			atomic.AddInt64(&cm.inflightCommit, -1)
+			cm.inflightCommit.Add(-1)
 		}
 	}()
 
@@ -139,7 +139,7 @@ func (cm *committer) commitLoop(ctx context.Context) {
 func (cm *committer) commitLoopInternal(ctx context.Context, ct *commitTask) {
 	defer func() {
 		ct.release()
-		atomic.AddInt64(&cm.inflightCommit, -1)
+		cm.inflightCommit.Add(-1)
 	}()
 
 	// TODO: Move these condition expressions to `internal/storagenode/logstream.(*committer).commit` method.
@@ -250,9 +250,9 @@ func (cm *committer) commitInternal(cc storage.CommitContext, requireCommitWaitT
 		if cm.lse.lsm == nil {
 			return
 		}
-		atomic.AddInt64(&cm.lse.lsm.CommitterOperationDuration, time.Since(startTime).Microseconds())
-		atomic.AddInt64(&cm.lse.lsm.CommitterOperations, 1)
-		atomic.AddInt64(&cm.lse.lsm.CommitterLogs, int64(numCommits))
+		cm.lse.lsm.CommitterOperationDuration.Add(int64(time.Since(startTime).Microseconds()))
+		cm.lse.lsm.CommitterOperations.Add(1)
+		cm.lse.lsm.CommitterLogs.Add(int64(numCommits))
 	}()
 
 	iter := cm.commitWaitQ.peekIterator()
@@ -321,7 +321,7 @@ func (cm *committer) commitInternal(cc storage.CommitContext, requireCommitWaitT
 
 	// NOTE: When sync replication is occurred, it can be zero.
 	if len(committedTasks) > 0 {
-		atomic.AddInt64(&cm.inflightCommitWait, int64(-numCommits))
+		cm.inflightCommitWait.Add(int64(-numCommits))
 	}
 
 	return nil
@@ -331,19 +331,19 @@ func (cm *committer) commitInternal(cc storage.CommitContext, requireCommitWaitT
 func (cm *committer) drainCommitWaitQ(cause error) {
 	if ce := cm.logger.Check(zap.DebugLevel, "draining commit wait tasks"); ce != nil {
 		ce.Write(
-			zap.Int64("inflight", atomic.LoadInt64(&cm.inflightCommitWait)),
+			zap.Int64("inflight", cm.inflightCommitWait.Load()),
 			zap.Error(cause),
 		)
 	}
 
-	for atomic.LoadInt64(&cm.inflightCommitWait) > 0 {
+	for cm.inflightCommitWait.Load() > 0 {
 		cwt := cm.commitWaitQ.pop()
 		if cwt == nil {
 			continue
 		}
 		cwt.awg.commitDone(cause)
 		cwt.release()
-		inflight := atomic.AddInt64(&cm.inflightCommitWait, -1)
+		inflight := cm.inflightCommitWait.Add(-1)
 		if ce := cm.logger.Check(zap.DebugLevel, "discard a commit wait task"); ce != nil {
 			ce.Write(zap.Int64("inflight", inflight))
 		}
@@ -357,7 +357,7 @@ func (cm *committer) waitForDrainageOfCommitQueue(forceDrain bool) {
 	timer := time.NewTimer(tick)
 	defer timer.Stop()
 
-	for atomic.LoadInt64(&cm.inflightCommit) > 0 {
+	for cm.inflightCommit.Load() > 0 {
 		if !forceDrain {
 			<-timer.C
 			timer.Reset(tick)
@@ -369,7 +369,7 @@ func (cm *committer) waitForDrainageOfCommitQueue(forceDrain bool) {
 			timer.Reset(tick)
 		case ct := <-cm.commitQueue:
 			ct.release()
-			atomic.AddInt64(&cm.inflightCommit, -1)
+			cm.inflightCommit.Add(-1)
 		}
 	}
 }

--- a/internal/storagenode/logstream/committer_test.go
+++ b/internal/storagenode/logstream/committer_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -147,10 +146,10 @@ func TestCommitter_DrainCommitWaitQ(t *testing.T) {
 	err := cm.sendCommitWaitTask(context.Background(), cwts)
 	assert.NoError(t, err)
 
-	assert.EqualValues(t, 1, atomic.LoadInt64(&cm.inflightCommitWait))
+	assert.EqualValues(t, 1, cm.inflightCommitWait.Load())
 	assert.EqualValues(t, 1, cm.commitWaitQ.size())
 
 	cm.drainCommitWaitQ(errors.New("drain"))
-	assert.Zero(t, atomic.LoadInt64(&cm.inflightCommitWait))
+	assert.Zero(t, cm.inflightCommitWait.Load())
 	assert.Zero(t, cm.commitWaitQ.size())
 }

--- a/internal/storagenode/logstream/replicate_client_test.go
+++ b/internal/storagenode/logstream/replicate_client_test.go
@@ -3,7 +3,6 @@ package logstream
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -162,12 +161,12 @@ func TestReplicateClientDrain(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.EqualValues(t, numTasks, atomic.LoadInt64(&rc.inflight))
+	assert.EqualValues(t, numTasks, rc.inflight.Load())
 	assert.Len(t, rc.queue, numTasks)
 
 	rc.waitForDrainage()
 
-	assert.Zero(t, atomic.LoadInt64(&rc.inflight))
+	assert.Zero(t, rc.inflight.Load())
 	assert.Empty(t, rc.queue)
 }
 

--- a/internal/storagenode/logstream/sequencer.go
+++ b/internal/storagenode/logstream/sequencer.go
@@ -19,7 +19,7 @@ type sequencer struct {
 	sequencerConfig
 	llsn     types.LLSN
 	queue    chan *sequenceTask
-	inflight int64
+	inflight atomic.Int64
 	runner   *runner.Runner
 }
 
@@ -42,10 +42,10 @@ func newSequencer(cfg sequencerConfig) (*sequencer, error) {
 // send sends a sequence task to the sequencer.
 // If state of the log stream executor is not appendable, it returns an error.
 func (sq *sequencer) send(ctx context.Context, st *sequenceTask) (err error) {
-	inflight := atomic.AddInt64(&sq.inflight, 1)
+	inflight := sq.inflight.Add(1)
 	defer func() {
 		if err != nil {
-			inflight = atomic.AddInt64(&sq.inflight, -1)
+			inflight = sq.inflight.Add(-1)
 		}
 		if ce := sq.logger.Check(zap.DebugLevel, "sent seqeuencer a task"); ce != nil {
 			ce.Write(
@@ -90,14 +90,14 @@ func (sq *sequencer) sequenceLoop(ctx context.Context) {
 func (sq *sequencer) sequenceLoopInternal(ctx context.Context, st *sequenceTask) {
 	var startTime, operationEndTime time.Time
 	defer func() {
-		inflight := atomic.AddInt64(&sq.inflight, -1)
+		inflight := sq.inflight.Add(-1)
 		if sq.lse.lsm == nil {
 			return
 		}
-		atomic.AddInt64(&sq.lse.lsm.SequencerFanoutDuration, time.Since(operationEndTime).Microseconds())
-		atomic.AddInt64(&sq.lse.lsm.SequencerOperationDuration, operationEndTime.Sub(startTime).Microseconds())
-		atomic.AddInt64(&sq.lse.lsm.SequencerOperations, 1)
-		atomic.StoreInt64(&sq.lse.lsm.ReplicateClientInflightOperations, inflight)
+		sq.lse.lsm.SequencerFanoutDuration.Add(time.Since(operationEndTime).Microseconds())
+		sq.lse.lsm.SequencerOperationDuration.Add(int64(operationEndTime.Sub(startTime).Microseconds()))
+		sq.lse.lsm.SequencerOperations.Add(1)
+		sq.lse.lsm.ReplicateClientInflightOperations.Store(inflight)
 	}()
 
 	startTime = time.Now()
@@ -189,12 +189,12 @@ func (sq *sequencer) waitForDrainage(cause error, forceDrain bool) {
 
 	if ce := sq.logger.Check(zap.DebugLevel, "draining sequencer tasks"); ce != nil {
 		ce.Write(
-			zap.Int64("inflight", atomic.LoadInt64(&sq.inflight)),
+			zap.Int64("inflight", sq.inflight.Load()),
 			zap.Error(cause),
 		)
 	}
 
-	for atomic.LoadInt64(&sq.inflight) > 0 {
+	for sq.inflight.Load() > 0 {
 		if !forceDrain {
 			<-timer.C
 			timer.Reset(tick)
@@ -209,7 +209,7 @@ func (sq *sequencer) waitForDrainage(cause error, forceDrain bool) {
 				st.awgs[i].writeDone(cause)
 				st.awgs[i].commitDone(nil)
 			}
-			atomic.AddInt64(&sq.inflight, -1)
+			sq.inflight.Add(-1)
 		}
 	}
 }

--- a/internal/storagenode/logstream/sequencer_test.go
+++ b/internal/storagenode/logstream/sequencer_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -241,7 +240,7 @@ func TestSequencer_Drain(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.EqualValues(t, numTasks, atomic.LoadInt64(&sq.inflight))
+	assert.EqualValues(t, numTasks, sq.inflight.Load())
 	assert.Len(t, sq.queue, numTasks)
 
 	lse.esm.store(executorStateSealing)
@@ -258,7 +257,7 @@ func TestSequencer_Drain(t *testing.T) {
 	}()
 
 	assert.Eventually(t, func() bool {
-		return atomic.LoadInt64(&sq.inflight) == 0 && len(sq.queue) == 0
+		return sq.inflight.Load() == 0 && len(sq.queue) == 0
 	}, time.Second, 10*time.Millisecond)
 
 	cancel()
@@ -289,11 +288,11 @@ func TestSequencer_ForceDrain(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.EqualValues(t, numTasks, atomic.LoadInt64(&sq.inflight))
+	assert.EqualValues(t, numTasks, sq.inflight.Load())
 	assert.Len(t, sq.queue, numTasks)
 
 	sq.waitForDrainage(errors.New("force drain"), true)
 
-	assert.Zero(t, atomic.LoadInt64(&sq.inflight))
+	assert.Zero(t, sq.inflight.Load())
 	assert.Empty(t, sq.queue)
 }

--- a/internal/storagenode/logstream/subscribe.go
+++ b/internal/storagenode/logstream/subscribe.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"sync/atomic"
 
 	"github.com/kakao/varlog/internal/storage"
 	"github.com/kakao/varlog/pkg/types"
@@ -65,8 +64,8 @@ func (lse *Executor) newEmptySubscribeResult() (*SubscribeResult, context.Contex
 // SubscribeWithGLSN subscribes to the log stream with the given range of GLSNs.
 // TODO: The first argument ctx may not be necessary, since the subscription can be stopped by the `internal/varlogsn/logstream.(*SubscribeResult).Stop()`.
 func (lse *Executor) SubscribeWithGLSN(begin, end types.GLSN) (*SubscribeResult, error) {
-	atomic.AddInt64(&lse.inflight, 1)
-	defer atomic.AddInt64(&lse.inflight, -1)
+	lse.inflight.Add(1)
+	defer lse.inflight.Add(-1)
 
 	if lse.esm.load() == executorStateClosed {
 		return nil, verrors.ErrClosed
@@ -113,8 +112,8 @@ func (lse *Executor) SubscribeWithGLSN(begin, end types.GLSN) (*SubscribeResult,
 // SubscribeWithLLSN subscribes to the log stream with the given range of LLSNs.
 // TODO: The first argument ctx may not be necessary, since the subscription can be stopped by the `internal/varlogsn/logstream.(*SubscribeResult).Stop()`.
 func (lse *Executor) SubscribeWithLLSN(begin, end types.LLSN) (*SubscribeResult, error) {
-	atomic.AddInt64(&lse.inflight, 1)
-	defer atomic.AddInt64(&lse.inflight, -1)
+	lse.inflight.Add(1)
+	defer lse.inflight.Add(-1)
 
 	if lse.esm.load() == executorStateClosed {
 		return nil, verrors.ErrClosed

--- a/internal/storagenode/logstream/sync.go
+++ b/internal/storagenode/logstream/sync.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"go.uber.org/multierr"
@@ -65,8 +64,8 @@ func (st *syncTracker) setCursor(cursor varlogpb.LogEntryMeta) {
 }
 
 func (lse *Executor) Sync(ctx context.Context, dstReplica varlogpb.LogStreamReplica) (*snpb.SyncStatus, error) {
-	atomic.AddInt64(&lse.inflight, 1)
-	defer atomic.AddInt64(&lse.inflight, -1)
+	lse.inflight.Add(1)
+	defer lse.inflight.Add(-1)
 
 	lse.muAdmin.Lock()
 	defer lse.muAdmin.Unlock()
@@ -251,8 +250,8 @@ func (lse *Executor) syncLoop(_ context.Context, sc *syncClient, st *syncTracker
 }
 
 func (lse *Executor) SyncInit(_ context.Context, srcReplica varlogpb.LogStreamReplica, srcRange snpb.SyncRange, srcLastCommittedLLSN types.LLSN) (syncRange snpb.SyncRange, err error) {
-	atomic.AddInt64(&lse.inflight, 1)
-	defer atomic.AddInt64(&lse.inflight, -1)
+	lse.inflight.Add(1)
+	defer lse.inflight.Add(-1)
 
 	lse.muAdmin.Lock()
 	defer lse.muAdmin.Unlock()
@@ -458,8 +457,8 @@ func (lse *Executor) SyncInit(_ context.Context, srcReplica varlogpb.LogStreamRe
 }
 
 func (lse *Executor) SyncReplicate(_ context.Context, srcReplica varlogpb.LogStreamReplica, payload snpb.SyncPayload) (err error) {
-	atomic.AddInt64(&lse.inflight, 1)
-	defer atomic.AddInt64(&lse.inflight, -1)
+	lse.inflight.Add(1)
+	defer lse.inflight.Add(-1)
 
 	lse.muAdmin.Lock()
 	defer lse.muAdmin.Unlock()

--- a/internal/storagenode/logstream/writer.go
+++ b/internal/storagenode/logstream/writer.go
@@ -15,7 +15,7 @@ import (
 type writer struct {
 	writerConfig
 	queue    chan *sequenceTask
-	inflight int64
+	inflight atomic.Int64
 	runner   *runner.Runner
 }
 
@@ -37,10 +37,10 @@ func newWriter(cfg writerConfig) (*writer, error) {
 
 // send sends a sequenceTask to the queue.
 func (w *writer) send(ctx context.Context, st *sequenceTask) (err error) {
-	inflight := atomic.AddInt64(&w.inflight, 1)
+	inflight := w.inflight.Add(1)
 	defer func() {
 		if err != nil {
-			inflight = atomic.AddInt64(&w.inflight, -1)
+			inflight = w.inflight.Add(-1)
 		}
 		if ce := w.logger.Check(zap.DebugLevel, "sent writer a task"); ce != nil {
 			ce.Write(
@@ -91,13 +91,13 @@ func (w *writer) writeLoopInternal(_ context.Context, st *sequenceTask) {
 		// _ = st.dwb.Close()
 		_ = st.wb.Close()
 		st.release()
-		inflight := atomic.AddInt64(&w.inflight, -1)
+		inflight := w.inflight.Add(-1)
 		if w.lse.lsm == nil {
 			return
 		}
-		atomic.AddInt64(&w.lse.lsm.WriterOperationDuration, time.Since(startTime).Microseconds())
-		atomic.AddInt64(&w.lse.lsm.WriterOperations, 1)
-		atomic.StoreInt64(&w.lse.lsm.WriterInflightOperations, inflight)
+		w.lse.lsm.WriterOperationDuration.Add(time.Since(startTime).Microseconds())
+		w.lse.lsm.WriterOperations.Add(1)
+		w.lse.lsm.WriterInflightOperations.Store(inflight)
 	}()
 
 	// err = st.dwb.Apply()
@@ -135,12 +135,12 @@ func (w *writer) waitForDrainage(cause error, forceDrain bool) {
 
 	if ce := w.logger.Check(zap.DebugLevel, "draining writer tasks"); ce != nil {
 		ce.Write(
-			zap.Int64("inflight", atomic.LoadInt64(&w.inflight)),
+			zap.Int64("inflight", w.inflight.Load()),
 			zap.Error(cause),
 		)
 	}
 
-	for atomic.LoadInt64(&w.inflight) > 0 {
+	for w.inflight.Load() > 0 {
 		if !forceDrain {
 			<-timer.C
 			timer.Reset(tick)
@@ -155,7 +155,7 @@ func (w *writer) waitForDrainage(cause error, forceDrain bool) {
 				st.awgs[i].writeDone(cause)
 			}
 			st.release()
-			atomic.AddInt64(&w.inflight, -1)
+			w.inflight.Add(-1)
 		}
 	}
 }

--- a/internal/storagenode/logstream/writer_test.go
+++ b/internal/storagenode/logstream/writer_test.go
@@ -3,7 +3,6 @@ package logstream
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -93,10 +92,10 @@ func TestWriter_DrainForce(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
-	assert.EqualValues(t, numTasks, atomic.LoadInt64(&wr.inflight))
+	assert.EqualValues(t, numTasks, wr.inflight.Load())
 	assert.Len(t, wr.queue, numTasks)
 	wr.waitForDrainage(errors.New("force drain"), true)
-	assert.Zero(t, atomic.LoadInt64(&wr.inflight))
+	assert.Zero(t, wr.inflight.Load())
 	assert.Empty(t, wr.queue)
 }
 

--- a/internal/storagenode/replication_server.go
+++ b/internal/storagenode/replication_server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"sync"
-	"sync/atomic"
 
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -165,7 +164,7 @@ func (rs *replicationServer) replicate(ctx context.Context, requestC <-chan *rep
 				}
 			}
 
-			atomic.AddInt64(&lse.Metrics().ReplicateServerOperations, 1)
+			lse.Metrics().ReplicateServerOperations.Add(1)
 
 			err = lse.Replicate(ctx, rst.req.LLSN, rst.req.Data)
 			if err != nil {

--- a/internal/storagenode/telemetry/metrics.go
+++ b/internal/storagenode/telemetry/metrics.go
@@ -14,37 +14,37 @@ import (
 )
 
 type LogStreamMetrics struct {
-	AppendLogs             int64
-	AppendBytes            int64
-	AppendDuration         int64
-	AppendOperations       int64
-	AppendPreparationMicro int64
-	AppendBatchCommitGap   int64
+	AppendLogs             atomic.Int64
+	AppendBytes            atomic.Int64
+	AppendDuration         atomic.Int64
+	AppendOperations       atomic.Int64
+	AppendPreparationMicro atomic.Int64
+	AppendBatchCommitGap   atomic.Int64
 
-	SequencerOperationDuration  int64
-	SequencerFanoutDuration     int64
-	SequencerOperations         int64
-	SequencerInflightOperations int64
+	SequencerOperationDuration  atomic.Int64
+	SequencerFanoutDuration     atomic.Int64
+	SequencerOperations         atomic.Int64
+	SequencerInflightOperations atomic.Int64
 
-	WriterOperationDuration  int64
-	WriterOperations         int64
-	WriterInflightOperations int64
+	WriterOperationDuration  atomic.Int64
+	WriterOperations         atomic.Int64
+	WriterInflightOperations atomic.Int64
 
-	CommitterOperationDuration int64
-	CommitterOperations        int64
-	CommitterLogs              int64
+	CommitterOperationDuration atomic.Int64
+	CommitterOperations        atomic.Int64
+	CommitterLogs              atomic.Int64
 
-	ReplicateClientOperationDuration  int64
-	ReplicateClientOperations         int64
-	ReplicateClientInflightOperations int64
+	ReplicateClientOperationDuration  atomic.Int64
+	ReplicateClientOperations         atomic.Int64
+	ReplicateClientInflightOperations atomic.Int64
 
-	ReplicateServerOperations int64
+	ReplicateServerOperations atomic.Int64
 
-	ReplicateLogs             int64
-	ReplicateBytes            int64
-	ReplicateDuration         int64
-	ReplicateOperations       int64
-	ReplicatePreparationMicro int64
+	ReplicateLogs             atomic.Int64
+	ReplicateBytes            atomic.Int64
+	ReplicateDuration         atomic.Int64
+	ReplicateOperations       atomic.Int64
+	ReplicatePreparationMicro atomic.Int64
 }
 
 type Metrics struct {
@@ -106,37 +106,37 @@ func RegisterMetrics(meter metric.Meter, snid types.StorageNodeID) (m *Metrics, 
 			}
 
 			result.Observe(attrs,
-				appendLogs.Observation(atomic.LoadInt64(&lsm.AppendLogs)),
-				appendBytes.Observation(atomic.LoadInt64(&lsm.AppendBytes)),
-				appendDuration.Observation(atomic.LoadInt64(&lsm.AppendDuration)),
-				appendOperations.Observation(atomic.LoadInt64(&lsm.AppendOperations)),
-				appendPreparationMicroseconds.Observation(atomic.LoadInt64(&lsm.AppendPreparationMicro)),
-				appendBatchCommitGap.Observation(atomic.LoadInt64(&lsm.AppendBatchCommitGap)),
+				appendLogs.Observation(lsm.AppendLogs.Load()),
+				appendBytes.Observation(lsm.AppendBytes.Load()),
+				appendDuration.Observation(lsm.AppendDuration.Load()),
+				appendOperations.Observation(lsm.AppendOperations.Load()),
+				appendPreparationMicroseconds.Observation(lsm.AppendPreparationMicro.Load()),
+				appendBatchCommitGap.Observation(lsm.AppendBatchCommitGap.Load()),
 
-				sequencerOperationDuration.Observation(atomic.LoadInt64(&lsm.SequencerOperationDuration)),
-				sequencerFanoutDuration.Observation(atomic.LoadInt64(&lsm.SequencerFanoutDuration)),
-				sequencerOperations.Observation(atomic.LoadInt64(&lsm.SequencerOperations)),
-				sequencerInflightOperations.Observation(atomic.LoadInt64(&lsm.SequencerInflightOperations)),
+				sequencerOperationDuration.Observation(lsm.SequencerOperationDuration.Load()),
+				sequencerFanoutDuration.Observation(lsm.SequencerFanoutDuration.Load()),
+				sequencerOperations.Observation(lsm.SequencerOperations.Load()),
+				sequencerInflightOperations.Observation(lsm.SequencerInflightOperations.Load()),
 
-				writerOperationDuration.Observation(atomic.LoadInt64(&lsm.WriterOperationDuration)),
-				writerOperations.Observation(atomic.LoadInt64(&lsm.WriterOperations)),
-				writerInflightOperations.Observation(atomic.LoadInt64(&lsm.WriterInflightOperations)),
+				writerOperationDuration.Observation(lsm.WriterOperationDuration.Load()),
+				writerOperations.Observation(lsm.WriterOperations.Load()),
+				writerInflightOperations.Observation(lsm.WriterInflightOperations.Load()),
 
-				committerOperationDuration.Observation(atomic.LoadInt64(&lsm.CommitterOperationDuration)),
-				committerOperations.Observation(atomic.LoadInt64(&lsm.CommitterOperations)),
-				committerLogs.Observation(atomic.LoadInt64(&lsm.CommitterLogs)),
+				committerOperationDuration.Observation(lsm.CommitterOperationDuration.Load()),
+				committerOperations.Observation(lsm.CommitterOperations.Load()),
+				committerLogs.Observation(lsm.CommitterLogs.Load()),
 
-				replicateClientOperationDuration.Observation(atomic.LoadInt64(&lsm.ReplicateClientOperationDuration)),
-				replicateClientOperations.Observation(atomic.LoadInt64(&lsm.ReplicateClientOperations)),
-				replicateClientInflightOperations.Observation(atomic.LoadInt64(&lsm.ReplicateClientInflightOperations)),
+				replicateClientOperationDuration.Observation(lsm.ReplicateClientOperationDuration.Load()),
+				replicateClientOperations.Observation(lsm.ReplicateClientOperations.Load()),
+				replicateClientInflightOperations.Observation(lsm.ReplicateClientInflightOperations.Load()),
 
-				replicateServerOperations.Observation(atomic.LoadInt64(&lsm.ReplicateServerOperations)),
+				replicateServerOperations.Observation(lsm.ReplicateServerOperations.Load()),
 
-				replicateLogs.Observation(atomic.LoadInt64(&lsm.ReplicateLogs)),
-				replicateBytes.Observation(atomic.LoadInt64(&lsm.ReplicateBytes)),
-				replicateDuration.Observation(atomic.LoadInt64(&lsm.ReplicateDuration)),
-				replicateOperations.Observation(atomic.LoadInt64(&lsm.ReplicateOperations)),
-				replicatePreparationMicroseconds.Observation(atomic.LoadInt64(&lsm.ReplicatePreparationMicro)),
+				replicateLogs.Observation(lsm.ReplicateLogs.Load()),
+				replicateBytes.Observation(lsm.ReplicateBytes.Load()),
+				replicateDuration.Observation(lsm.ReplicateDuration.Load()),
+				replicateOperations.Observation(lsm.ReplicateOperations.Load()),
+				replicatePreparationMicroseconds.Observation(lsm.ReplicatePreparationMicro.Load()),
 			)
 
 			return true

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -102,25 +102,6 @@ func (ver Version) Invalid() bool {
 	return ver == InvalidVersion
 }
 
-type AtomicVersion uint64
-
-func (ver *AtomicVersion) Add(delta uint64) Version {
-	return Version(atomic.AddUint64((*uint64)(ver), delta))
-}
-
-func (ver *AtomicVersion) Load() Version {
-	return Version(atomic.LoadUint64((*uint64)(ver)))
-}
-
-func (ver *AtomicVersion) Store(val Version) {
-	atomic.StoreUint64((*uint64)(ver), uint64(val))
-}
-
-func (ver *AtomicVersion) CompareAndSwap(old, new Version) (swapped bool) {
-	swapped = atomic.CompareAndSwapUint64((*uint64)(ver), uint64(old), uint64(new))
-	return swapped
-}
-
 type GLSN uint64
 
 const (
@@ -133,25 +114,6 @@ var GLSNLen = binary.Size(InvalidGLSN)
 
 func (glsn GLSN) Invalid() bool {
 	return glsn == InvalidGLSN
-}
-
-type AtomicGLSN uint64
-
-func (glsn *AtomicGLSN) Add(delta uint64) GLSN {
-	return GLSN(atomic.AddUint64((*uint64)(glsn), delta))
-}
-
-func (glsn *AtomicGLSN) Load() GLSN {
-	return GLSN(atomic.LoadUint64((*uint64)(glsn)))
-}
-
-func (glsn *AtomicGLSN) Store(val GLSN) {
-	atomic.StoreUint64((*uint64)(glsn), uint64(val))
-}
-
-func (glsn *AtomicGLSN) CompareAndSwap(old, new GLSN) (swapped bool) {
-	swapped = atomic.CompareAndSwapUint64((*uint64)(glsn), uint64(old), uint64(new))
-	return swapped
 }
 
 type LLSN uint64

--- a/pkg/types/types_test.go
+++ b/pkg/types/types_test.go
@@ -47,21 +47,6 @@ func TestGLSN(t *testing.T) {
 
 		var invalid GLSN
 		So(invalid.Invalid(), ShouldBeTrue)
-
-		Convey("AtomicGLSN should work", func() {
-			glsn := AtomicGLSN(1)
-			glsn.Add(10)
-			So(glsn.Load(), ShouldEqual, GLSN(11))
-
-			glsn.Store(20)
-			So(glsn.Load(), ShouldEqual, GLSN(20))
-
-			So(glsn.CompareAndSwap(GLSN(20), GLSN(21)), ShouldBeTrue)
-			So(glsn.Load(), ShouldEqual, GLSN(21))
-
-			So(glsn.CompareAndSwap(GLSN(20), GLSN(22)), ShouldBeFalse)
-			So(glsn.Load(), ShouldEqual, GLSN(21))
-		})
 	})
 }
 

--- a/tests/it/cluster/client_test.go
+++ b/tests/it/cluster/client_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -231,7 +232,7 @@ func TestClientAppendCancel(t *testing.T) {
 	client := clus.ClientAtIndex(t, 0)
 
 	var (
-		atomicGLSN types.AtomicGLSN
+		atomicGLSN atomic.Uint64
 		wg         sync.WaitGroup
 	)
 	wg.Add(1)
@@ -244,7 +245,7 @@ func TestClientAppendCancel(t *testing.T) {
 			if res.Err == nil {
 				require.Equal(t, expectedGLSN, res.Metadata[0].GLSN)
 				expectedGLSN++
-				atomicGLSN.Store(res.Metadata[0].GLSN)
+				atomicGLSN.Store(uint64(res.Metadata[0].GLSN))
 			} else {
 				t.Logf("canceled")
 				return


### PR DESCRIPTION
### What this PR does

Use new atomic types instead of old atomic functions to avoid misuse of variables.

