### PR TITLE
perf(admin): use singleflight to handle Admin's RPCs

### DIFF
--- a/internal/admin/sfgkey/keys.go
+++ b/internal/admin/sfgkey/keys.go
@@ -1,0 +1,44 @@
+package sfgkey
+
+import (
+	"github.com/kakao/varlog/pkg/types"
+)
+
+const (
+	delimiter           = "_"
+	keyGetStorageNode   = "getsn"
+	keyListStorageNodes = "listsns"
+	keyGetTopic         = "gettp"
+	keyListTopics       = "listtps"
+	keyGetLogStream     = "getls"
+	keyListLogStreams   = "listlss"
+	keyDescribeTopic    = "desctp"
+)
+
+func GetStorageNodeKey(snid types.StorageNodeID) string {
+	return keyGetStorageNode + delimiter + snid.String()
+}
+
+func ListStorageNodesKey() string {
+	return keyListStorageNodes
+}
+
+func GetTopicKey(tpid types.TopicID) string {
+	return keyGetTopic + delimiter + tpid.String()
+}
+
+func ListTopicsKey() string {
+	return keyListTopics
+}
+
+func GetLogStreamKey(tpid types.TopicID, lsid types.LogStreamID) string {
+	return keyGetLogStream + delimiter + tpid.String() + delimiter + lsid.String()
+}
+
+func ListLogStreamsKey(tpid types.TopicID) string {
+	return keyListLogStreams + delimiter + tpid.String()
+}
+
+func DescribeTopicKey(tpid types.TopicID) string {
+	return keyDescribeTopic + delimiter + tpid.String()
+}


### PR DESCRIPTION
### What this PR does

This PR makes the admin server handle RPCs by using singleflight. It helps the admin to reduce redundant computation, especially read operations.

I am only altering read operations. However, it is possible to refactor the admin server to eliminate the use of a single big lock.
