### PR TITLE
feat(varlogtest): add initial metadata repository and support fetch APIs

### DIFF
--- a/pkg/varlogtest/config.go
+++ b/pkg/varlogtest/config.go
@@ -4,15 +4,35 @@ import (
 	"fmt"
 
 	"github.com/kakao/varlog/pkg/types"
+	"github.com/kakao/varlog/proto/varlogpb"
 )
 
 type config struct {
 	clusterID         types.ClusterID
 	replicationFactor int
+	initialMRNodes    []varlogpb.MetadataRepositoryNode
 }
 
 func newConfig(opts []Option) (config, error) {
-	cfg := config{}
+	cfg := config{
+		initialMRNodes: []varlogpb.MetadataRepositoryNode{
+			{
+				NodeID:  types.NewNodeIDFromURL("http://127.0.10.1:9091"),
+				RaftURL: "http://127.0.10.1:9091",
+				RPCAddr: "127.0.10.1:9092",
+			},
+			{
+				NodeID:  types.NewNodeIDFromURL("http://127.0.10.2:9091"),
+				RaftURL: "http://127.0.10.2:9091",
+				RPCAddr: "127.0.10.2:9092",
+			},
+			{
+				NodeID:  types.NewNodeIDFromURL("http://127.0.10.3:9091"),
+				RaftURL: "http://127.0.10.3:9091",
+				RPCAddr: "127.0.10.3:9092",
+			},
+		},
+	}
 	for _, opt := range opts {
 		opt.apply(&cfg)
 	}
@@ -28,6 +48,11 @@ func (cfg *config) validate() error {
 	}
 	if cfg.replicationFactor < 1 {
 		return fmt.Errorf("invalid replication factor %d", cfg.replicationFactor)
+	}
+	for _, mrn := range cfg.initialMRNodes {
+		if mrn.NodeID == types.InvalidNodeID {
+			return fmt.Errorf("invalid metadata repository node id %d", mrn.NodeID)
+		}
 	}
 	return nil
 }
@@ -57,5 +82,11 @@ func WithClusterID(cid types.ClusterID) Option {
 func WithReplicationFactor(repfactor int) Option {
 	return newFuncOption(func(cfg *config) {
 		cfg.replicationFactor = repfactor
+	})
+}
+
+func WithInitialMetadataRepositoryNodes(mrns ...varlogpb.MetadataRepositoryNode) Option {
+	return newFuncOption(func(cfg *config) {
+		cfg.initialMRNodes = mrns
 	})
 }


### PR DESCRIPTION
### What this PR does

This PR adds an option to set initial metadata repository nodes and supports fetch APIs for the metadata repository nodes in the varlogtest admin. Although it doesn't provide mutation APIs for the metadata repository yet, it will be helpful to test the varlog.

