### PR TITLE
fix(storagenode): restore uncommitted logs

### DIFF
--- a/internal/storage/testing.go
+++ b/internal/storage/testing.go
@@ -31,6 +31,15 @@ func TestGetUnderlyingDB(tb testing.TB, stg *Storage) (dataDB, commitDB *pebble.
 	return stg.dataDB, stg.commitDB
 }
 
+// TestWriteLogEntry stores data located by the llsn. The data is not committed
+// because it does not store commits.
+func TestWriteLogEntry(tb testing.TB, stg *Storage, llsn types.LLSN, data []byte) {
+	batch := stg.NewWriteBatch()
+	require.NoError(tb, batch.Set(llsn, data))
+	require.NoError(tb, batch.Apply())
+	require.NoError(tb, batch.Close())
+}
+
 // TestAppendLogEntryWithoutCommitContext stores log entries without commit
 // context.
 func TestAppendLogEntryWithoutCommitContext(tb testing.TB, stg *Storage, llsn types.LLSN, glsn types.GLSN, data []byte) {

--- a/internal/storagenode/logstream/committer_test.go
+++ b/internal/storagenode/logstream/committer_test.go
@@ -55,25 +55,25 @@ func TestCommitter_ShouldNotAcceptTasksWhileNotAppendable(t *testing.T) {
 
 	lse.esm.store(executorStateAppendable)
 	assert.Panics(t, func() {
-		_ = cm.sendCommitWaitTask(context.Background(), cwts)
+		_ = cm.sendCommitWaitTask(context.Background(), cwts, false /*ignoreSealing*/)
 	})
 
 	assert.Panics(t, func() {
-		_ = cm.sendCommitWaitTask(context.Background(), nil)
+		_ = cm.sendCommitWaitTask(context.Background(), nil, false /*ignoreSealing*/)
 	})
 
 	cwts.PushFront(&commitWaitTask{})
 
 	lse.esm.store(executorStateSealing)
-	err := cm.sendCommitWaitTask(context.Background(), cwts)
+	err := cm.sendCommitWaitTask(context.Background(), cwts, false /*ignoreSealing*/)
 	assert.Error(t, err)
 
 	lse.esm.store(executorStateSealed)
-	err = cm.sendCommitWaitTask(context.Background(), cwts)
+	err = cm.sendCommitWaitTask(context.Background(), cwts, false /*ignoreSealing*/)
 	assert.Error(t, err)
 
 	lse.esm.store(executorStateClosed)
-	err = cm.sendCommitWaitTask(context.Background(), cwts)
+	err = cm.sendCommitWaitTask(context.Background(), cwts, false /*ignoreSealing*/)
 	assert.Error(t, err)
 
 	// sendCommitTask
@@ -143,7 +143,7 @@ func TestCommitter_DrainCommitWaitQ(t *testing.T) {
 
 	cwts := newListQueue()
 	cwts.PushFront(newCommitWaitTask(newAppendWaitGroup(newWriteWaitGroup())))
-	err := cm.sendCommitWaitTask(context.Background(), cwts)
+	err := cm.sendCommitWaitTask(context.Background(), cwts, false /*ignoreSealing*/)
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, 1, cm.inflightCommitWait.Load())

--- a/internal/storagenode/logstream/sequencer.go
+++ b/internal/storagenode/logstream/sequencer.go
@@ -139,7 +139,7 @@ func (sq *sequencer) sequenceLoopInternal(ctx context.Context, st *sequenceTask)
 	// before sending tasks to writer. It prevents the above subtle case.
 	//
 	// send to committer
-	if err := sq.lse.cm.sendCommitWaitTask(ctx, cwts); err != nil {
+	if err := sq.lse.cm.sendCommitWaitTask(ctx, cwts, false /*ignoreSealing*/); err != nil {
 		sq.logger.Error("could not send to committer", zap.Error(err))
 		sq.lse.esm.compareAndSwap(executorStateAppendable, executorStateSealing)
 		st.wwg.done(err)


### PR DESCRIPTION
### What this PR does

Currently, all log stream replicas belonging to the storage nodes that are just
restarted can't commit logs written before restarting if all log stream
replicas in a log stream were restarted simultaneously. They have logs
uncommitted in their storages, but they can't process Commit RPC sent from the
metadata repository.

This PR fixes the above issue. While recovering the log stream context after
restarting the storage nodes, it restores uncommitted logs.

### Which issue(s) this PR resolves

Resolves #490
