### PR TITLE
chore(go): use 1.22.0 in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kakao/varlog
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/cockroachdb/pebble v1.1.0


### PR DESCRIPTION
### What this PR does

Use 1.22.0 in go.mod.

See: <https://github.com/github/codeql/issues/15647#issuecomment-1949920878>
