### PR TITLE
feat(storagenode): add configurations for initial window size

### DIFF
--- a/bin/start_varlogsn.py
+++ b/bin/start_varlogsn.py
@@ -179,6 +179,12 @@ def start(args: argparse.Namespace) -> None:
             if args.server_write_buffer_size:
                 cmd.append(
                     f"--server-write-buffer-size={args.server_write_buffer_size}")
+            if args.server_initial_conn_window_size:
+                cmd.append(
+                        f"--server-initial-conn-window-size={args.server_initial_conn_window_size}")
+            if args.server_initial_stream_window_size:
+                cmd.append(
+                        f"--server-initial-stream-window-size={args.server_initial_stream_window_size}")
             if args.replication_client_read_buffer_size:
                 cmd.append(
                     f"--replication-client-read-buffer-size={args.replication_client_read_buffer_size}")
@@ -266,6 +272,8 @@ def main() -> None:
     # grpc options
     parser.add_argument("--server-read-buffer-size", type=str)
     parser.add_argument("--server-write-buffer-size", type=str)
+    parser.add_argument("--server-initial-conn-window-size", type=str)
+    parser.add_argument("--server-initial-stream-window-size", type=str)
     parser.add_argument("--replication-client-read-buffer-size", type=str)
     parser.add_argument("--replication-client-write-buffer-size", type=str)
 

--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -48,6 +48,8 @@ func newStartCommand() *cli.Command {
 			flagServerMaxRecvMsgSize.StringFlag(false, units.ToByteSizeString(storagenode.DefaultServerMaxRecvSize)),
 			flagReplicationClientReadBufferSize.StringFlag(false, units.ToByteSizeString(storagenode.DefaultReplicateClientReadBufferSize)),
 			flagReplicationClientWriteBufferSize.StringFlag(false, units.ToByteSizeString(storagenode.DefaultReplicateClientWriteBufferSize)),
+			flagServerInitialConnWindowSize,
+			flagServerInitialStreamWindowSize,
 
 			// lse options
 			flagLogStreamExecutorSequenceQueueCapacity.IntFlag(false, logstream.DefaultSequenceQueueCapacity),

--- a/cmd/varlogsn/flags.go
+++ b/cmd/varlogsn/flags.go
@@ -56,6 +56,16 @@ var (
 		Envs:    []string{"SERVER_MAX_MSG_SIZE", "SERVER_MAX_MESSAGE_SIZE"},
 		Usage:   "B, KiB, MiB, GiB",
 	}
+	flagServerInitialConnWindowSize = &cli.StringFlag{
+		Name:    "server-initial-conn-window-size",
+		EnvVars: []string{"SERVER_INITIAL_CONN_WINDOW_SIZE"},
+		Usage:   "Window size for a connection.",
+	}
+	flagServerInitialStreamWindowSize = &cli.StringFlag{
+		Name:    "server-initial-stream-window-size",
+		EnvVars: []string{"SERVER_INITIAL_STREAM_WINDOW_SIZE"},
+		Usage:   "Window size for stream.",
+	}
 	flagReplicationClientReadBufferSize = flags.FlagDesc{
 		Name:  "replication-client-read-buffer-size",
 		Envs:  []string{"REPLICATION_CLIENT_READ_BUFFER_SIZE"},

--- a/internal/storagenode/config.go
+++ b/internal/storagenode/config.go
@@ -33,6 +33,14 @@ type config struct {
 	grpcServerReadBufferSize        int64
 	grpcServerWriteBufferSize       int64
 	grpcServerMaxRecvMsgSize        int64
+	grpcServerInitialConnWindowSize struct {
+		value int32
+		set   bool
+	}
+	grpcServerInitialWindowSize struct {
+		value int32
+		set   bool
+	}
 	replicateClientReadBufferSize   int64
 	replicateClientWriteBufferSize  int64
 	maxLogStreamReplicasCount       int32
@@ -165,6 +173,20 @@ func WithGRPCServerWriteBufferSize(grpcServerWriteBufferSize int64) Option {
 func WithGRPCServerMaxRecvMsgSize(grpcServerMaxRecvMsgSize int64) Option {
 	return newFuncOption(func(cfg *config) {
 		cfg.grpcServerMaxRecvMsgSize = grpcServerMaxRecvMsgSize
+	})
+}
+
+func WithGRPCServerInitialConnWindowSize(grpcServerInitialConnWindowSize int32) Option {
+	return newFuncOption(func(cfg *config) {
+		cfg.grpcServerInitialConnWindowSize.value = grpcServerInitialConnWindowSize
+		cfg.grpcServerInitialConnWindowSize.set = true
+	})
+}
+
+func WithGRPCServerInitialWindowSize(grpcServerInitialWindowSize int32) Option {
+	return newFuncOption(func(cfg *config) {
+		cfg.grpcServerInitialWindowSize.value = grpcServerInitialWindowSize
+		cfg.grpcServerInitialWindowSize.set = true
 	})
 }
 


### PR DESCRIPTION
### What this PR does

This PR adds new gRPC initial flow control window size options to the storage node.

- `--server-initial-conn-window-size`
- `--server-initial-stream-window-size`

### Anything else

See:

- https://httpwg.org/specs/rfc7540.html#InitialWindowSize
- https://pkg.go.dev/google.golang.org/grpc#InitialConnWindowSize

