### PR TITLE
fix(client): remove subscribe's initial delay

### DIFF
--- a/pkg/varlog/subscribe.go
+++ b/pkg/varlog/subscribe.go
@@ -288,6 +288,8 @@ func (p *transmitter) transmit(ctx context.Context) {
 	p.timer = time.NewTimer(p.timeout)
 	defer p.timer.Stop()
 
+	_ = p.refreshSubscriber(ctx)
+
 	for {
 		select {
 		case <-ctx.Done():


### PR DESCRIPTION
### What this PR does

This PR removes the initial delay from the client's Subscribe API. It now
refreshes subscribers manually to fetch logs immediately.
