### PR TITLE
fix(varlogtest): panic on PeekLogStream after removing all logs

### DIFF
--- a/pkg/varlogtest/varlogtest.go
+++ b/pkg/varlogtest/varlogtest.go
@@ -144,12 +144,13 @@ func (vt *VarlogTest) peek(topicID types.TopicID, logStreamID types.LogStreamID)
 	if idx < len(vt.localLogEntries[logStreamID]) && vt.localLogEntries[logStreamID][idx].GLSN == trimGLSN {
 		idx++
 	}
-
-	head.GLSN = vt.localLogEntries[logStreamID][idx].GLSN
-	head.LLSN = vt.localLogEntries[logStreamID][idx].LLSN
-	lastIdx := len(vt.localLogEntries[logStreamID]) - 1
-	tail.GLSN = vt.localLogEntries[logStreamID][lastIdx].GLSN
-	tail.LLSN = vt.localLogEntries[logStreamID][lastIdx].LLSN
+	if idx < len(vt.localLogEntries[logStreamID]) {
+		head.GLSN = vt.localLogEntries[logStreamID][idx].GLSN
+		head.LLSN = vt.localLogEntries[logStreamID][idx].LLSN
+		lastIdx := len(vt.localLogEntries[logStreamID]) - 1
+		tail.GLSN = vt.localLogEntries[logStreamID][lastIdx].GLSN
+		tail.LLSN = vt.localLogEntries[logStreamID][lastIdx].LLSN
+	}
 	return head, tail
 }
 


### PR DESCRIPTION
### What this PR does

Package varlogtest could panic when a user calls PeekLogStream after deleting
all logs from a log stream. This PR fixed the bug.
