### PR TITLE
perf(metarepos): avoid copy overhead by removing unnecessary converting from byte slice to string

### DIFF
--- a/internal/metarepos/raft.go
+++ b/internal/metarepos/raft.go
@@ -33,7 +33,7 @@ import (
 type raftNode struct {
 	raftConfig
 
-	proposeC    chan string              // proposed messages from app
+	proposeC    chan []byte              // proposed messages from app
 	confChangeC chan raftpb.ConfChange   // proposed cluster config changes
 	commitC     chan *raftCommittedEntry // entries committed to app
 	snapshotC   chan struct{}            // snapshot trigger
@@ -98,7 +98,7 @@ var purgeInterval = 30 * time.Second
 // current), then new log entries.
 func newRaftNode(cfg raftConfig,
 	snapshotGetter SnapshotGetter,
-	proposeC chan string,
+	proposeC chan []byte,
 	confChangeC chan raftpb.ConfChange,
 	tmStub *telemetryStub,
 	logger *zap.Logger) *raftNode {
@@ -707,7 +707,7 @@ Loop:
 
 			// blocks until accepted by raft state machine
 			// TODO:: handle dropped proposal
-			err := rc.node.Propose(context.TODO(), []byte(prop))
+			err := rc.node.Propose(context.TODO(), prop)
 			if err != nil {
 				rc.logger.Warn("proposal fail", zap.String("err", err.Error()))
 			}

--- a/internal/metarepos/raft_metadata_repository.go
+++ b/internal/metarepos/raft_metadata_repository.go
@@ -64,7 +64,7 @@ type RaftMetadataRepository struct {
 	proposeC      chan *mrpb.RaftEntry
 	commitC       chan *committedEntry
 	rnConfChangeC chan raftpb.ConfChange
-	rnProposeC    chan string
+	rnProposeC    chan []byte
 	rnCommitC     chan *raftCommittedEntry
 
 	// for report
@@ -110,7 +110,7 @@ func NewRaftMetadataRepository(opts ...Option) *RaftMetadataRepository {
 		proposeC:      make(chan *mrpb.RaftEntry, 4096),
 		commitC:       make(chan *committedEntry, 4096),
 		rnConfChangeC: make(chan raftpb.ConfChange, 1),
-		rnProposeC:    make(chan string),
+		rnProposeC:    make(chan []byte),
 		reportQueue:   make([]*mrpb.Report, 0, 1024),
 		runner:        runner.New("mr", cfg.logger),
 		sw:            stopwaiter.New(),
@@ -307,7 +307,7 @@ Loop:
 			}
 
 			select {
-			case mr.rnProposeC <- string(b):
+			case mr.rnProposeC <- b:
 			case <-ctx.Done():
 				mr.sendAck(e.NodeIndex, e.RequestIndex, ctx.Err())
 			}


### PR DESCRIPTION
### What this PR does

This change removes copy overhead caused by unnecessary type casting from byte slice to string. Refer to [this blog](https://www.sobyte.net/post/2022-09/string-byte-convertion/#performance-testing) for performance.
