### PR TITLE
perf(metarepos): add a pool for []*mrpb.Report

### DIFF
--- a/proto/mrpb/raft_entry.go
+++ b/proto/mrpb/raft_entry.go
@@ -22,7 +22,34 @@ func NewReports(nodeID types.NodeID, ts time.Time) *Reports {
 
 func (rs *Reports) Release() {
 	if rs != nil {
+		rq := (ReportQueue)(rs.Reports)
+		rq.Release()
 		*rs = Reports{}
 		reportsPool.Put(rs)
+	}
+}
+
+const (
+	reportQueueSize = 1024
+)
+
+type ReportQueue []*Report
+
+var reportQueuePool = sync.Pool{
+	New: func() any {
+		q := make(ReportQueue, 0, reportQueueSize)
+		return &q
+	},
+}
+
+func NewReportQueue() ReportQueue {
+	rq := reportQueuePool.Get().(*ReportQueue)
+	return *rq
+}
+
+func (rq *ReportQueue) Release() {
+	if rq != nil {
+		*rq = (*rq)[0:0:reportQueueSize]
+		reportQueuePool.Put(rq)
 	}
 }

--- a/proto/mrpb/raft_entry_test.go
+++ b/proto/mrpb/raft_entry_test.go
@@ -1,0 +1,84 @@
+package mrpb
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kakao/varlog/pkg/types"
+)
+
+func TestReports(t *testing.T) {
+	const nid = types.NodeID(1)
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 1e4; i++ {
+		reports := NewReports(nid, time.Now())
+		require.Empty(t, reports.Reports)
+
+		queue := NewReportQueue()
+		require.Empty(t, queue)
+		require.Equal(t, reportQueueSize, cap(queue))
+		numReports := rng.Intn(reportQueueSize*2) + 1
+		for j := 0; j < numReports; j++ {
+			queue = append(queue, &Report{})
+		}
+		require.Len(t, queue, numReports)
+		reports.Reports = queue
+
+		reports.Release()
+	}
+}
+
+func TestReportQueuePool(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for i := 0; i < 1e4; i++ {
+		queue := NewReportQueue()
+		require.Empty(t, queue)
+		require.Equal(t, reportQueueSize, cap(queue))
+
+		numReports := rng.Intn(reportQueueSize*2) + 1
+		for j := 0; j < numReports; j++ {
+			queue = append(queue, &Report{})
+		}
+		require.Len(t, queue, numReports)
+
+		queue.Release()
+	}
+}
+
+func BenchmarkReportQueuePool(b *testing.B) {
+	const numReports = 128
+	predefinedReports := make([]*Report, numReports)
+	for i := 0; i < numReports; i++ {
+		predefinedReports[i] = &Report{}
+	}
+	reports := &Reports{}
+
+	reports.Reports = make([]*Report, 0, reportQueueSize)
+	b.ResetTimer()
+	b.Run("WithoutPool", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			for j := 0; j < numReports; j++ {
+				reports.Reports = append(reports.Reports, predefinedReports[j])
+			}
+			reports.Reports = make([]*Report, 0, reportQueueSize)
+		}
+	})
+
+	reports.Reports = NewReportQueue()
+	b.ResetTimer()
+	b.Run("WithPool", func(b *testing.B) {
+		for n := 0; n < b.N; n++ {
+			for j := 0; j < numReports; j++ {
+				reports.Reports = append(reports.Reports, predefinedReports[j])
+			}
+			rq := (ReportQueue)(reports.Reports)
+			rq.Release()
+			reports.Reports = NewReportQueue()
+		}
+	})
+}


### PR DESCRIPTION
### What this PR does

This change adds the pool for []*mrpb.Report, which is reportQueuePool.

```
BenchmarkReportQueuePool/WithoutPool-16                   763526              1573 ns/op            8192 B/op          1 allocs/op
BenchmarkReportQueuePool/WithoutPool-16                   745612              1574 ns/op            8192 B/op          1 allocs/op
BenchmarkReportQueuePool/WithoutPool-16                   738848              1569 ns/op            8192 B/op          1 allocs/op
BenchmarkReportQueuePool/WithoutPool-16                   765339              1563 ns/op            8192 B/op          1 allocs/op
BenchmarkReportQueuePool/WithoutPool-16                   739354              1567 ns/op            8192 B/op          1 allocs/op
BenchmarkReportQueuePool/WithPool-16                     4445330               270.2 ns/op            24 B/op          1 allocs/op
BenchmarkReportQueuePool/WithPool-16                     4342182               271.9 ns/op            24 B/op          1 allocs/op
BenchmarkReportQueuePool/WithPool-16                     4517366               267.3 ns/op            24 B/op          1 allocs/op
BenchmarkReportQueuePool/WithPool-16                     4440441               263.5 ns/op            24 B/op          1 allocs/op
BenchmarkReportQueuePool/WithPool-16                     4666981               263.1 ns/op            24 B/op          1 allocs/op

```
