### PR TITLE
feat(client): add call timeout to log stream appender

### DIFF
--- a/pkg/varlog/config.go
+++ b/pkg/varlog/config.go
@@ -106,6 +106,7 @@ type logStreamAppenderConfig struct {
 	tpid                 types.TopicID
 	lsid                 types.LogStreamID
 	pipelineSize         int
+	callTimeout          time.Duration
 }
 
 func newLogStreamAppenderConfig(opts []LogStreamAppenderOption) logStreamAppenderConfig {
@@ -161,5 +162,20 @@ func WithPipelineSize(pipelineSize int) LogStreamAppenderOption {
 func WithDefaultBatchCallback(defaultBatchCallback BatchCallback) LogStreamAppenderOption {
 	return newFuncLogStreamAppenderOption(func(cfg *logStreamAppenderConfig) {
 		cfg.defaultBatchCallback = defaultBatchCallback
+	})
+}
+
+// WithCallTimeout configures a timeout for each AppendBatch call. If the
+// timeout has elapsed, the AppendBatch and callback functions may result in an
+// ErrCallTimeout error.
+//
+// ErrCallTimeout may be returned in the following scenarios:
+// - Waiting for the pipeline too long since it is full.
+// - Sending RPC requests to the varlog is blocked for too long.
+// - Receiving RPC response from the varlog is blocked too long.
+// - User codes for callback take time too long.
+func WithCallTimeout(callTimeout time.Duration) LogStreamAppenderOption {
+	return newFuncLogStreamAppenderOption(func(cfg *logStreamAppenderConfig) {
+		cfg.callTimeout = callTimeout
 	})
 }

--- a/pkg/varlog/errors.go
+++ b/pkg/varlog/errors.go
@@ -2,4 +2,7 @@ package varlog
 
 import "errors"
 
-var ErrClosed = errors.New("client: closed")
+var (
+	ErrClosed      = errors.New("client: closed")
+	ErrCallTimeout = errors.New("client: call timeout")
+)

--- a/pkg/varlog/log_stream_appender_test.go
+++ b/pkg/varlog/log_stream_appender_test.go
@@ -1,1 +1,0 @@
-package varlog

--- a/tests/it/cluster/client_test.go
+++ b/tests/it/cluster/client_test.go
@@ -833,6 +833,80 @@ func TestLogStreamAppender(t *testing.T) {
 				}, 5*time.Second, 100*time.Millisecond)
 			},
 		},
+		{
+			name: "CallTimeoutCausedBySemaphore",
+			testf: func(t *testing.T, tpid types.TopicID, lsid types.LogStreamID, vcli varlog.Log) {
+				const (
+					callTimeout         = 500 * time.Millisecond
+					blockedPipelineSize = 1
+				)
+
+				lsa, err := vcli.NewLogStreamAppender(tpid, lsid,
+					varlog.WithPipelineSize(blockedPipelineSize),
+					varlog.WithCallTimeout(callTimeout),
+				)
+				require.NoError(t, err)
+				defer lsa.Close()
+
+				var wg sync.WaitGroup
+				dataBatch := [][]byte{[]byte("foo")}
+
+				wg.Add(1)
+				err = lsa.AppendBatch(dataBatch, func(_ []varlogpb.LogEntryMeta, err error) {
+					defer wg.Done()
+					assert.NoError(t, err)
+					time.Sleep(callTimeout * 2)
+				})
+				require.NoError(t, err)
+
+				err = lsa.AppendBatch(dataBatch, func([]varlogpb.LogEntryMeta, error) {
+					assert.Fail(t, "unexpected callback")
+				})
+				require.Error(t, err)
+				require.Equal(t, varlog.ErrCallTimeout, err)
+
+				wg.Wait()
+			},
+		},
+		{
+			name: "CallTimeoutCausedSlowCallback",
+			testf: func(t *testing.T, tpid types.TopicID, lsid types.LogStreamID, vcli varlog.Log) {
+				const callTimeout = 500 * time.Millisecond
+
+				lsa, err := vcli.NewLogStreamAppender(tpid, lsid,
+					varlog.WithCallTimeout(callTimeout),
+					varlog.WithPipelineSize(5),
+				)
+				require.NoError(t, err)
+				defer lsa.Close()
+
+				var wg sync.WaitGroup
+				dataBatch := [][]byte{[]byte("foo")}
+
+				var failfast atomic.Bool
+				for err == nil {
+					wg.Add(1)
+					err = lsa.AppendBatch(dataBatch, func(_ []varlogpb.LogEntryMeta, cerr error) {
+						defer wg.Done()
+						if cerr != nil {
+							assert.Equal(t, varlog.ErrCallTimeout, cerr)
+							failfast.Store(true)
+							return
+						}
+						time.Sleep(callTimeout * 2)
+					})
+					if err == nil {
+						require.True(t, failfast.CompareAndSwap(false, false))
+					} else {
+						wg.Done()
+						require.Equal(t, varlog.ErrCallTimeout, err)
+					}
+					time.Sleep(callTimeout)
+				}
+
+				wg.Wait()
+			},
+		},
 	}
 
 	for _, tc := range tcs {


### PR DESCRIPTION
### What this PR does

This PR adds a call timeout to the log stream appender. It helps the log stream appender not to be blocked.
LogStreamAppender can be blocked at the following points:

- (a) Waiting for the pipeline to have room
- (b) Flow-controlled when calling RPC
- (c) Stucked server
- (d) Slow callback

```
+------+            +-------------------------+            +--------+
|      |            |    LogStreamAppender    |            |        |
|      |            |                         |            |        |
|      |            |  (a)----------------(b) |            |        |
|      +--AppendBatch--->| pipeline queue |--gRPC request->|        |
| User |            |    +----------------+   |            |        |
| code |            |                         |            | Varlog |
|      |            |    +----------------+   |            |        |
|      |            |    |    callback    |   |            |        |
|      |<--Callback-+----|   processing   |<-gRPC response-+        |
|      |            |  (c)   goroutine    (d) |            |        |
|      |            |    +----------------+   |            |        |
+------+            +-------------------------+            +--------+
```

When a user configures call timeout by using `pkg/varlog.WithCallTimeout`, the `pkg/varlog.(LogStreamAppender).AppendBatch` or its callback function can return ErrCallTimeout when above situations.
