### PR TITLE
chore(benchmark): improve the readability of benchmark stats

### DIFF
--- a/internal/benchmark/report_codec.go
+++ b/internal/benchmark/report_codec.go
@@ -28,50 +28,42 @@ func (se StringEncoder) Encode(trs TargetReports) ([]byte, error) {
 	//  slps: subscribed logs per second
 	//  sbps: subscribed megabytes per second
 	// eelat: end-to-end latency in milliseconds
-	fmt.Fprintf(&buf, "___tgt")  //  6 spaces
-	fmt.Fprintf(&buf, "__arpsR") //  7 spaces
-	fmt.Fprintf(&buf, "__arpsT") //  7 spaces
+	fmt.Fprintf(&buf, "target")                 //  6 spaces
+	fmt.Fprintf(&buf, "_____arps(now,tot)")     // 18 spaces
+	fmt.Fprintf(&buf, "_________abps(now,tot)") // 22 spaces
+	fmt.Fprintf(&buf, "_adur(now,tot)")         // 14 spaces
 
-	fmt.Fprintf(&buf, "_______abpsR") // 12 spaces
-	fmt.Fprintf(&buf, "_______abpsT") // 12 spaces
+	fmt.Fprintf(&buf, "_____slps(now,tot)")     // 18 spaces
+	fmt.Fprintf(&buf, "_________sbps(now,tot)") // 22 spaces
+	fmt.Fprintf(&buf, "__eelat(now,tot)")       // 16 spaces
+	fmt.Fprintf(&buf, "\n")
 
-	fmt.Fprintf(&buf, "__adurR") //  7 spaces
-	fmt.Fprintf(&buf, "__adurT") //  7 spaces
-
-	fmt.Fprintf(&buf, "__slpsR") //  7 spaces
-	fmt.Fprintf(&buf, "__slpsT") //  7 spaces
-
-	fmt.Fprintf(&buf, "_______sbpsR") // 12 spaces
-	fmt.Fprintf(&buf, "_______sbpsT") // 12 spaces
-
-	fmt.Fprintf(&buf, "__eelatR")   //  8 spaces
-	fmt.Fprintf(&buf, "__eelatT\n") //  8 spaces
 	for idx, rpt := range trs.Reports {
 		fmt.Fprintf(&buf, "%6s", rpt.Target)
 
 		// arps
-		fmt.Fprintf(&buf, "%7.1f", rpt.Recent.AppendReport.RequestsPerSecond)
-		fmt.Fprintf(&buf, "%7.1f", rpt.Total.AppendReport.RequestsPerSecond)
+		fmt.Fprintf(&buf, "%7s/s", units.ToHumanSizeStringWithoutUnit(rpt.Recent.AppendReport.RequestsPerSecond, 4))
+		fmt.Fprintf(&buf, "%7s/s", units.ToHumanSizeStringWithoutUnit(rpt.Total.AppendReport.RequestsPerSecond, 4))
 
 		// abps
-		fmt.Fprintf(&buf, "%10s/s", units.ToByteSizeString(rpt.Recent.AppendReport.BytesPerSecond))
-		fmt.Fprintf(&buf, "%10s/s", units.ToByteSizeString(rpt.Total.AppendReport.BytesPerSecond))
+		fmt.Fprintf(&buf, "%9s/s", units.ToByteSizeString(rpt.Recent.AppendReport.BytesPerSecond))
+		fmt.Fprintf(&buf, "%9s/s", units.ToByteSizeString(rpt.Total.AppendReport.BytesPerSecond))
 
 		// adur
-		fmt.Fprintf(&buf, "%7.1f", rpt.Recent.AppendReport.Duration)
-		fmt.Fprintf(&buf, "%7.1f", rpt.Total.AppendReport.Duration)
+		fmt.Fprintf(&buf, "%5.1fms", rpt.Recent.AppendReport.Duration)
+		fmt.Fprintf(&buf, "%5.1fms", rpt.Total.AppendReport.Duration)
 
 		// slps
-		fmt.Fprintf(&buf, "%7.1f", rpt.Recent.SubscribeReport.LogsPerSecond)
-		fmt.Fprintf(&buf, "%7.1f", rpt.Total.SubscribeReport.LogsPerSecond)
+		fmt.Fprintf(&buf, "%7s/s", units.ToHumanSizeStringWithoutUnit(rpt.Recent.SubscribeReport.LogsPerSecond, 4))
+		fmt.Fprintf(&buf, "%7s/s", units.ToHumanSizeStringWithoutUnit(rpt.Total.SubscribeReport.LogsPerSecond, 4))
 
 		// sbps
-		fmt.Fprintf(&buf, "%10s/s", units.ToByteSizeString(rpt.Recent.SubscribeReport.BytesPerSecond))
-		fmt.Fprintf(&buf, "%10s/s", units.ToByteSizeString(rpt.Total.SubscribeReport.BytesPerSecond))
+		fmt.Fprintf(&buf, "%9s/s", units.ToByteSizeString(rpt.Recent.SubscribeReport.BytesPerSecond))
+		fmt.Fprintf(&buf, "%9s/s", units.ToByteSizeString(rpt.Total.SubscribeReport.BytesPerSecond))
 
 		// eelat
-		fmt.Fprintf(&buf, "%8.1f", rpt.Recent.EndToEndReport.Latency)
-		fmt.Fprintf(&buf, "%8.1f", rpt.Total.EndToEndReport.Latency)
+		fmt.Fprintf(&buf, "%6.1fms", rpt.Recent.EndToEndReport.Latency)
+		fmt.Fprintf(&buf, "%6.1fms", rpt.Total.EndToEndReport.Latency)
 
 		if idx < len(trs.Reports)-1 {
 			fmt.Fprint(&buf, "\n")

--- a/pkg/util/units/units.go
+++ b/pkg/util/units/units.go
@@ -3,9 +3,21 @@ package units
 import (
 	"fmt"
 	"math"
+	"strconv"
 
 	"github.com/docker/go-units"
 )
+
+const humanSizeBase = 1000.0
+
+var (
+	siUnit = []string{"", "k", "M", "G", "T", "P", "E", "Z", "Y"}
+)
+
+func ToHumanSizeStringWithoutUnit(size float64, precision int) string {
+	fmt := "%." + strconv.Itoa(precision) + "g%s"
+	return units.CustomSize(fmt, size, humanSizeBase, siUnit)
+}
 
 func ToByteSizeString(size float64) string {
 	return units.BytesSize(size)

--- a/pkg/util/units/units_test.go
+++ b/pkg/util/units/units_test.go
@@ -36,6 +36,39 @@ func TestToByteSizeString(t *testing.T) {
 	require.EqualValues(t, sizeInBytes, size)
 }
 
+func TestToHumanSizeStringWithoutUnit(t *testing.T) {
+	tcs := []struct {
+		size      float64
+		precision int
+		want      string
+	}{
+		{size: 0, precision: 0, want: "0"},
+		{size: 0, precision: 1, want: "0"},
+		{size: 1.49, precision: 0, want: "1"},
+		{size: 1.49, precision: 1, want: "1"},
+		{size: 1.49, precision: 2, want: "1.5"},
+		{size: 1.44, precision: 2, want: "1.4"},
+		{size: 1.50, precision: 1, want: "2"},
+		{size: 1.50, precision: 2, want: "1.5"},
+		{size: 1 << 10, precision: 1, want: "1k"},
+		{size: 10 << 10, precision: 1, want: "1e+01k"},
+		{size: 10 << 10, precision: 2, want: "10k"},
+		{size: 1 << 20, precision: 1, want: "1M"},
+		{size: 1 << 30, precision: 1, want: "1G"},
+		{size: 1 << 40, precision: 1, want: "1T"},
+		{size: 1 << 50, precision: 1, want: "1P"},
+		{size: 123456.78, precision: 6, want: "123.457k"},
+	}
+
+	for _, tc := range tcs {
+		tc := tc
+		t.Run(tc.want, func(t *testing.T) {
+			got := ToHumanSizeStringWithoutUnit(tc.size, tc.precision)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m)
 }


### PR DESCRIPTION
### What this PR does

Before:
```
___tgt__arpsR__arpsT_______abpsR_______abpsT__adurR__adurT__slpsR__slpsT_______sbpsR_______sbpsT__eelatR__eelatT
   1:123664.023244.1  92.44MiB/s   90.8MiB/s    4.0    4.0    0.0    0.0        0B/s        0B/s     0.0     0.0
```

Current:
```
target_____arps(now,tot)_________abps(now,tot)_adur(now,tot)_____slps(now,tot)_________sbps(now,tot)__eelat(now,tot)
   1:1  24.3k/s 23.38k/s 94.93MiB/s 91.32MiB/s  4.4ms  4.6ms      0/s      0/s       0B/s       0B/s   0.0ms   0.0ms
```
