### PR TITLE
feat(client): add call timeout to log stream appender

### DIFF
--- a/pkg/varlog/config.go
+++ b/pkg/varlog/config.go
@@ -107,6 +107,7 @@ type logStreamAppenderConfig struct {
 	tpid                 types.TopicID
 	lsid                 types.LogStreamID
 	pipelineSize         int
+	callTimeout          time.Duration
 }
 
 func newLogStreamAppenderConfig(opts []LogStreamAppenderOption) logStreamAppenderConfig {
@@ -162,5 +163,20 @@ func WithPipelineSize(pipelineSize int) LogStreamAppenderOption {
 func WithDefaultBatchCallback(defaultBatchCallback BatchCallback) LogStreamAppenderOption {
 	return newFuncLogStreamAppenderOption(func(cfg *logStreamAppenderConfig) {
 		cfg.defaultBatchCallback = defaultBatchCallback
+	})
+}
+
+// WithCallTimeout configures a timeout for each AppendBatch call. If the
+// timeout has elapsed, the AppendBatch and callback functions may result in an
+// ErrCallTimeout error.
+//
+// ErrCallTimeout may be returned in the following scenarios:
+// - Waiting for the pipeline too long since it is full.
+// - Sending RPC requests to the varlog is blocked for too long.
+// - Receiving RPC response from the varlog is blocked too long.
+// - User codes for callback take time too long.
+func WithCallTimeout(callTimeout time.Duration) LogStreamAppenderOption {
+	return newFuncLogStreamAppenderOption(func(cfg *logStreamAppenderConfig) {
+		cfg.callTimeout = callTimeout
 	})
 }

--- a/pkg/varlog/errors.go
+++ b/pkg/varlog/errors.go
@@ -2,4 +2,7 @@ package varlog
 
 import "errors"
 
-var ErrClosed = errors.New("client: closed")
+var (
+	ErrClosed      = errors.New("client: closed")
+	ErrCallTimeout = errors.New("client: call timeout")
+)


### PR DESCRIPTION
### What this PR does

This PR adds a call timeout to the log stream appender. It helps the log stream appender not to be
blocked. LogStreamAppender can be blocked at the following points:

- (a) Waiting for the pipeline to have room
- (b) Flow-controlled when calling RPC
- (c) Stucked server
- (d) Slow callback

```
+------+            +-------------------------+            +--------+
|      |            |    LogStreamAppender    |            |        |
|      |            |                         |            |        |
|      |            |  (a)----------------(b) |            |        |
|      +--AppendBatch--->| pipeline queue |--gRPC request->|        |
| User |            |    +----------------+   |            |        |
| code |            |                         |            | Varlog |
|      |            |    +----------------+   |            |        |
|      |            |    |    callback    |   |            |        |
|      |<--Callback-+----|   processing   |<-gRPC response-+        |
|      |            |  (c)   goroutine    (d) |            |        |
|      |            |    +----------------+   |            |        |
+------+            +-------------------------+            +--------+
```

When a user configures call timeout by using `pkg/varlog.WithCallTimeout`, the
`pkg/varlog.(LogStreamAppender).AppendBatch` or its callback function can return ErrCallTimeout when
above situations.
