### PR TITLE
feat(admin): check cluster id in mrmanager

### DIFF
--- a/tests/it/testenv.go
+++ b/tests/it/testenv.go
@@ -1185,6 +1185,7 @@ func (clus *VarlogCluster) initVMS(t *testing.T) {
 	mrMgrOpts := append(clus.mrMgrOpts,
 		mrmanager.WithAddresses(clus.mrRPCEndpoints...),
 		mrmanager.WithLogger(clus.logger.Logger),
+		mrmanager.WithClusterID(clus.clusterID),
 	)
 	mrMgr, err := mrmanager.New(context.TODO(), mrMgrOpts...)
 	require.NoError(t, err)


### PR DESCRIPTION
### What this PR does

This PR adds codes to check cluster id in mrmanager. Because the admin server doesn't have explicit health checking, comparing cluster id is performed in ClusterMetadataViewer.
In the next PR, checking the replication factor will be added.
