### PR TITLE
refactor(metarepos): remove redundant metric mr.build_commit_results.duration

### DIFF
--- a/internal/metarepos/raft_metadata_repository.go
+++ b/internal/metarepos/raft_metadata_repository.go
@@ -825,7 +825,6 @@ func (mr *RaftMetadataRepository) applyCommit(r *mrpb.Commit, appliedIndex uint6
 		)
 	}
 
-	startTime := time.Now()
 	_, err := mr.withTelemetry(context.TODO(), "mr.build_commit_results.duration", func(ctx context.Context) (interface{}, error) {
 		defer mr.storage.ResetUpdateSinceCommit()
 
@@ -972,10 +971,6 @@ func (mr *RaftMetadataRepository) applyCommit(r *mrpb.Commit, appliedIndex uint6
 
 		return nil, nil
 	})
-
-	mr.tmStub.mb.Records("mr.build_commit_results.duration").Record(context.Background(),
-		float64(time.Since(startTime).Nanoseconds())/float64(time.Millisecond),
-	)
 
 	return err
 }


### PR DESCRIPTION
### What this PR does

Remove the redundant metric, which is `mr.build_commit_results.duration`.
