### PR TITLE
feat(benchmark): share a connection between appenders in a target

### DIFF
--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -47,10 +47,11 @@ func New(opts ...Option) (bm *Benchmark, err error) {
 		target := bm.targets[idx]
 		loaderMetrics := &LoaderMetrics{tgt: target}
 		loader, err = NewLoader(loaderConfig{
-			Target:  target,
-			cid:     bm.cid,
-			mraddrs: bm.mraddrs,
-			metrics: loaderMetrics,
+			Target:              target,
+			cid:                 bm.cid,
+			mraddrs:             bm.mraddrs,
+			metrics:             loaderMetrics,
+			singleConnPerTarget: bm.singleConnPerTarget,
 		})
 		if err != nil {
 			return bm, err

--- a/internal/benchmark/config.go
+++ b/internal/benchmark/config.go
@@ -17,12 +17,13 @@ const (
 )
 
 type config struct {
-	cid            types.ClusterID
-	targets        []Target
-	mraddrs        []string
-	duration       time.Duration
-	reportInterval time.Duration
-	reportEncoder  ReportEncoder
+	cid                 types.ClusterID
+	targets             []Target
+	mraddrs             []string
+	duration            time.Duration
+	reportInterval      time.Duration
+	reportEncoder       ReportEncoder
+	singleConnPerTarget bool
 }
 
 func newConfig(opts []Option) (config, error) {
@@ -104,5 +105,11 @@ func WithReportInterval(reportInterval time.Duration) Option {
 func WithReportEncoder(enc ReportEncoder) Option {
 	return newFuncOption(func(cfg *config) {
 		cfg.reportEncoder = enc
+	})
+}
+
+func WithSingleConnPerTarget() Option {
+	return newFuncOption(func(cfg *config) {
+		cfg.singleConnPerTarget = true
 	})
 }


### PR DESCRIPTION
### What this PR does

This change adds a new flag, `--single-conn-per-target`, which makes appenders in a benchmark target share a connection.
