### PR TITLE
chore(metarepos): fix typo from NewStoragenodeUncommitReport to NewStorageNodeUncommitReport

### DIFF
--- a/internal/metarepos/report_collector.go
+++ b/internal/metarepos/report_collector.go
@@ -647,7 +647,7 @@ func (rce *reportCollectExecutor) getReport(ctx context.Context) error {
 }
 
 func (rce *reportCollectExecutor) processReport(response *snpb.GetReportResponse) *mrpb.StorageNodeUncommitReport {
-	report := mrpb.NewStoragenodeUncommitReport(response.StorageNodeID)
+	report := mrpb.NewStorageNodeUncommitReport(response.StorageNodeID)
 	report.UncommitReports = response.UncommitReports
 
 	if report.Len() == 0 {
@@ -662,7 +662,7 @@ func (rce *reportCollectExecutor) processReport(response *snpb.GetReportResponse
 		return report
 	}
 
-	diff := mrpb.NewStoragenodeUncommitReport(report.StorageNodeID)
+	diff := mrpb.NewStorageNodeUncommitReport(report.StorageNodeID)
 	diff.UncommitReports = make([]snpb.LogStreamUncommitReport, 0, len(report.UncommitReports))
 	defer report.Release()
 
@@ -917,7 +917,7 @@ func (rc *reportContext) saveReport(report *mrpb.StorageNodeUncommitReport) {
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 
-	rc.report = mrpb.NewStoragenodeUncommitReport(report.StorageNodeID)
+	rc.report = mrpb.NewStorageNodeUncommitReport(report.StorageNodeID)
 	rc.report.UncommitReports = report.UncommitReports
 }
 
@@ -931,7 +931,7 @@ func (rc *reportContext) swapReport(newReport *mrpb.StorageNodeUncommitReport) (
 		rc.report.Release()
 	}
 
-	rc.report = mrpb.NewStoragenodeUncommitReport(newReport.StorageNodeID)
+	rc.report = mrpb.NewStorageNodeUncommitReport(newReport.StorageNodeID)
 	rc.report.UncommitReports = newReport.UncommitReports
 
 	return old, ok

--- a/internal/metarepos/report_collector_test.go
+++ b/internal/metarepos/report_collector_test.go
@@ -1199,7 +1199,7 @@ func (rc *testReportContextPtr) saveReport(report *mrpb.StorageNodeUncommitRepor
 	rc.mu.Lock()
 	defer rc.mu.Unlock()
 
-	rc.report = mrpb.NewStoragenodeUncommitReport(report.StorageNodeID)
+	rc.report = mrpb.NewStorageNodeUncommitReport(report.StorageNodeID)
 	rc.report.UncommitReports = report.UncommitReports
 }
 

--- a/proto/mrpb/raft_metadata_repository.go
+++ b/proto/mrpb/raft_metadata_repository.go
@@ -82,7 +82,7 @@ var storageNodeUncommitReportPool = sync.Pool{
 	},
 }
 
-func NewStoragenodeUncommitReport(snid types.StorageNodeID) *StorageNodeUncommitReport {
+func NewStorageNodeUncommitReport(snid types.StorageNodeID) *StorageNodeUncommitReport {
 	r := storageNodeUncommitReportPool.Get().(*StorageNodeUncommitReport)
 	r.StorageNodeID = snid
 	return r


### PR DESCRIPTION
### What this PR does

Fix typo from NewStoragenodeUncommitReport to NewStorageNodeUncommitReport.

