### PR TITLE
fix(benchmark): support graceful stop

### DIFF
--- a/internal/benchmark/benchmark.go
+++ b/internal/benchmark/benchmark.go
@@ -18,6 +18,7 @@ type Benchmark struct {
 	config
 	loaders []*Loader
 	metrics Metrics
+	stopC   chan struct{}
 }
 
 // New creates a new Benchmark and returns it. Users must call Close to release resources if it returns successfully.
@@ -34,6 +35,7 @@ func New(opts ...Option) (bm *Benchmark, err error) {
 
 	bm = &Benchmark{
 		config: cfg,
+		stopC:  make(chan struct{}),
 	}
 
 	defer func() {
@@ -52,6 +54,7 @@ func New(opts ...Option) (bm *Benchmark, err error) {
 			mraddrs:             bm.mraddrs,
 			metrics:             loaderMetrics,
 			singleConnPerTarget: bm.singleConnPerTarget,
+			stopC:               bm.stopC,
 		})
 		if err != nil {
 			return bm, err
@@ -65,8 +68,7 @@ func New(opts ...Option) (bm *Benchmark, err error) {
 
 // Run starts Loaders and metric reporter. It blocks until the loaders are finished.
 func (bm *Benchmark) Run() error {
-	ctx, cancel := context.WithCancel(context.Background())
-	g, ctx := errgroup.WithContext(ctx)
+	g, ctx := errgroup.WithContext(context.Background())
 
 	benchmarkTimer := time.NewTimer(bm.duration)
 
@@ -81,7 +83,7 @@ func (bm *Benchmark) Run() error {
 	wg.Add(1)
 	go func() {
 		defer func() {
-			cancel()
+			close(bm.stopC)
 			wg.Done()
 			fmt.Println(MustEncode(bm.reportEncoder, bm.metrics.Flush()))
 		}()


### PR DESCRIPTION
### What this PR does

This change makes the benchmark loader stop gracefully. Previously the benchmark loader stopped regardless of inflight requests. In terms of performance testing, it is not important though it is not intended. From now, the benchmark tool will stop its performance testing gracefully; that is, it won't terminate ongoing requests.

