### PR TITLE
fix(varlogtest): log stream appender can be closed in the callback

### DIFF
--- a/pkg/varlogtest/varlogtest.go
+++ b/pkg/varlogtest/varlogtest.go
@@ -73,7 +73,7 @@ func (vt *VarlogTest) NewAdminClient() varlog.Admin {
 }
 
 func (vt *VarlogTest) NewLogClient() varlog.Log {
-	return &testLog{vt: vt}
+	return newTestLog(vt)
 }
 
 func (vt *VarlogTest) generateTopicID() types.TopicID {


### PR DESCRIPTION
### What this PR does

This PR fixed the varlogtest to be able to close the log stream appender in the callback.

