### PR TITLE
test(benchmark): support log stream appender

### DIFF
--- a/cmd/benchmark/test_command.go
+++ b/cmd/benchmark/test_command.go
@@ -60,6 +60,11 @@ var (
 		Name:  "print-json",
 		Usage: "Print json output if it is set",
 	}
+	flagPipelineSize = &cli.IntFlag{
+		Name:  "pipeline-size",
+		Usage: "Pipeline size, no pipelined requests if zero. Not support per-target pipeline size yet.",
+		Value: 0,
+	}
 )
 
 func newCommandTest() *cli.Command {
@@ -77,6 +82,7 @@ func newCommandTest() *cli.Command {
 			flagDuration,
 			flagReportInterval,
 			flagPrintJSON,
+			flagPipelineSize,
 		},
 		Action: runCommandTest,
 	}
@@ -109,6 +115,7 @@ func runCommandTest(c *cli.Context) error {
 				return fmt.Errorf("malformed target %s: invalid log stream %s", str, toks[1])
 			}
 		}
+		target.PipelineSize = c.Int(flagPipelineSize.Name)
 		targets[idx] = target
 	}
 

--- a/internal/benchmark/target.go
+++ b/internal/benchmark/target.go
@@ -14,6 +14,7 @@ type Target struct {
 	BatchSize        uint
 	AppendersCount   uint
 	SubscribersCount uint
+	PipelineSize     int
 }
 
 func (tgt Target) Valid() error {


### PR DESCRIPTION
### What this PR does

This PR adds the `--pipeline-size` flag to the benchmark tool. It makes the benchmark test client use LogStreamAppender, which allows pipelined append requests.

- No pipelined requests if the flag is zero (default value).
- Use pipelined requests by using LogStreamAppender if the flag is greater than zero.

The benchmark tool cannot support per-target level pipelined yet. Thus, if the `--pipeline-size` is greater than zero, all the log stream-specific targets will use LogStreamAppender.

