### PR TITLE
fix(storagenode): ignore context error while checking to interleave of Append RPC errors

### DIFF
--- a/internal/storagenode/logstream/append_waitgroup.go
+++ b/internal/storagenode/logstream/append_waitgroup.go
@@ -147,6 +147,9 @@ func (awg *appendWaitGroup) wait(ctx context.Context) error {
 	if awg == nil {
 		return nil
 	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	err := awg.wwg.wait(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What this PR does

Append batch requests can succeed partially. In case of partial failure, failed log entries must be sequential. That is, suffixes of the batch can be failed to append, whose length can be from zero to the full size.

Our codebase panics when the batch's success and failure are interleaved. This PR ignores context errors caused by clients since the batch can succeed in the storage node, although clients canceled it.
