### PR TITLE
build(deps): bump github.com/cockroachdb/pebble from v0.0.0-20230701135918-609ae80aea41 to v0.0.0-20230716025533-809057a10ee4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/kakao/varlog
 go 1.20
 
 require (
-	github.com/cockroachdb/pebble v0.0.0-20230701135918-609ae80aea41
+	github.com/cockroachdb/pebble v0.0.0-20230716025533-809057a10ee4
 	github.com/docker/go-units v0.5.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/gogo/status v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/cockroachdb/errors v1.8.1 h1:A5+txlVZfOqFBDa4mGz2bUWSp0aHElvHX2bKkdbQ
 github.com/cockroachdb/errors v1.8.1/go.mod h1:qGwQn6JmZ+oMjuLwjWzUNqblqk0xl4CVV3SQbGwK7Ac=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f h1:o/kfcElHqOiXqcou5a3rIlMc7oJbMQkeLk0VQJ7zgqY=
 github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f/go.mod h1:i/u985jwjWRlyHXQbwatDASoW0RMlZ/3i9yJHE2xLkI=
-github.com/cockroachdb/pebble v0.0.0-20230701135918-609ae80aea41 h1:lYBVTS2P5fx79WWjoR/Gf4Fx5sZiIVCFWpuxntyiskY=
-github.com/cockroachdb/pebble v0.0.0-20230701135918-609ae80aea41/go.mod h1:FN5O47SBEz5+kO9fG8UTR64g2WS1u5ZFCgTvxGjoSks=
+github.com/cockroachdb/pebble v0.0.0-20230716025533-809057a10ee4 h1:+sVIlluXB1TKQebnED67QcRO6wyskLiLbrCZBQdL7LI=
+github.com/cockroachdb/pebble v0.0.0-20230716025533-809057a10ee4/go.mod h1:FN5O47SBEz5+kO9fG8UTR64g2WS1u5ZFCgTvxGjoSks=
 github.com/cockroachdb/redact v1.0.8 h1:8QG/764wK+vmEYoOlfobpe12EQcS81ukx/a4hdVMxNw=
 github.com/cockroachdb/redact v1.0.8/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
 github.com/cockroachdb/sentry-go v0.6.1-cockroachdb.2 h1:IKgmqgMQlVJIZj19CdocBeSfSaiCbEBZGKODaixqtHM=

--- a/vendor/github.com/cockroachdb/pebble/cleaner.go
+++ b/vendor/github.com/cockroachdb/pebble/cleaner.go
@@ -39,15 +39,16 @@ type cleanupManager struct {
 
 	mu struct {
 		sync.Mutex
-		queuedJobs        int
-		completedJobs     int
-		completedJobsCond sync.Cond
+		// totalJobs is the total number of enqueued jobs (completed or in progress).
+		totalJobs              int
+		completedJobs          int
+		completedJobsCond      sync.Cond
+		jobsQueueWarningIssued bool
 	}
 }
 
-// In practice, we should rarely have more than a couple of jobs (in most cases
-// we Wait() after queueing a job).
-const jobsChLen = 1000
+// We can queue this many jobs before we have to block EnqueueJob.
+const jobsQueueDepth = 1000
 
 // obsoleteFile holds information about a file that needs to be deleted soon.
 type obsoleteFile struct {
@@ -75,7 +76,7 @@ func openCleanupManager(
 		objProvider:     objProvider,
 		onTableDeleteFn: onTableDeleteFn,
 		deletePacer:     newDeletionPacer(time.Now(), int64(opts.TargetByteDeletionRate), getDeletePacerInfo),
-		jobsCh:          make(chan *cleanupJob, jobsChLen),
+		jobsCh:          make(chan *cleanupJob, jobsQueueDepth),
 	}
 	cm.mu.completedJobsCond.L = &cm.mu.Mutex
 	cm.waitGroup.Add(1)
@@ -118,12 +119,14 @@ func (cm *cleanupManager) EnqueueJob(jobID int, obsoleteFiles []obsoleteFile) {
 	}
 
 	cm.mu.Lock()
-	cm.mu.queuedJobs++
+	cm.mu.totalJobs++
+	cm.maybeLogLocked()
 	cm.mu.Unlock()
 
 	if invariants.Enabled && len(cm.jobsCh) >= cap(cm.jobsCh)-2 {
 		panic("cleanup jobs queue full")
 	}
+
 	cm.jobsCh <- job
 }
 
@@ -136,7 +139,7 @@ func (cm *cleanupManager) EnqueueJob(jobID int, obsoleteFiles []obsoleteFile) {
 func (cm *cleanupManager) Wait() {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
-	n := cm.mu.queuedJobs
+	n := cm.mu.totalJobs
 	for cm.mu.completedJobs < n {
 		cm.mu.completedJobsCond.Wait()
 	}
@@ -163,6 +166,7 @@ func (cm *cleanupManager) mainLoop() {
 		cm.mu.Lock()
 		cm.mu.completedJobs++
 		cm.mu.completedJobsCond.Broadcast()
+		cm.maybeLogLocked()
 		cm.mu.Unlock()
 	}
 }
@@ -266,5 +270,26 @@ func (cm *cleanupManager) deleteObsoleteObject(
 			FileNum: fileNum.FileNum(),
 			Err:     err,
 		})
+	}
+}
+
+// maybeLogLocked issues a log if the job queue gets 75% full and issues a log
+// when the job queue gets back to less than 10% full.
+//
+// Must be called with cm.mu locked.
+func (cm *cleanupManager) maybeLogLocked() {
+	const highThreshold = jobsQueueDepth * 3 / 4
+	const lowThreshold = jobsQueueDepth / 10
+
+	jobsInQueue := cm.mu.totalJobs - cm.mu.completedJobs
+
+	if !cm.mu.jobsQueueWarningIssued && jobsInQueue > highThreshold {
+		cm.mu.jobsQueueWarningIssued = true
+		cm.opts.Logger.Infof("cleanup falling behind; job queue has over %d jobs", highThreshold)
+	}
+
+	if cm.mu.jobsQueueWarningIssued && jobsInQueue < lowThreshold {
+		cm.mu.jobsQueueWarningIssued = false
+		cm.opts.Logger.Infof("cleanup back to normal; job queue has under %d jobs", lowThreshold)
 	}
 }

--- a/vendor/github.com/cockroachdb/pebble/compaction.go
+++ b/vendor/github.com/cockroachdb/pebble/compaction.go
@@ -566,6 +566,7 @@ type compaction struct {
 	// resulting version has been installed (if successful), but the compaction
 	// goroutine is still cleaning up (eg, deleting obsolete files).
 	versionEditApplied bool
+	bufferPool         sstable.BufferPool
 
 	score float64
 
@@ -1343,7 +1344,10 @@ func (c *compaction) newInputIter(
 		f manifest.LevelFile, _ *IterOptions, l manifest.Level, bytesIterated *uint64,
 	) (keyspan.FragmentIterator, error) {
 		iter, rangeDelIter, err := newIters(context.Background(), f.FileMetadata,
-			&IterOptions{level: l}, internalIterOpts{bytesIterated: &c.bytesIterated})
+			&IterOptions{level: l}, internalIterOpts{
+				bytesIterated: &c.bytesIterated,
+				bufferPool:    &c.bufferPool,
+			})
 		if err == nil {
 			// TODO(peter): It is mildly wasteful to open the point iterator only to
 			// immediately close it. One way to solve this would be to add new
@@ -1410,7 +1414,7 @@ func (c *compaction) newInputIter(
 			// any range tombstones completely outside file bounds.
 			rangeDelIter = keyspan.Truncate(
 				c.cmp, rangeDelIter, lowerBound.UserKey, upperBound.UserKey,
-				&f.Smallest, &f.Largest, false, /* panicOnPartialOverlap */
+				&f.Smallest, &f.Largest, false, /* panicOnUpperTruncate */
 			)
 		}
 		if rangeDelIter == nil {
@@ -1428,7 +1432,10 @@ func (c *compaction) newInputIter(
 	// to configure the levelIter at these levels to hide the obsolete points.
 	addItersForLevel := func(level *compactionLevel, l manifest.Level) error {
 		iters = append(iters, newLevelIter(iterOpts, c.cmp, nil /* split */, newIters,
-			level.files.Iter(), l, &c.bytesIterated))
+			level.files.Iter(), l, internalIterOpts{
+				bytesIterated: &c.bytesIterated,
+				bufferPool:    &c.bufferPool,
+			}))
 		// TODO(jackson): Use keyspan.LevelIter to avoid loading all the range
 		// deletions into memory upfront. (See #2015, which reverted this.)
 		// There will be no user keys that are split between sstables
@@ -2746,6 +2753,32 @@ func (d *DB) runCompaction(
 	d.mu.Unlock()
 	defer d.mu.Lock()
 
+	// Compactions use a pool of buffers to read blocks, avoiding polluting the
+	// block cache with blocks that will not be read again. We initialize the
+	// buffer pool with a size 12. This initial size does not need to be
+	// accurate, because the pool will grow to accommodate the maximum number of
+	// blocks allocated at a given time over the course of the compaction. But
+	// choosing a size larger than that working set avoids any additional
+	// allocations to grow the size of the pool over the course of iteration.
+	//
+	// Justification for initial size 12: In a two-level compaction, at any
+	// given moment we'll have 2 index blocks in-use and 2 data blocks in-use.
+	// Additionally, when decoding a compressed block, we'll temporarily
+	// allocate 1 additional block to hold the compressed buffer. In the worst
+	// case that all input sstables have two-level index blocks (+2), value
+	// blocks (+2), range deletion blocks (+n) and range key blocks (+n), we'll
+	// additionally require 2n+4 blocks where n is the number of input sstables.
+	// Range deletion and range key blocks are relatively rare, and the cost of
+	// an additional allocation or two over the course of the compaction is
+	// considered to be okay. A larger initial size would cause the pool to hold
+	// on to more memory, even when it's not in-use because the pool will
+	// recycle buffers up to the current capacity of the pool. The memory use of
+	// a 12-buffer pool is expected to be within reason, even if all the buffers
+	// grow to the typical size of an index block (256 KiB) which would
+	// translate to 3 MiB per compaction.
+	c.bufferPool.Init(12)
+	defer c.bufferPool.Release()
+
 	iiter, err := c.newInputIter(d.newIters, d.tableNewRangeKeyIter, snapshots)
 	if err != nil {
 		return nil, pendingOutputs, stats, err
@@ -3271,10 +3304,7 @@ func (d *DB) runCompaction(
 					return nil, pendingOutputs, stats, err
 				}
 			}
-			// iter.snapshotPinned is broader than whether the point was covered by
-			// a RANGEDEL, but it is harmless to pass true when the callee will also
-			// independently discover that the point is obsolete.
-			if err := tw.AddWithForceObsolete(*key, val, iter.snapshotPinned); err != nil {
+			if err := tw.AddWithForceObsolete(*key, val, iter.forceObsoleteDueToRangeDel); err != nil {
 				return nil, pendingOutputs, stats, err
 			}
 			if iter.snapshotPinned {

--- a/vendor/github.com/cockroachdb/pebble/db.go
+++ b/vendor/github.com/cockroachdb/pebble/db.go
@@ -1543,6 +1543,12 @@ func (d *DB) Close() error {
 		err = firstError(err, errors.Errorf("leaked memtable reservation: %d", errors.Safe(reserved)))
 	}
 
+	// Since we called d.readState.val.unrefLocked() above, we are expected to
+	// manually schedule deletion of obsolete files.
+	if len(d.mu.versions.obsoleteTables) > 0 {
+		d.deleteObsoleteFiles(d.mu.nextJobID)
+	}
+
 	d.mu.Unlock()
 	d.compactionSchedulers.Wait()
 

--- a/vendor/github.com/cockroachdb/pebble/flushable.go
+++ b/vendor/github.com/cockroachdb/pebble/flushable.go
@@ -172,7 +172,7 @@ func (s *ingestedFlushable) newIter(o *IterOptions) internalIterator {
 	// aren't truly levels in the lsm. Right now, the encoding only supports
 	// L0 sublevels, and the rest of the levels in the lsm.
 	return newLevelIter(
-		opts, s.cmp, s.split, s.newIters, s.slice.Iter(), manifest.Level(0), nil,
+		opts, s.cmp, s.split, s.newIters, s.slice.Iter(), manifest.Level(0), internalIterOpts{},
 	)
 }
 

--- a/vendor/github.com/cockroachdb/pebble/get_iter.go
+++ b/vendor/github.com/cockroachdb/pebble/get_iter.go
@@ -162,8 +162,14 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 				g.levelIter.init(context.Background(), iterOpts, g.cmp, nil /* split */, g.newIters,
 					files, manifest.L0Sublevel(n), internalIterOpts{})
 				g.levelIter.initRangeDel(&g.rangeDelIter)
+				bc := levelIterBoundaryContext{}
+				g.levelIter.initBoundaryContext(&bc)
 				g.iter = &g.levelIter
 				g.iterKey, g.iterValue = g.iter.SeekGE(g.key, base.SeekGEFlagsNone)
+				if bc.isSyntheticIterBoundsKey || bc.isIgnorableBoundaryKey {
+					g.iterKey = nil
+					g.iterValue = base.LazyValue{}
+				}
 				continue
 			}
 			g.level++
@@ -181,9 +187,15 @@ func (g *getIter) Next() (*InternalKey, base.LazyValue) {
 		g.levelIter.init(context.Background(), iterOpts, g.cmp, nil /* split */, g.newIters,
 			g.version.Levels[g.level].Iter(), manifest.Level(g.level), internalIterOpts{})
 		g.levelIter.initRangeDel(&g.rangeDelIter)
+		bc := levelIterBoundaryContext{}
+		g.levelIter.initBoundaryContext(&bc)
 		g.level++
 		g.iter = &g.levelIter
 		g.iterKey, g.iterValue = g.iter.SeekGE(g.key, base.SeekGEFlagsNone)
+		if bc.isSyntheticIterBoundsKey || bc.isIgnorableBoundaryKey {
+			g.iterKey = nil
+			g.iterValue = base.LazyValue{}
+		}
 	}
 }
 

--- a/vendor/github.com/cockroachdb/pebble/internal/cache/clockpro.go
+++ b/vendor/github.com/cockroachdb/pebble/internal/cache/clockpro.go
@@ -785,14 +785,14 @@ func (c *Cache) Size() int64 {
 // manually managed. The caller MUST either add the value to the cache (via
 // Cache.Set), or release the value (via Cache.Free). Failure to do so will
 // result in a memory leak.
-func (c *Cache) Alloc(n int) *Value {
+func Alloc(n int) *Value {
 	return newValue(n)
 }
 
 // Free frees the specified value. The buffer associated with the value will
 // possibly be reused, making it invalid to use the buffer after calling
 // Free. Do not call Free on a value that has been added to the cache.
-func (c *Cache) Free(v *Value) {
+func Free(v *Value) {
 	if n := v.refs(); n > 1 {
 		panic(fmt.Sprintf("pebble: Value has been added to the cache: refs=%d", n))
 	}

--- a/vendor/github.com/cockroachdb/pebble/internal/keyspan/truncate.go
+++ b/vendor/github.com/cockroachdb/pebble/internal/keyspan/truncate.go
@@ -14,7 +14,7 @@ func Truncate(
 	iter FragmentIterator,
 	lower, upper []byte,
 	start, end *base.InternalKey,
-	panicOnPartialOverlap bool,
+	panicOnUpperTruncate bool,
 ) FragmentIterator {
 	return Filter(iter, func(in *Span, out *Span) (keep bool) {
 		out.Start, out.End = in.Start, in.End
@@ -57,7 +57,6 @@ func Truncate(
 		var truncated bool
 		// Truncate the bounds to lower and upper.
 		if cmp(in.Start, lower) < 0 {
-			truncated = true
 			out.Start = lower
 		}
 		if cmp(in.End, upper) > 0 {
@@ -65,8 +64,8 @@ func Truncate(
 			out.End = upper
 		}
 
-		if panicOnPartialOverlap && truncated {
-			panic("pebble: bounds should not be truncated")
+		if panicOnUpperTruncate && truncated {
+			panic("pebble: upper bound should not be truncated")
 		}
 
 		return !out.Empty() && cmp(out.Start, out.End) < 0

--- a/vendor/github.com/cockroachdb/pebble/internal/manifest/version.go
+++ b/vendor/github.com/cockroachdb/pebble/internal/manifest/version.go
@@ -288,6 +288,33 @@ type PhysicalFileMeta struct {
 // VirtualFileMeta is used by functions which want a guarantee that their input
 // belongs to a virtual sst and not a physical sst.
 //
+// A VirtualFileMeta inherits all the same fields as a FileMetadata. These
+// fields have additional invariants imposed on them, and/or slightly varying
+// meanings:
+//   - Smallest and Largest (and their counterparts
+//     {Smallest, Largest}{Point,Range}Key) remain tight bounds that represent a
+//     key at that exact bound. We make the effort to determine the next smallest
+//     or largest key in an sstable after virtualizing it, to maintain this
+//     tightness. If the largest is a sentinel key (IsExclusiveSentinel()), it
+//     could mean that a rangedel or range key ends at that user key, or has been
+//     truncated to that user key.
+//   - One invariant is that if a rangedel or range key is truncated on its
+//     upper bound, the virtual sstable *must* have a rangedel or range key
+//     sentinel key as its upper bound. This is because truncation yields
+//     an exclusive upper bound for the rangedel/rangekey, and if there are
+//     any points at that exclusive upper bound within the same virtual
+//     sstable, those could get uncovered by this truncation. We enforce this
+//     invariant in calls to keyspan.Truncate.
+//   - Size is an estimate of the size of the virtualized portion of this sstable.
+//     The underlying file's size is stored in FileBacking.Size, though it could
+//     also be estimated or could correspond to just the referenced portion of
+//     a file (eg. if the file originated on another node).
+//   - SmallestSeqNum and LargestSeqNum are loose bounds for virtual sstables.
+//     This means that all keys in the virtual sstable must have seqnums within
+//     [SmallestSeqNum, LargestSeqNum], however there's no guarantee that there's
+//     a key with a seqnum at either of the bounds. Calculating tight seqnum
+//     bounds would be too expensive and deliver little value.
+//
 // NB: This type should only be constructed by calling FileMetadata.VirtualMeta.
 type VirtualFileMeta struct {
 	*FileMetadata

--- a/vendor/github.com/cockroachdb/pebble/level_iter.go
+++ b/vendor/github.com/cockroachdb/pebble/level_iter.go
@@ -51,6 +51,7 @@ func tableNewRangeDelIter(ctx context.Context, newIters tableNewIters) keyspan.T
 
 type internalIterOpts struct {
 	bytesIterated      *uint64
+	bufferPool         *sstable.BufferPool
 	stats              *base.InternalIteratorStats
 	boundLimitedFilter sstable.BoundLimitedBlockPropertyFilter
 }
@@ -246,11 +247,11 @@ func newLevelIter(
 	newIters tableNewIters,
 	files manifest.LevelIterator,
 	level manifest.Level,
-	bytesIterated *uint64,
+	internalOpts internalIterOpts,
 ) *levelIter {
 	l := &levelIter{}
 	l.init(context.Background(), opts, cmp, split, newIters, files, level,
-		internalIterOpts{bytesIterated: bytesIterated})
+		internalOpts)
 	return l
 }
 

--- a/vendor/github.com/cockroachdb/pebble/objstorage/objstorageprovider/provider.go
+++ b/vendor/github.com/cockroachdb/pebble/objstorage/objstorageprovider/provider.go
@@ -184,9 +184,9 @@ func open(settings Settings) (p *provider, _ error) {
 
 // Close is part of the objstorage.Provider interface.
 func (p *provider) Close() error {
-	var err error
+	err := p.sharedClose()
 	if p.fsDir != nil {
-		err = p.fsDir.Close()
+		err = firstError(err, p.fsDir.Close())
 		p.fsDir = nil
 	}
 	if objiotracing.Enabled {

--- a/vendor/github.com/cockroachdb/pebble/objstorage/objstorageprovider/shared.go
+++ b/vendor/github.com/cockroachdb/pebble/objstorage/objstorageprovider/shared.go
@@ -111,6 +111,22 @@ func (p *provider) sharedInit() error {
 	return nil
 }
 
+func (p *provider) sharedClose() error {
+	if p.st.Shared.StorageFactory == nil {
+		return nil
+	}
+	var err error
+	if p.shared.cache != nil {
+		err = p.shared.cache.Close()
+		p.shared.cache = nil
+	}
+	if p.shared.catalog != nil {
+		err = firstError(err, p.shared.catalog.Close())
+		p.shared.catalog = nil
+	}
+	return err
+}
+
 // SetCreatorID is part of the objstorage.Provider interface.
 func (p *provider) SetCreatorID(creatorID objstorage.CreatorID) error {
 	if p.st.Shared.StorageFactory == nil {

--- a/vendor/github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedobjcat/catalog.go
+++ b/vendor/github.com/cockroachdb/pebble/objstorage/objstorageprovider/sharedobjcat/catalog.go
@@ -218,28 +218,36 @@ func (c *Catalog) ApplyBatch(b Batch) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	for _, n := range b.ve.DeletedObjects {
-		if _, exists := c.mu.objects[n]; !exists {
-			return errors.AssertionFailedf("deleting non-existent object %s", n)
-		}
-	}
+	// Add new objects before deleting any objects. This allows for cases where
+	// the same batch adds and deletes an object.
 	for _, meta := range b.ve.NewObjects {
 		if _, exists := c.mu.objects[meta.FileNum]; exists {
 			return errors.AssertionFailedf("adding existing object %s", meta.FileNum)
 		}
+	}
+	for _, meta := range b.ve.NewObjects {
+		c.mu.objects[meta.FileNum] = meta
+	}
+	removeAddedObjects := func() {
+		for i := range b.ve.NewObjects {
+			delete(c.mu.objects, b.ve.NewObjects[i].FileNum)
+		}
+	}
+	for _, n := range b.ve.DeletedObjects {
+		if _, exists := c.mu.objects[n]; !exists {
+			removeAddedObjects()
+			return errors.AssertionFailedf("deleting non-existent object %s", n)
+		}
+	}
+	// Apply the remainder of the batch to our current state.
+	for _, n := range b.ve.DeletedObjects {
+		delete(c.mu.objects, n)
 	}
 
 	if err := c.writeToCatalogFileLocked(&b.ve); err != nil {
 		return errors.Wrapf(err, "pebble: could not write to shared object catalog: %v", err)
 	}
 
-	// Apply the batch to our current state.
-	for _, n := range b.ve.DeletedObjects {
-		delete(c.mu.objects, n)
-	}
-	for _, meta := range b.ve.NewObjects {
-		c.mu.objects[meta.FileNum] = meta
-	}
 	b.Reset()
 	return nil
 }

--- a/vendor/github.com/cockroachdb/pebble/objstorage/shared/localfs.go
+++ b/vendor/github.com/cockroachdb/pebble/objstorage/shared/localfs.go
@@ -1,0 +1,118 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package shared
+
+import (
+	"context"
+	"io"
+	"os"
+	"path"
+
+	"github.com/cockroachdb/pebble/vfs"
+)
+
+// NewLocalFS returns a vfs-backed implementation of the shared.Storage
+// interface (for testing). All objects will be stored at the directory
+// dirname.
+func NewLocalFS(dirname string, fs vfs.FS) Storage {
+	store := &localFSStore{
+		dirname: dirname,
+		vfs:     fs,
+	}
+	return store
+}
+
+// localFSStore is a vfs-backed implementation of the shared.Storage
+// interface (for testing).
+type localFSStore struct {
+	dirname string
+	vfs     vfs.FS
+}
+
+var _ Storage = (*localFSStore)(nil)
+
+// Close is part of the shared.Storage interface.
+func (s *localFSStore) Close() error {
+	*s = localFSStore{}
+	return nil
+}
+
+// ReadObject is part of the shared.Storage interface.
+func (s *localFSStore) ReadObject(
+	ctx context.Context, objName string,
+) (_ ObjectReader, objSize int64, _ error) {
+	f, err := s.vfs.Open(path.Join(s.dirname, objName))
+	if err != nil {
+		return nil, 0, err
+	}
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return &localFSReader{f}, stat.Size(), nil
+}
+
+type localFSReader struct {
+	file vfs.File
+}
+
+var _ ObjectReader = (*localFSReader)(nil)
+
+// ReadAt is part of the shared.ObjectReader interface.
+func (r *localFSReader) ReadAt(_ context.Context, p []byte, offset int64) error {
+	n, err := r.file.ReadAt(p, offset)
+	// https://pkg.go.dev/io#ReaderAt
+	if err == io.EOF && n == len(p) {
+		return nil
+	}
+	return err
+}
+
+// Close is part of the shared.ObjectReader interface.
+func (r *localFSReader) Close() error {
+	r.file.Close()
+	r.file = nil
+	return nil
+}
+
+// CreateObject is part of the shared.Storage interface.
+func (s *localFSStore) CreateObject(objName string) (io.WriteCloser, error) {
+	file, err := s.vfs.Create(path.Join(s.dirname, objName))
+	return file, err
+}
+
+// List is part of the shared.Storage interface.
+func (s *localFSStore) List(prefix, delimiter string) ([]string, error) {
+	// TODO(josh): For the intended use case of localfs.go of running 'pebble bench',
+	// List can always return <nil, nil>, since this indicates a file has only one ref,
+	// and since `pebble bench` implies running in a single-pebble-instance context.
+	// https://github.com/cockroachdb/pebble/blob/a9a079d4fb6bf4a9ebc52e4d83a76ad4cbf676cb/objstorage/objstorageprovider/shared.go#L292
+	return nil, nil
+}
+
+// Delete is part of the shared.Storage interface.
+func (s *localFSStore) Delete(objName string) error {
+	return s.vfs.Remove(path.Join(s.dirname, objName))
+}
+
+// Size is part of the shared.Storage interface.
+func (s *localFSStore) Size(objName string) (int64, error) {
+	f, err := s.vfs.Open(path.Join(s.dirname, objName))
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	stat, err := f.Stat()
+	if err != nil {
+		return 0, err
+	}
+	return stat.Size(), nil
+}
+
+// IsNotExistError is part of the shared.Storage interface.
+func (s *localFSStore) IsNotExistError(err error) bool {
+	return err == os.ErrNotExist
+}

--- a/vendor/github.com/cockroachdb/pebble/open.go
+++ b/vendor/github.com/cockroachdb/pebble/open.go
@@ -6,6 +6,7 @@ package pebble
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider"
 	"github.com/cockroachdb/pebble/record"
+	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -298,6 +300,7 @@ func Open(dirname string, opts *Options) (db *DB, _ error) {
 	providerSettings.Shared.StorageFactory = opts.Experimental.SharedStorage
 	providerSettings.Shared.CreateOnShared = opts.Experimental.CreateOnShared
 	providerSettings.Shared.CreateOnSharedLocator = opts.Experimental.CreateOnSharedLocator
+	providerSettings.Shared.CacheSizeBytes = opts.Experimental.SecondaryCacheSize
 
 	d.objProvider, err = objstorageprovider.Open(providerSettings)
 	if err != nil {
@@ -804,17 +807,36 @@ func (d *DB) replayWAL(
 					panic("pebble: invalid number of entries in batch.")
 				}
 
-				paths := make([]string, len(fileNums))
+				meta := make([]*fileMetadata, len(fileNums))
 				for i, n := range fileNums {
-					paths[i] = base.MakeFilepath(d.opts.FS, d.dirname, fileTypeTable, n)
-				}
+					var readable objstorage.Readable
+					objMeta, err := d.objProvider.Lookup(fileTypeTable, n)
+					if err != nil {
+						return nil, 0, errors.Wrap(err, "pebble: error when looking up ingested SSTs")
+					}
+					if objMeta.IsShared() {
+						readable, err = d.objProvider.OpenForReading(context.TODO(), fileTypeTable, n, objstorage.OpenOptions{MustExist: true})
+						if err != nil {
+							return nil, 0, errors.Wrap(err, "pebble: error when opening flushable ingest files")
+						}
+					} else {
+						path := base.MakeFilepath(d.opts.FS, d.dirname, fileTypeTable, n)
+						f, err := d.opts.FS.Open(path)
+						if err != nil {
+							return nil, 0, err
+						}
 
-				var lr ingestLoadResult
-				lr, err = ingestLoad(d.opts, d.FormatMajorVersion(), paths, nil, d.cacheID, fileNums)
-				if err != nil {
-					return nil, 0, err
+						readable, err = sstable.NewSimpleReadable(f)
+						if err != nil {
+							return nil, 0, err
+						}
+					}
+					// NB: ingestLoad1 will close readable.
+					meta[i], err = ingestLoad1(d.opts, d.FormatMajorVersion(), readable, d.cacheID, n)
+					if err != nil {
+						return nil, 0, errors.Wrap(err, "pebble: error when loading flushable ingest files")
+					}
 				}
-				meta := lr.localMeta
 
 				if uint32(len(meta)) != b.Count() {
 					panic("pebble: couldn't load all files in WAL entry.")
@@ -1086,9 +1108,15 @@ func checkConsistency(v *manifest.Version, dirname string, objProvider objstorag
 			dedup[backingState.DiskFileNum] = struct{}{}
 			fileNum := backingState.DiskFileNum
 			fileSize := backingState.Size
+			// We allow foreign objects to have a mismatch between sizes. This is
+			// because we might skew the backing size stored by our objprovider
+			// to prevent us from over-prioritizing this file for compaction.
 			meta, err := objProvider.Lookup(base.FileTypeTable, fileNum)
 			var size int64
 			if err == nil {
+				if objProvider.IsForeign(meta) {
+					continue
+				}
 				size, err = objProvider.Size(meta)
 			}
 			if err != nil {

--- a/vendor/github.com/cockroachdb/pebble/options.go
+++ b/vendor/github.com/cockroachdb/pebble/options.go
@@ -667,6 +667,10 @@ type Options struct {
 		// using CreateOnSharedLocator. Can only be used when SharedStorage is set.
 		CreateOnShared        bool
 		CreateOnSharedLocator shared.Locator
+
+		// CacheSizeBytes is the size of the on-disk block cache for objects
+		// on shared storage. If it is 0, no cache is used.
+		SecondaryCacheSize int64
 	}
 
 	// Filters is a map from filter policy name to filter policy. It is used for

--- a/vendor/github.com/cockroachdb/pebble/sstable/buffer_pool.go
+++ b/vendor/github.com/cockroachdb/pebble/sstable/buffer_pool.go
@@ -1,0 +1,148 @@
+// Copyright 2023 The LevelDB-Go and Pebble Authors. All rights reserved. Use
+// of this source code is governed by a BSD-style license that can be found in
+// the LICENSE file.
+
+package sstable
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble/internal/cache"
+)
+
+// A bufferHandle is a handle to manually-managed memory. The handle may point
+// to a block in the block cache (h.Get() != nil), or a buffer that exists
+// outside the block cache allocated from a BufferPool (b.Valid()).
+type bufferHandle struct {
+	h cache.Handle
+	b Buf
+}
+
+// Get retrieves the underlying buffer referenced by the handle.
+func (bh bufferHandle) Get() []byte {
+	if v := bh.h.Get(); v != nil {
+		return v
+	} else if bh.b.p != nil {
+		return bh.b.p.pool[bh.b.i].b
+	}
+	return nil
+}
+
+// Release releases the buffer, either back to the block cache or BufferPool.
+func (bh bufferHandle) Release() {
+	bh.h.Release()
+	bh.b.Release()
+}
+
+// A BufferPool holds a pool of buffers for holding sstable blocks. An initial
+// size of the pool is provided on Init, but a BufferPool will grow to meet the
+// largest working set size. It'll never shrink. When a buffer is released, the
+// BufferPool recycles the buffer for future allocations.
+//
+// A BufferPool should only be used for short-lived allocations with
+// well-understood working set sizes to avoid excessive memory consumption.
+//
+// BufferPool is not thread-safe.
+type BufferPool struct {
+	// pool contains all the buffers held by the pool, including buffers that
+	// are in-use. For every i < len(pool): pool[i].v is non-nil.
+	pool []allocedBuffer
+}
+
+type allocedBuffer struct {
+	v *cache.Value
+	// b holds the current byte slice. It's backed by v, but may be a subslice
+	// of v's memory while the buffer is in-use [ len(b) ≤ len(v.Buf()) ].
+	//
+	// If the buffer is not currently in-use, b is nil. When being recycled, the
+	// BufferPool.Alloc will reset b to be a subslice of v.Buf().
+	b []byte
+}
+
+// Init initializes the pool with an initial working set buffer size of
+// `initialSize`.
+func (p *BufferPool) Init(initialSize int) {
+	*p = BufferPool{
+		pool: make([]allocedBuffer, 0, initialSize),
+	}
+}
+
+// initPreallocated is like Init but for internal sstable package use in
+// instances where a pre-allocated slice of []allocedBuffer already exists. It's
+// used to avoid an extra allocation initializing BufferPool.pool.
+func (p *BufferPool) initPreallocated(pool []allocedBuffer) {
+	*p = BufferPool{
+		pool: pool[:0],
+	}
+}
+
+// Release releases all buffers held by the pool and resets the pool to an
+// uninitialized state.
+func (p *BufferPool) Release() {
+	for i := range p.pool {
+		if p.pool[i].b != nil {
+			panic(errors.AssertionFailedf("Release called on a BufferPool with in-use buffers"))
+		}
+		cache.Free(p.pool[i].v)
+	}
+	*p = BufferPool{}
+}
+
+// Alloc allocates a new buffer of size n. If the pool already holds a buffer at
+// least as large as n, the pooled buffer is used instead.
+//
+// Alloc is O(MAX(N,M)) where N is the largest number of concurrently in-use
+// buffers allocated and M is the initialSize passed to Init.
+func (p *BufferPool) Alloc(n int) Buf {
+	unusableBufferIdx := -1
+	for i := 0; i < len(p.pool); i++ {
+		if p.pool[i].b == nil {
+			if len(p.pool[i].v.Buf()) >= n {
+				p.pool[i].b = p.pool[i].v.Buf()[:n]
+				return Buf{p: p, i: i}
+			}
+			unusableBufferIdx = i
+		}
+	}
+
+	// If we would need to grow the size of the pool to allocate another buffer,
+	// but there was a slot available occupied by a buffer that's just too
+	// small, replace the too-small buffer.
+	if len(p.pool) == cap(p.pool) && unusableBufferIdx >= 0 {
+		i := unusableBufferIdx
+		cache.Free(p.pool[i].v)
+		p.pool[i].v = cache.Alloc(n)
+		p.pool[i].b = p.pool[i].v.Buf()
+		return Buf{p: p, i: i}
+	}
+
+	// Allocate a new buffer.
+	v := cache.Alloc(n)
+	p.pool = append(p.pool, allocedBuffer{v: v, b: v.Buf()[:n]})
+	return Buf{p: p, i: len(p.pool) - 1}
+}
+
+// A Buf holds a reference to a manually-managed, pooled byte buffer.
+type Buf struct {
+	p *BufferPool
+	// i holds the index into p.pool where the buffer may be found. This scheme
+	// avoids needing to allocate the handle to the buffer on the heap at the
+	// cost of copying two words instead of one.
+	i int
+}
+
+// Valid returns true if the buf holds a valid buffer.
+func (b Buf) Valid() bool {
+	return b.p != nil
+}
+
+// Release releases the buffer back to the pool.
+func (b *Buf) Release() {
+	if b.p == nil {
+		return
+	}
+	// Clear the allocedBuffer's byte slice. This signals the allocated buffer
+	// is no longer in use and a future call to BufferPool.Alloc may reuse this
+	// buffer.
+	b.p.pool[b.i].b = nil
+	b.p = nil
+}

--- a/vendor/github.com/cockroachdb/pebble/sstable/compression.go
+++ b/vendor/github.com/cockroachdb/pebble/sstable/compression.go
@@ -52,10 +52,10 @@ func decompressInto(blockType blockType, compressed []byte, buf []byte) ([]byte,
 	return result, nil
 }
 
-// decompressBlock decompresses an SST block, with space allocated from a cache.
+// decompressBlock decompresses an SST block, with manually-allocated space.
 // NB: If decompressBlock returns (nil, nil), no decompression was necessary and
 // the caller may use `b` directly.
-func decompressBlock(cache *cache.Cache, blockType blockType, b []byte) (*cache.Value, error) {
+func decompressBlock(blockType blockType, b []byte) (*cache.Value, error) {
 	if blockType == noCompressionBlockType {
 		return nil, nil
 	}

--- a/vendor/github.com/cockroachdb/pebble/sstable/format.go
+++ b/vendor/github.com/cockroachdb/pebble/sstable/format.go
@@ -91,7 +91,8 @@ const (
 // obsolete, i.e., obsolete within the sstable, and we can guarantee that at
 // most one point will be exposed per user key. MERGE keys create more
 // complexity: MERGE followed by MERGE causes multiple keys to not be
-// obsolete. Same applies for MERGE followed by SET/SETWITHDEL. Note that:
+// obsolete. Same applies for MERGE followed by SET/SETWITHDEL/DEL*. Note
+// that:
 //
 // - For regular sst iteration, the obsolete marking is a performance
 //   optimization, and multiple keys for the same userkey can be handled by

--- a/vendor/github.com/cockroachdb/pebble/sstable/reader.go
+++ b/vendor/github.com/cockroachdb/pebble/sstable/reader.go
@@ -224,6 +224,7 @@ type singleLevelIterator struct {
 	err          error
 	closeHook    func(i Iterator) error
 	stats        *base.InternalIteratorStats
+	bufferPool   *BufferPool
 
 	// boundsCmp and positionedUsingLatestBounds are for optimizing iteration
 	// that uses multiple adjacent bounds. The seek after setting a new bound
@@ -362,32 +363,32 @@ var rangeKeyFragmentBlockIterPool = sync.Pool{
 
 func checkSingleLevelIterator(obj interface{}) {
 	i := obj.(*singleLevelIterator)
-	if p := i.data.cacheHandle.Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "singleLevelIterator.data.cacheHandle is not nil: %p\n", p)
+	if p := i.data.handle.Get(); p != nil {
+		fmt.Fprintf(os.Stderr, "singleLevelIterator.data.handle is not nil: %p\n", p)
 		os.Exit(1)
 	}
-	if p := i.index.cacheHandle.Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "singleLevelIterator.index.cacheHandle is not nil: %p\n", p)
+	if p := i.index.handle.Get(); p != nil {
+		fmt.Fprintf(os.Stderr, "singleLevelIterator.index.handle is not nil: %p\n", p)
 		os.Exit(1)
 	}
 }
 
 func checkTwoLevelIterator(obj interface{}) {
 	i := obj.(*twoLevelIterator)
-	if p := i.data.cacheHandle.Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "singleLevelIterator.data.cacheHandle is not nil: %p\n", p)
+	if p := i.data.handle.Get(); p != nil {
+		fmt.Fprintf(os.Stderr, "singleLevelIterator.data.handle is not nil: %p\n", p)
 		os.Exit(1)
 	}
-	if p := i.index.cacheHandle.Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "singleLevelIterator.index.cacheHandle is not nil: %p\n", p)
+	if p := i.index.handle.Get(); p != nil {
+		fmt.Fprintf(os.Stderr, "singleLevelIterator.index.handle is not nil: %p\n", p)
 		os.Exit(1)
 	}
 }
 
 func checkRangeKeyFragmentBlockIterator(obj interface{}) {
 	i := obj.(*rangeKeyFragmentBlockIter)
-	if p := i.blockIter.cacheHandle.Get(); p != nil {
-		fmt.Fprintf(os.Stderr, "fragmentBlockIter.blockIter.cacheHandle is not nil: %p\n", p)
+	if p := i.blockIter.handle.Get(); p != nil {
+		fmt.Fprintf(os.Stderr, "fragmentBlockIter.blockIter.handle is not nil: %p\n", p)
 		os.Exit(1)
 	}
 }
@@ -408,6 +409,7 @@ func (i *singleLevelIterator) init(
 	useFilter, hideObsoletePoints bool,
 	stats *base.InternalIteratorStats,
 	rp ReaderProvider,
+	bufferPool *BufferPool,
 ) error {
 	if r.err != nil {
 		return r.err
@@ -430,6 +432,7 @@ func (i *singleLevelIterator) init(
 	i.cmp = r.Compare
 	i.stats = stats
 	i.hideObsoletePoints = hideObsoletePoints
+	i.bufferPool = bufferPool
 	err = i.index.initHandle(i.cmp, indexH, r.Properties.GlobalSeqNum, false)
 	if err != nil {
 		// blockIter.Close releases indexH and always returns a nil error
@@ -581,7 +584,7 @@ func (i *singleLevelIterator) loadBlock(dir int8) loadBlockResult {
 		// blockIntersects
 	}
 	ctx := objiotracing.WithBlockType(i.ctx, objiotracing.DataBlock)
-	block, err := i.reader.readBlock(ctx, i.dataBH, nil /* transform */, i.dataRH, i.stats)
+	block, err := i.reader.readBlock(ctx, i.dataBH, nil /* transform */, i.dataRH, i.stats, i.bufferPool)
 	if err != nil {
 		i.err = err
 		return loadBlockFailed
@@ -600,9 +603,9 @@ func (i *singleLevelIterator) loadBlock(dir int8) loadBlockResult {
 // the valueBlockReader.
 func (i *singleLevelIterator) readBlockForVBR(
 	ctx context.Context, h BlockHandle, stats *base.InternalIteratorStats,
-) (cache.Handle, error) {
+) (bufferHandle, error) {
 	ctx = objiotracing.WithBlockType(ctx, objiotracing.ValueBlock)
-	return i.reader.readBlock(ctx, h, nil, i.vbRH, stats)
+	return i.reader.readBlock(ctx, h, nil, i.vbRH, stats, i.bufferPool)
 }
 
 // resolveMaybeExcluded is invoked when the block-property filterer has found
@@ -967,7 +970,7 @@ func (i *singleLevelIterator) seekPrefixGE(
 		}
 		i.lastBloomFilterMatched = false
 		// Check prefix bloom filter.
-		var dataH cache.Handle
+		var dataH bufferHandle
 		dataH, i.err = i.reader.readFilter(i.ctx, i.stats)
 		if i.err != nil {
 			i.data.invalidate()
@@ -1780,7 +1783,7 @@ func (i *twoLevelIterator) loadIndex(dir int8) loadBlockResult {
 		// blockIntersects
 	}
 	ctx := objiotracing.WithBlockType(i.ctx, objiotracing.MetadataBlock)
-	indexBlock, err := i.reader.readBlock(ctx, bhp.BlockHandle, nil /* transform */, nil /* readHandle */, i.stats)
+	indexBlock, err := i.reader.readBlock(ctx, bhp.BlockHandle, nil /* transform */, nil /* readHandle */, i.stats, i.bufferPool)
 	if err != nil {
 		i.err = err
 		return loadBlockFailed
@@ -1866,6 +1869,7 @@ func (i *twoLevelIterator) init(
 	useFilter, hideObsoletePoints bool,
 	stats *base.InternalIteratorStats,
 	rp ReaderProvider,
+	bufferPool *BufferPool,
 ) error {
 	if r.err != nil {
 		return r.err
@@ -1889,6 +1893,7 @@ func (i *twoLevelIterator) init(
 	i.cmp = r.Compare
 	i.stats = stats
 	i.hideObsoletePoints = hideObsoletePoints
+	i.bufferPool = bufferPool
 	err = i.topLevelIndex.initHandle(i.cmp, topLevelIndexH, r.Properties.GlobalSeqNum, false)
 	if err != nil {
 		// blockIter.Close releases topLevelIndexH and always returns a nil error
@@ -2130,7 +2135,7 @@ func (i *twoLevelIterator) SeekPrefixGE(
 			flags = flags.DisableTrySeekUsingNext()
 		}
 		i.lastBloomFilterMatched = false
-		var dataH cache.Handle
+		var dataH bufferHandle
 		dataH, i.err = i.reader.readFilter(i.ctx, i.stats)
 		if i.err != nil {
 			i.data.invalidate()
@@ -2924,9 +2929,9 @@ func MakeVirtualReader(reader *Reader, meta manifest.VirtualFileMeta) VirtualRea
 
 // NewCompactionIter is the compaction iterator function for virtual readers.
 func (v *VirtualReader) NewCompactionIter(
-	bytesIterated *uint64, rp ReaderProvider,
+	bytesIterated *uint64, rp ReaderProvider, bufferPool *BufferPool,
 ) (Iterator, error) {
-	return v.reader.newCompactionIter(bytesIterated, rp, &v.vState)
+	return v.reader.newCompactionIter(bytesIterated, rp, &v.vState, bufferPool)
 }
 
 // NewIterWithBlockPropertyFiltersAndContextEtc wraps
@@ -2956,11 +2961,19 @@ func (v *VirtualReader) NewRawRangeDelIter() (keyspan.FragmentIterator, error) {
 		return nil, nil
 	}
 
-	// There should be no spans which cross virtual sstable bounds. So, no
-	// truncation should occur.
+	// Truncation of spans isn't allowed at a user key that also contains points
+	// in the same virtual sstable, as it would lead to covered points getting
+	// uncovered. Set panicOnUpperTruncate to true if the file's upper bound
+	// is not an exclusive sentinel.
+	//
+	// As an example, if an sstable contains a rangedel a-c and point keys at
+	// a.SET.2 and b.SET.3, the file bounds [a#2,SET-b#RANGEDELSENTINEL] are
+	// allowed (as they exclude b.SET.3), or [a#2,SET-c#RANGEDELSENTINEL] (as it
+	// includes both point keys), but not [a#2,SET-b#3,SET] (as it would truncate
+	// the rangedel at b and lead to the point being uncovered).
 	return keyspan.Truncate(
 		v.reader.Compare, iter, v.vState.lower.UserKey, v.vState.upper.UserKey,
-		&v.vState.lower, &v.vState.upper, true, /* panicOnPartialOverlap */
+		&v.vState.lower, &v.vState.upper, !v.vState.upper.IsExclusiveSentinel(), /* panicOnUpperTruncate */
 	), nil
 }
 
@@ -2974,11 +2987,19 @@ func (v *VirtualReader) NewRawRangeKeyIter() (keyspan.FragmentIterator, error) {
 		return nil, nil
 	}
 
-	// There should be no spans which cross virtual sstable bounds. So, no
-	// truncation should occur.
+	// Truncation of spans isn't allowed at a user key that also contains points
+	// in the same virtual sstable, as it would lead to covered points getting
+	// uncovered. Set panicOnUpperTruncate to true if the file's upper bound
+	// is not an exclusive sentinel.
+	//
+	// As an example, if an sstable contains a range key a-c and point keys at
+	// a.SET.2 and b.SET.3, the file bounds [a#2,SET-b#RANGEKEYSENTINEL] are
+	// allowed (as they exclude b.SET.3), or [a#2,SET-c#RANGEKEYSENTINEL] (as it
+	// includes both point keys), but not [a#2,SET-b#3,SET] (as it would truncate
+	// the range key at b and lead to the point being uncovered).
 	return keyspan.Truncate(
 		v.reader.Compare, iter, v.vState.lower.UserKey, v.vState.upper.UserKey,
-		&v.vState.lower, &v.vState.upper, true, /* panicOnPartialOverlap */
+		&v.vState.lower, &v.vState.upper, !v.vState.upper.IsExclusiveSentinel(), /* panicOnUpperTruncate */
 	), nil
 }
 
@@ -3050,6 +3071,14 @@ type Reader struct {
 	rawTombstones bool
 	mergerOK      bool
 	checksumType  ChecksumType
+	// metaBufferPool is a buffer pool used exclusively when opening a table and
+	// loading its meta blocks. metaBufferPoolAlloc is used to batch-allocate
+	// the BufferPool.pool slice as a part of the Reader allocation. It's
+	// capacity 3 to accommodate the meta block (1), and both the compressed
+	// properties block (1) and decompressed properties block (1)
+	// simultaneously.
+	metaBufferPool      BufferPool
+	metaBufferPoolAlloc [3]allocedBuffer
 }
 
 // Close implements DB.Close, as documented in the pebble package.
@@ -3136,7 +3165,7 @@ func (r *Reader) newIterWithBlockPropertyFiltersAndContext(
 	// until the final iterator closes.
 	if r.Properties.IndexType == twoLevelIndex {
 		i := twoLevelIterPool.Get().(*twoLevelIterator)
-		err := i.init(ctx, r, v, lower, upper, filterer, useFilterBlock, hideObsoletePoints, stats, rp)
+		err := i.init(ctx, r, v, lower, upper, filterer, useFilterBlock, hideObsoletePoints, stats, rp, nil /* bufferPool */)
 		if err != nil {
 			return nil, err
 		}
@@ -3144,7 +3173,7 @@ func (r *Reader) newIterWithBlockPropertyFiltersAndContext(
 	}
 
 	i := singleLevelIterPool.Get().(*singleLevelIterator)
-	err := i.init(ctx, r, v, lower, upper, filterer, useFilterBlock, hideObsoletePoints, stats, rp)
+	err := i.init(ctx, r, v, lower, upper, filterer, useFilterBlock, hideObsoletePoints, stats, rp, nil /* bufferPool */)
 	if err != nil {
 		return nil, err
 	}
@@ -3164,12 +3193,14 @@ func (r *Reader) NewIter(lower, upper []byte) (Iterator, error) {
 // NewCompactionIter returns an iterator similar to NewIter but it also increments
 // the number of bytes iterated. If an error occurs, NewCompactionIter cleans up
 // after itself and returns a nil iterator.
-func (r *Reader) NewCompactionIter(bytesIterated *uint64, rp ReaderProvider) (Iterator, error) {
-	return r.newCompactionIter(bytesIterated, rp, nil)
+func (r *Reader) NewCompactionIter(
+	bytesIterated *uint64, rp ReaderProvider, bufferPool *BufferPool,
+) (Iterator, error) {
+	return r.newCompactionIter(bytesIterated, rp, nil, bufferPool)
 }
 
 func (r *Reader) newCompactionIter(
-	bytesIterated *uint64, rp ReaderProvider, v *virtualState,
+	bytesIterated *uint64, rp ReaderProvider, v *virtualState, bufferPool *BufferPool,
 ) (Iterator, error) {
 	if r.Properties.IndexType == twoLevelIndex {
 		i := twoLevelIterPool.Get().(*twoLevelIterator)
@@ -3177,7 +3208,7 @@ func (r *Reader) newCompactionIter(
 			context.Background(),
 			r, v, nil /* lower */, nil /* upper */, nil,
 			false /* useFilter */, false, /* hideObsoletePoints */
-			nil /* stats */, rp,
+			nil /* stats */, rp, bufferPool,
 		)
 		if err != nil {
 			return nil, err
@@ -3192,7 +3223,7 @@ func (r *Reader) newCompactionIter(
 	err := i.init(
 		context.Background(), r, v, nil /* lower */, nil, /* upper */
 		nil, false /* useFilter */, false, /* hideObsoletePoints */
-		nil /* stats */, rp,
+		nil /* stats */, rp, bufferPool,
 	)
 	if err != nil {
 		return nil, err
@@ -3259,26 +3290,26 @@ func (i *rangeKeyFragmentBlockIter) Close() error {
 
 func (r *Reader) readIndex(
 	ctx context.Context, stats *base.InternalIteratorStats,
-) (cache.Handle, error) {
+) (bufferHandle, error) {
 	ctx = objiotracing.WithBlockType(ctx, objiotracing.MetadataBlock)
-	return r.readBlock(ctx, r.indexBH, nil, nil, stats)
+	return r.readBlock(ctx, r.indexBH, nil, nil, stats, nil /* buffer pool */)
 }
 
 func (r *Reader) readFilter(
 	ctx context.Context, stats *base.InternalIteratorStats,
-) (cache.Handle, error) {
+) (bufferHandle, error) {
 	ctx = objiotracing.WithBlockType(ctx, objiotracing.FilterBlock)
-	return r.readBlock(ctx, r.filterBH, nil /* transform */, nil /* readHandle */, stats)
+	return r.readBlock(ctx, r.filterBH, nil /* transform */, nil /* readHandle */, stats, nil /* buffer pool */)
 }
 
-func (r *Reader) readRangeDel(stats *base.InternalIteratorStats) (cache.Handle, error) {
+func (r *Reader) readRangeDel(stats *base.InternalIteratorStats) (bufferHandle, error) {
 	ctx := objiotracing.WithBlockType(context.Background(), objiotracing.MetadataBlock)
-	return r.readBlock(ctx, r.rangeDelBH, r.rangeDelTransform, nil /* readHandle */, stats)
+	return r.readBlock(ctx, r.rangeDelBH, r.rangeDelTransform, nil /* readHandle */, stats, nil /* buffer pool */)
 }
 
-func (r *Reader) readRangeKey(stats *base.InternalIteratorStats) (cache.Handle, error) {
+func (r *Reader) readRangeKey(stats *base.InternalIteratorStats) (bufferHandle, error) {
 	ctx := objiotracing.WithBlockType(context.Background(), objiotracing.MetadataBlock)
-	return r.readBlock(ctx, r.rangeKeyBH, nil /* transform */, nil /* readHandle */, stats)
+	return r.readBlock(ctx, r.rangeKeyBH, nil /* transform */, nil /* readHandle */, stats, nil /* buffer pool */)
 }
 
 func checkChecksum(
@@ -3303,15 +3334,46 @@ func checkChecksum(
 	return nil
 }
 
-// readBlock reads and decompresses a block from disk into memory.
+type cacheValueOrBuf struct {
+	// buf.Valid() returns true if backed by a BufferPool.
+	buf Buf
+	// v is non-nil if backed by the block cache.
+	v *cache.Value
+}
+
+func (b cacheValueOrBuf) get() []byte {
+	if b.buf.Valid() {
+		return b.buf.p.pool[b.buf.i].b
+	}
+	return b.v.Buf()
+}
+
+func (b cacheValueOrBuf) release() {
+	if b.buf.Valid() {
+		b.buf.Release()
+	} else {
+		cache.Free(b.v)
+	}
+}
+
+func (b cacheValueOrBuf) truncate(n int) {
+	if b.buf.Valid() {
+		b.buf.p.pool[b.buf.i].b = b.buf.p.pool[b.buf.i].b[:n]
+	} else {
+		b.v.Truncate(n)
+	}
+}
+
 func (r *Reader) readBlock(
 	ctx context.Context,
 	bh BlockHandle,
 	transform blockTransform,
 	readHandle objstorage.ReadHandle,
 	stats *base.InternalIteratorStats,
-) (handle cache.Handle, _ error) {
+	bufferPool *BufferPool,
+) (handle bufferHandle, _ error) {
 	if h := r.opts.Cache.Get(r.cacheID, r.fileNum, bh.Offset); h.Get() != nil {
+		// Cache hit.
 		if readHandle != nil {
 			readHandle.RecordCacheHit(ctx, int64(bh.Offset), int64(bh.Length+blockTrailerLen))
 		}
@@ -3319,17 +3381,29 @@ func (r *Reader) readBlock(
 			stats.BlockBytes += bh.Length
 			stats.BlockBytesInCache += bh.Length
 		}
-		return h, nil
+		// This block is already in the cache; return a handle to existing vlaue
+		// in the cache.
+		return bufferHandle{h: h}, nil
 	}
 
-	v := r.opts.Cache.Alloc(int(bh.Length + blockTrailerLen))
-	b := v.Buf()
+	// Cache miss.
+	var compressed cacheValueOrBuf
+	if bufferPool != nil {
+		compressed = cacheValueOrBuf{
+			buf: bufferPool.Alloc(int(bh.Length + blockTrailerLen)),
+		}
+	} else {
+		compressed = cacheValueOrBuf{
+			v: cache.Alloc(int(bh.Length + blockTrailerLen)),
+		}
+	}
+
 	readStartTime := time.Now()
 	var err error
 	if readHandle != nil {
-		err = readHandle.ReadAt(ctx, b, int64(bh.Offset))
+		err = readHandle.ReadAt(ctx, compressed.get(), int64(bh.Offset))
 	} else {
-		err = r.readable.ReadAt(ctx, b, int64(bh.Offset))
+		err = r.readable.ReadAt(ctx, compressed.get(), int64(bh.Offset))
 	}
 	readDuration := time.Since(readStartTime)
 	// TODO(sumeer): should the threshold be configurable.
@@ -3342,56 +3416,74 @@ func (r *Reader) readBlock(
 	// interface{}, unless necessary.
 	if readDuration >= slowReadTracingThreshold && r.opts.LoggerAndTracer.IsTracingEnabled(ctx) {
 		r.opts.LoggerAndTracer.Eventf(ctx, "reading %d bytes took %s",
-			bh.Length+blockTrailerLen, readDuration.String())
+			int(bh.Length+blockTrailerLen), readDuration.String())
 	}
 	if stats != nil {
 		stats.BlockReadDuration += readDuration
 	}
 	if err != nil {
-		r.opts.Cache.Free(v)
-		return cache.Handle{}, err
+		compressed.release()
+		return bufferHandle{}, err
+	}
+	if err := checkChecksum(r.checksumType, compressed.get(), bh, r.fileNum.FileNum()); err != nil {
+		compressed.release()
+		return bufferHandle{}, err
 	}
 
-	if err := checkChecksum(r.checksumType, b, bh, r.fileNum.FileNum()); err != nil {
-		r.opts.Cache.Free(v)
-		return cache.Handle{}, err
-	}
+	typ := blockType(compressed.get()[bh.Length])
+	compressed.truncate(int(bh.Length))
 
-	typ := blockType(b[bh.Length])
-	b = b[:bh.Length]
-	v.Truncate(len(b))
+	var decompressed cacheValueOrBuf
+	if typ == noCompressionBlockType {
+		decompressed = compressed
+	} else {
+		// Decode the length of the decompressed value.
+		decodedLen, prefixLen, err := decompressedLen(typ, compressed.get())
+		if err != nil {
+			compressed.release()
+			return bufferHandle{}, err
+		}
 
-	decoded, err := decompressBlock(r.opts.Cache, typ, b)
-	if decoded != nil {
-		r.opts.Cache.Free(v)
-		v = decoded
-		b = v.Buf()
-	} else if err != nil {
-		r.opts.Cache.Free(v)
-		return cache.Handle{}, err
+		if bufferPool != nil {
+			decompressed = cacheValueOrBuf{buf: bufferPool.Alloc(decodedLen)}
+		} else {
+			decompressed = cacheValueOrBuf{v: cache.Alloc(decodedLen)}
+		}
+		if _, err := decompressInto(typ, compressed.get()[prefixLen:], decompressed.get()); err != nil {
+			compressed.release()
+			return bufferHandle{}, err
+		}
+		compressed.release()
 	}
 
 	if transform != nil {
-		// Transforming blocks is rare, so the extra copy of the transformed data
-		// is not problematic.
-		var err error
-		b, err = transform(b)
+		// Transforming blocks is very rare, so the extra copy of the
+		// transformed data is not problematic.
+		tmpTransformed, err := transform(decompressed.get())
 		if err != nil {
-			r.opts.Cache.Free(v)
-			return cache.Handle{}, err
+			decompressed.release()
+			return bufferHandle{}, err
 		}
-		newV := r.opts.Cache.Alloc(len(b))
-		copy(newV.Buf(), b)
-		r.opts.Cache.Free(v)
-		v = newV
+
+		var transformed cacheValueOrBuf
+		if bufferPool != nil {
+			transformed = cacheValueOrBuf{buf: bufferPool.Alloc(len(tmpTransformed))}
+		} else {
+			transformed = cacheValueOrBuf{v: cache.Alloc(len(tmpTransformed))}
+		}
+		copy(transformed.get(), tmpTransformed)
+		decompressed.release()
+		decompressed = transformed
 	}
 
 	if stats != nil {
 		stats.BlockBytes += bh.Length
 	}
-
-	h := r.opts.Cache.Set(r.cacheID, r.fileNum, bh.Offset, v)
-	return h, nil
+	if decompressed.buf.Valid() {
+		return bufferHandle{b: decompressed.buf}, nil
+	}
+	h := r.opts.Cache.Set(r.cacheID, r.fileNum, bh.Offset, decompressed.v)
+	return bufferHandle{h: h}, nil
 }
 
 func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
@@ -3438,8 +3530,21 @@ func (r *Reader) transformRangeDelV1(b []byte) ([]byte, error) {
 }
 
 func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
+	// We use a BufferPool when reading metaindex blocks in order to avoid
+	// populating the block cache with these blocks. In heavy-write workloads,
+	// especially with high compaction concurrency, new tables may be created
+	// frequently. Populating the block cache with these metaindex blocks adds
+	// additional contention on the block cache mutexes (see #1997).
+	// Additionally, these blocks are exceedingly unlikely to be read again
+	// while they're still in the block cache except in misconfigurations with
+	// excessive sstables counts or a table cache that's far too small.
+	r.metaBufferPool.initPreallocated(r.metaBufferPoolAlloc[:0])
+	// When we're finished, release the buffers we've allocated back to memory
+	// allocator. We don't expect to use metaBufferPool again.
+	defer r.metaBufferPool.Release()
+
 	b, err := r.readBlock(
-		context.Background(), metaindexBH, nil /* transform */, nil /* readHandle */, nil /* stats */)
+		context.Background(), metaindexBH, nil /* transform */, nil /* readHandle */, nil /* stats */, &r.metaBufferPool)
 	if err != nil {
 		return err
 	}
@@ -3482,7 +3587,7 @@ func (r *Reader) readMetaindex(metaindexBH BlockHandle) error {
 
 	if bh, ok := meta[metaPropertiesName]; ok {
 		b, err = r.readBlock(
-			context.Background(), bh, nil /* transform */, nil /* readHandle */, nil /* stats */)
+			context.Background(), bh, nil /* transform */, nil /* readHandle */, nil /* stats */, nil /* buffer pool */)
 		if err != nil {
 			return err
 		}
@@ -3587,8 +3692,8 @@ func (r *Reader) Layout() (*Layout, error) {
 			}
 			l.Index = append(l.Index, indexBH.BlockHandle)
 
-			subIndex, err := r.readBlock(context.Background(),
-				indexBH.BlockHandle, nil /* transform */, nil /* readHandle */, nil /* stats */)
+			subIndex, err := r.readBlock(context.Background(), indexBH.BlockHandle,
+				nil /* transform */, nil /* readHandle */, nil /* stats */, nil /* buffer pool */)
 			if err != nil {
 				return nil, err
 			}
@@ -3611,7 +3716,7 @@ func (r *Reader) Layout() (*Layout, error) {
 		}
 	}
 	if r.valueBIH.h.Length != 0 {
-		vbiH, err := r.readBlock(context.Background(), r.valueBIH.h, nil, nil, nil)
+		vbiH, err := r.readBlock(context.Background(), r.valueBIH.h, nil, nil, nil, nil /* buffer pool */)
 		if err != nil {
 			return nil, err
 		}
@@ -3682,7 +3787,7 @@ func (r *Reader) ValidateBlockChecksums() error {
 		}
 
 		// Read the block, which validates the checksum.
-		h, err := r.readBlock(context.Background(), bh, nil, rh, nil)
+		h, err := r.readBlock(context.Background(), bh, nil, rh, nil, nil /* buffer pool */)
 		if err != nil {
 			return err
 		}
@@ -3744,8 +3849,8 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 		if err != nil {
 			return 0, errCorruptIndexEntry
 		}
-		startIdxBlock, err := r.readBlock(context.Background(),
-			startIdxBH.BlockHandle, nil /* transform */, nil /* readHandle */, nil /* stats */)
+		startIdxBlock, err := r.readBlock(context.Background(), startIdxBH.BlockHandle,
+			nil /* transform */, nil /* readHandle */, nil /* stats */, nil /* buffer pool */)
 		if err != nil {
 			return 0, err
 		}
@@ -3766,7 +3871,7 @@ func (r *Reader) EstimateDiskUsage(start, end []byte) (uint64, error) {
 				return 0, errCorruptIndexEntry
 			}
 			endIdxBlock, err := r.readBlock(context.Background(),
-				endIdxBH.BlockHandle, nil /* transform */, nil /* readHandle */, nil /* stats */)
+				endIdxBH.BlockHandle, nil /* transform */, nil /* readHandle */, nil /* stats */, nil /* buffer pool */)
 			if err != nil {
 				return 0, err
 			}
@@ -4043,7 +4148,7 @@ func (l *Layout) Describe(
 		}
 
 		h, err := r.readBlock(
-			context.Background(), b.BlockHandle, nil /* transform */, nil /* readHandle */, nil /* stats */)
+			context.Background(), b.BlockHandle, nil /* transform */, nil /* readHandle */, nil /* stats */, nil /* buffer pool */)
 		if err != nil {
 			fmt.Fprintf(w, "  [err: %s]\n", err)
 			continue

--- a/vendor/github.com/cockroachdb/pebble/sstable/value_block.go
+++ b/vendor/github.com/cockroachdb/pebble/sstable/value_block.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/internal/base"
-	"github.com/cockroachdb/pebble/internal/cache"
 	"github.com/cockroachdb/pebble/internal/invariants"
 	"github.com/cockroachdb/pebble/objstorage/objstorageprovider/objiotracing"
 	"golang.org/x/exp/rand"
@@ -728,7 +727,7 @@ func (ukb *UserKeyPrefixBound) IsEmpty() bool {
 type blockProviderWhenOpen interface {
 	readBlockForVBR(
 		ctx context.Context, h BlockHandle, stats *base.InternalIteratorStats,
-	) (cache.Handle, error)
+	) (bufferHandle, error)
 }
 
 type blockProviderWhenClosed struct {
@@ -749,9 +748,12 @@ func (bpwc *blockProviderWhenClosed) close() {
 
 func (bpwc blockProviderWhenClosed) readBlockForVBR(
 	ctx context.Context, h BlockHandle, stats *base.InternalIteratorStats,
-) (cache.Handle, error) {
+) (bufferHandle, error) {
 	ctx = objiotracing.WithBlockType(ctx, objiotracing.ValueBlock)
-	return bpwc.r.readBlock(ctx, h, nil, nil, stats)
+	// TODO(jackson,sumeer): Consider whether to use a buffer pool in this case.
+	// The bpwc is not allowed to outlive the iterator tree, so it cannot
+	// outlive the buffer pool.
+	return bpwc.r.readBlock(ctx, h, nil, nil, stats, nil /* buffer pool */)
 }
 
 // ReaderProvider supports the implementation of blockProviderWhenClosed.
@@ -790,16 +792,16 @@ type valueBlockReader struct {
 	// The value blocks index is lazily retrieved the first time the reader
 	// needs to read a value that resides in a value block.
 	vbiBlock []byte
-	vbiCache cache.Handle
+	vbiCache bufferHandle
 	// When sequentially iterating through all key-value pairs, the cost of
 	// repeatedly getting a block that is already in the cache and releasing the
-	// cache.Handle can be ~40% of the cpu overhead. So the reader remembers the
+	// bufferHandle can be ~40% of the cpu overhead. So the reader remembers the
 	// last value block it retrieved, in case there is locality of access, and
 	// this value block can be used for the next value retrieval.
 	valueBlockNum uint32
 	valueBlock    []byte
 	valueBlockPtr unsafe.Pointer
-	valueCache    cache.Handle
+	valueCache    bufferHandle
 	lazyFetcher   base.LazyFetcher
 	closed        bool
 	bufToMangle   []byte
@@ -833,12 +835,12 @@ func (r *valueBlockReader) close() {
 	// we were to reopen this valueBlockReader and retrieve the same
 	// Handle.value from the cache, we don't want to accidentally unref it when
 	// attempting to unref the old handle.
-	r.vbiCache = cache.Handle{}
+	r.vbiCache = bufferHandle{}
 	r.valueBlock = nil
 	r.valueBlockPtr = nil
 	r.valueCache.Release()
 	// See comment above.
-	r.valueCache = cache.Handle{}
+	r.valueCache = bufferHandle{}
 	r.closed = true
 	// rp, vbih, stats remain valid, so that LazyFetcher.ValueFetcher can be
 	// implemented.

--- a/vendor/github.com/cockroachdb/pebble/sstable/writer.go
+++ b/vendor/github.com/cockroachdb/pebble/sstable/writer.go
@@ -852,32 +852,35 @@ func (w *Writer) makeAddPointDecisionV3(
 	} else {
 		cmpUser = w.compare(prevPointUserKey, key.UserKey)
 	}
-	keyKindIsSetOrMerge := keyKind == InternalKeyKindSet || keyKind == InternalKeyKindSetWithDelete ||
-		keyKind == InternalKeyKindMerge
-	keyKindIsPointDelete := keyKind == InternalKeyKindDelete ||
-		keyKind == InternalKeyKindSingleDelete || keyKind == InternalKeyKindDeleteSized
-	if !keyKindIsSetOrMerge && !keyKindIsPointDelete {
+	// Ensure that no one adds a point key kind without considering the obsolete
+	// handling for that kind.
+	switch keyKind {
+	case InternalKeyKindSet, InternalKeyKindSetWithDelete, InternalKeyKindMerge,
+		InternalKeyKindDelete, InternalKeyKindSingleDelete, InternalKeyKindDeleteSized:
+	default:
 		panic(errors.AssertionFailedf("unexpected key kind %s", keyKind.String()))
 	}
 	// If same user key, then the current key is obsolete if any of the
 	// following is true:
 	// C1 The prev key was obsolete.
-	// C2 The prev key was not a MERGE
-	// C3 The current key is not a SET or SETWITHDELETE or MERGE, then it is
-	//    obsolete. This rule excludes SET, SETWITHDELETE, MERGE, since they
-	//    will be merged with the previous key.
+	// C2 The prev key was not a MERGE. When the previous key is a MERGE we must
+	//    preserve SET* and MERGE since their values will be merged into the
+	//    previous key. We also must preserve DEL* since there may be an older
+	//    SET*/MERGE in a lower level that must not be merged with the MERGE --
+	//    if we omit the DEL* that lower SET*/MERGE will become visible.
 	//
 	// Regardless of whether it is the same user key or not
-	// C4 The current key is some kind of point delete, and we are writing to
-	//    the lowest level, then it is also obsolete.
+	// C3 The current key is some kind of point delete, and we are writing to
+	//    the lowest level, then it is also obsolete. The correctness of this
+	//    relies on the same user key not spanning multiple sstables in a level.
 	//
 	// C1 ensures that for a user key there is at most one transition from
 	// !obsolete to obsolete. Consider a user key k, for which the first n keys
 	// are not obsolete. We consider the various value of n:
 	//
 	// n = 0: This happens due to forceObsolete being set by the caller, or due
-	// to C4. forceObsolete must only be set due a RANGEDEL, and that RANGEDEL
-	// must also delete all the lower seqnums for the same user key. C4 triggers
+	// to C3. forceObsolete must only be set due a RANGEDEL, and that RANGEDEL
+	// must also delete all the lower seqnums for the same user key. C3 triggers
 	// due to a point delete and that deletes all the lower seqnums for the same
 	// user key.
 	//
@@ -885,12 +888,13 @@ func (w *Writer) makeAddPointDecisionV3(
 	// MERGE, or the current key is some kind of point delete.
 	//
 	// n > 1: This is due to a sequence of MERGE keys, potentially followed by a
-	// single SET or SETWITHDELETE.
-	isObsolete = (cmpUser == 0 &&
-		(prevKeyKind != InternalKeyKindMerge || prevPointKeyInfo.isObsolete || !keyKindIsSetOrMerge)) ||
-		(w.writingToLowestLevel &&
-			(keyKind == InternalKeyKindDelete || keyKind == InternalKeyKindSingleDelete ||
-				keyKind == InternalKeyKindDeleteSized))
+	// single non-MERGE key.
+	isObsoleteC1AndC2 := cmpUser == 0 &&
+		(prevPointKeyInfo.isObsolete || prevKeyKind != InternalKeyKindMerge)
+	isObsoleteC3 := w.writingToLowestLevel &&
+		(keyKind == InternalKeyKindDelete || keyKind == InternalKeyKindSingleDelete ||
+			keyKind == InternalKeyKindDeleteSized)
+	isObsolete = isObsoleteC1AndC2 || isObsoleteC3
 	// TODO(sumeer): storing isObsolete SET and SETWITHDEL in value blocks is
 	// possible, but requires some care in documenting and checking invariants.
 	// There is code that assumes nothing in value blocks because of single MVCC
@@ -942,8 +946,7 @@ func (w *Writer) addPoint(key InternalKey, value []byte, forceObsolete bool) err
 	if err != nil {
 		return err
 	}
-	// Temporarily disable `isObsolete`.
-	isObsolete = false && w.tableFormat >= TableFormatPebblev4 && (isObsolete || forceObsolete)
+	isObsolete = w.tableFormat >= TableFormatPebblev4 && (isObsolete || forceObsolete)
 	w.lastPointKeyInfo.isObsolete = isObsolete
 	var valueStoredWithKey []byte
 	var prefix valuePrefix

--- a/vendor/github.com/cockroachdb/pebble/table_stats.go
+++ b/vendor/github.com/cockroachdb/pebble/table_stats.go
@@ -886,7 +886,7 @@ func newCombinedDeletionKeyspanIter(
 		// See docs/range_deletions.md for why this is necessary.
 		iter = keyspan.Truncate(
 			comparer.Compare, iter, m.Smallest.UserKey, m.Largest.UserKey,
-			nil, nil, false, /* panicOnPartialOverlap */
+			nil, nil, false, /* panicOnUpperTruncate */
 		)
 		mIter.AddLevel(iter)
 	}

--- a/vendor/github.com/cockroachdb/pebble/vfs/disk_health.go
+++ b/vendor/github.com/cockroachdb/pebble/vfs/disk_health.go
@@ -704,7 +704,7 @@ func (d *diskHealthCheckingFS) Open(name string, opts ...OpenOption) (File, erro
 
 // OpenReadWrite implements the FS interface.
 func (d *diskHealthCheckingFS) OpenReadWrite(name string, opts ...OpenOption) (File, error) {
-	return d.fs.Open(name, opts...)
+	return d.fs.OpenReadWrite(name, opts...)
 }
 
 // OpenDir implements the FS interface.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -39,7 +39,7 @@ github.com/cockroachdb/errors/withstack
 # github.com/cockroachdb/logtags v0.0.0-20190617123548-eb05cc24525f
 ## explicit
 github.com/cockroachdb/logtags
-# github.com/cockroachdb/pebble v0.0.0-20230701135918-609ae80aea41
+# github.com/cockroachdb/pebble v0.0.0-20230716025533-809057a10ee4
 ## explicit; go 1.19
 github.com/cockroachdb/pebble
 github.com/cockroachdb/pebble/bloom


### PR DESCRIPTION
### What this PR does

Bump github.com/cockroachdb/pebble from v0.0.0-20230701135918-609ae80aea41 to v0.0.0-20230716025533-809057a10ee4.
    
```
678f7e48 internal/manifest: link issue to skipped test
ca11d1bb *: allow virtual sstables to truncate range keys/dels
fa85ec45 db: deflake TestCompactionPickerScores
168079ac metamorphic: test shared storage including the secondary cache
52a12cd5 internal/manifest: delete L0Sublevels_LargeImport
a9a079d4 sharedobjcat: allow addition/deletion of object in same batch
5c2da530 ingest: don't assume flushable ingests are locally present
88bbab59 db: Bring back call to deleteObsoleteFiles in Close()
5afd803f db: add some logging for the cleaner
2ad4e668 vfs: Deflake TestDiskHealthChecking_File*
840866b8 ingest: Use Overlaps() to calculate L0 overlaps in excise
9d75815f objstorage: close the shared provider including the catalog & cache
4606eaf6 db,sstable: bug fixes for keys with obsolete bit
02413ad7 cmd: enable benchmarking shared storage including the secondary cache
7bb765ec db: smoother thresholds for the delete pacer
10d9e4a0 lint: disable during race tests
9976c78b manifest: reduce test size under race
a89c926f internal/cache: move Alloc and Free into package-level functions
03c97cda db: do not cache compaction block reads
809057a1 sstable: avoid caching meta blocks
```
