### PR TITLE
fix(storagenode): accept SyncInit sent from trimmed source to new destination

### DIFF
--- a/internal/storagenode/logstream/testing.go
+++ b/internal/storagenode/logstream/testing.go
@@ -11,8 +11,10 @@ import (
 
 	"github.com/kakao/varlog/internal/storage"
 	"github.com/kakao/varlog/pkg/rpc"
+	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/proto/snpb"
 	"github.com/kakao/varlog/proto/snpb/mock"
+	"github.com/kakao/varlog/proto/varlogpb"
 )
 
 type testReplicateServer struct {
@@ -90,4 +92,14 @@ func TestGetStorage(t *testing.T, lse *Executor) *storage.Storage {
 	require.NotNil(t, lse)
 	require.NotNil(t, lse.stg)
 	return lse.stg
+}
+
+func TestGetReportCommitBase(t *testing.T, lse *Executor) (commitVersion types.Version, highWatermark types.GLSN, uncommittedBegin varlogpb.LogSequenceNumber, invalid bool) {
+	require.NotNil(t, lse)
+	return lse.lsc.reportCommitBase()
+}
+
+func TestGetUncommittedLLSNEnd(t *testing.T, lse *Executor) types.LLSN {
+	require.NotNil(t, lse)
+	return lse.lsc.uncommittedLLSNEnd.Load()
 }

--- a/internal/storagenode/replication_server.go
+++ b/internal/storagenode/replication_server.go
@@ -60,8 +60,9 @@ func (rs *replicationServer) SyncReplicateStream(stream snpb.Replicator_SyncRepl
 		if err != nil {
 			if err == io.EOF {
 				err = nil
+			} else {
+				err = fmt.Errorf("replication server: sync replicate stream: %w", err)
 			}
-			err = fmt.Errorf("replication server: sync replicate stream: %w", err)
 			break
 		}
 


### PR DESCRIPTION
### What this PR does

Storage nodes can be trimmed and synchronized. However, there is some bug in that a new destination
replica joined into the log stream rejects SyncInit RPC sent from the trimmed source replica. Those
replicas are all empty and have no log entries; however, the source replica has a commit context
indicating the last committed LLSN. In this situation, the destination replica must accept SyncInit
to receive the commit context from the source replica, but it does not.

This PR fixes the above issue. To solve the problem, it changes the condition that the destination
replica decides whether they are already synchronized.

```go
    // Previous code: https://github.com/kakao/varlog/blob/5269481c0e80c2eebf8214116a2d1544a26cb443/internal/storagenode/logstream/sync.go#L297-L302
    //
    // NOTE: When the replica has all log entries, it returns its range of logs and non-error results.
    // In this case, this replica remains executorStateSealing.
    // Breaking change: previously it returns ErrExist when the replica has all log entries to replicate.
    if dstLastCommittedLLSN == srcRange.LastLLSN && !invalid {
        return snpb.SyncRange{}, status.Errorf(codes.AlreadyExists, "already synchronized")
    }
```

Since both replicas have no log entries, the condition `dstLastCommittedLLSN == srcRange.LastLLSN`
is not enough. This PR changed the condition to be `dstLastCommittedLLSN == srcLastCommittedLLSN &&
dstLastCommittedLLSN == srcRange.LastLLSN`. Since the `srcLastCommittedLLSN` is valid regardless of
log entries in the source replica, the destination replica will accept the SyncInit.

### Which issue(s) this PR resolves

Resolves #478
