### PR TITLE
perf(client): reuse snpb.SubscribeResponse in RPC handler

### DIFF
--- a/internal/storagenode/client/log_client.go
+++ b/internal/storagenode/client/log_client.go
@@ -97,8 +97,10 @@ func (c *LogClient) Subscribe(ctx context.Context, tpid types.TopicID, lsid type
 		defer func() {
 			close(out)
 		}()
+		var rsp snpb.SubscribeResponse
 		for {
-			rsp, rpcErr := stream.Recv()
+			rsp.Reset()
+			rpcErr := stream.RecvMsg(&rsp)
 			err := verrors.FromStatusError(rpcErr)
 			result := SubscribeResult{Error: err}
 			if err == nil {


### PR DESCRIPTION
### What this PR does

This pull request optimizes
`internal/storagenode/client.(*LogClient).Subscribe`. It reuses
`snpb.SubscribeResponse` to reduce heap allocations. Note that it does not reuse
the byte slice in the `snpb.SubscribeResponse`. It only reuses the struct
`snpb.SubscribeResponse` itself.
