### PR TITLE
fix(varlogtest): log stream appender returns missing errors in the callback

### DIFF
--- a/pkg/varlogtest/log.go
+++ b/pkg/varlogtest/log.go
@@ -346,7 +346,7 @@ func (c *testLog) NewLogStreamAppender(tpid types.TopicID, lsid types.LogStreamI
 	go func() {
 		defer lsa.wg.Done()
 		for qe := range lsa.queue.ch {
-			qe.callback(qe.result.Metadata, nil)
+			qe.callback(qe.result.Metadata, qe.result.Err)
 			lsa.queue.cv.L.Lock()
 			lsa.queue.cv.Broadcast()
 			lsa.queue.cv.L.Unlock()


### PR DESCRIPTION
### What this PR does

This PR fixed the log stream appender's bug in the varlogtest package. It had
the bug that the callback in the log stream appender didn't return an error.

