### PR TITLE
fix(varlogsn): fix JSON parsing of get_data_dirs in start_varlogsn

### DIFF
--- a/bin/start_varlogsn.py
+++ b/bin/start_varlogsn.py
@@ -59,14 +59,14 @@ def fetch_storage_node_id(admin: str, advertise: str) -> Tuple[int, bool]:
 
 
 def get_data_dirs(admin: str, snid: int) -> List[str]:
-    cmd = [f"{binpath}/varlogctl", "sn", "describe", f"--admin={admin}",
+    cmd = [f"{binpath}/varlogctl", "sn", "get", f"--admin={admin}",
            f"--snid={snid}"]
     out = subprocess.check_output(cmd)
     snm = json.loads(out)
-    logstreams = snm.get("logStreams")
-    if not logstreams:
-        logstreams = []
-    return [logstream["path"] for logstream in logstreams]
+    logStreamReplicas = snm.get("logStreamReplicas")
+    if not logStreamReplicas:
+        logStreamReplicas = []
+    return [logStreamReplica["path"] for logStreamReplica in logStreamReplicas]
 
 
 def truncate(path: str) -> None:


### PR DESCRIPTION
### What this PR does

This PR fixed the JSON parsing of the get_data_dirs function in the start_varlogsn.py script. It has been affected by #606.

