### PR TITLE
ci: bump go.uber.org/mock/mockgen from v0.3.0 to v0.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ generate-check:
 tools:
 	$(GO) install golang.org/x/tools/cmd/goimports@latest
 	$(GO) install golang.org/x/lint/golint@latest
-	$(GO) install go.uber.org/mock/mockgen@v0.3.0
+	$(GO) install go.uber.org/mock/mockgen@v0.4.0
 
 fmt:
 	@echo goimports

--- a/internal/admin/mrmanager/manager_mock.go
+++ b/internal/admin/mrmanager/manager_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/internal/admin/mrmanager -package mrmanager -destination manager_mock.go . ClusterMetadataView,MetadataRepositoryManager
 //
+
 // Package mrmanager is a generated GoMock package.
 package mrmanager
 

--- a/internal/admin/replica_selector_mock.go
+++ b/internal/admin/replica_selector_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/internal/admin -package admin -destination replica_selector_mock.go . ReplicaSelector
 //
+
 // Package admin is a generated GoMock package.
 package admin
 

--- a/internal/admin/snmanager/manager_mock.go
+++ b/internal/admin/snmanager/manager_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/internal/admin/snmanager -package snmanager -destination manager_mock.go . StorageNodeManager
 //
+
 // Package snmanager is a generated GoMock package.
 package snmanager
 

--- a/internal/admin/snwatcher/snwatcher_mock.go
+++ b/internal/admin/snwatcher/snwatcher_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/internal/admin/snwatcher -package snwatcher -destination snwatcher_mock.go . EventHandler
 //
+
 // Package snwatcher is a generated GoMock package.
 package snwatcher
 

--- a/internal/admin/stats/repository_mock.go
+++ b/internal/admin/stats/repository_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/internal/admin/stats -package stats -destination repository_mock.go . Repository
 //
+
 // Package stats is a generated GoMock package.
 package stats
 

--- a/internal/reportcommitter/client_mock.go
+++ b/internal/reportcommitter/client_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/internal/reportcommitter -package reportcommitter -destination client_mock.go . Client
 //
+
 // Package reportcommitter is a generated GoMock package.
 package reportcommitter
 

--- a/internal/storagenode/client/management_client_mock.go
+++ b/internal/storagenode/client/management_client_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/internal/storagenode/client -package client -destination management_client_mock.go . StorageNodeManagementClient
 //
+
 // Package client is a generated GoMock package.
 package client
 

--- a/pkg/mrc/metadata_repository_client_mock.go
+++ b/pkg/mrc/metadata_repository_client_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/pkg/mrc -package mrc -destination metadata_repository_client_mock.go . MetadataRepositoryClient
 //
+
 // Package mrc is a generated GoMock package.
 package mrc
 

--- a/pkg/mrc/metadata_repository_management_client_mock.go
+++ b/pkg/mrc/metadata_repository_management_client_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/pkg/mrc -package mrc -destination metadata_repository_management_client_mock.go . MetadataRepositoryManagementClient
 //
+
 // Package mrc is a generated GoMock package.
 package mrc
 

--- a/pkg/varlog/admin_mock.go
+++ b/pkg/varlog/admin_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -package varlog -destination admin_mock.go . Admin
 //
+
 // Package varlog is a generated GoMock package.
 package varlog
 

--- a/pkg/varlog/log_mock.go
+++ b/pkg/varlog/log_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -package varlog -destination log_mock.go . Log
 //
+
 // Package varlog is a generated GoMock package.
 package varlog
 

--- a/pkg/varlog/log_stream_appender_mock.go
+++ b/pkg/varlog/log_stream_appender_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -package varlog -destination log_stream_appender_mock.go . LogStreamAppender
 //
+
 // Package varlog is a generated GoMock package.
 package varlog
 

--- a/pkg/varlog/metadata_refresher_mock.go
+++ b/pkg/varlog/metadata_refresher_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/pkg/varlog -package varlog -destination metadata_refresher_mock.go . MetadataRefresher
 //
+
 // Package varlog is a generated GoMock package.
 package varlog
 

--- a/pkg/varlog/replicas_retriever_mock.go
+++ b/pkg/varlog/replicas_retriever_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -self_package github.com/kakao/varlog/pkg/varlog -package varlog -destination replicas_retriever_mock.go . ReplicasRetriever,RenewableReplicasRetriever
 //
+
 // Package varlog is a generated GoMock package.
 package varlog
 

--- a/proto/admpb/admin_mock.go
+++ b/proto/admpb/admin_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -package admpb -destination admin_mock.go . ClusterManagerClient,ClusterManagerServer
 //
+
 // Package admpb is a generated GoMock package.
 package admpb
 

--- a/proto/mrpb/mock/mrpb_mock.go
+++ b/proto/mrpb/mock/mrpb_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -package mock -destination mock/mrpb_mock.go . ManagementClient,ManagementServer,MetadataRepositoryServiceClient,MetadataRepositoryServiceServer
 //
+
 // Package mock is a generated GoMock package.
 package mock
 

--- a/proto/snpb/mock/snpb_mock.go
+++ b/proto/snpb/mock/snpb_mock.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -build_flags -mod=vendor -package mock -destination mock/snpb_mock.go . ReplicatorClient,ReplicatorServer,Replicator_ReplicateClient,LogIOClient,LogIOServer,LogIO_AppendClient,LogIO_SubscribeClient,LogIO_SubscribeServer,LogStreamReporterClient,LogStreamReporterServer,ManagementClient,ManagementServer
 //
+
 // Package mock is a generated GoMock package.
 package mock
 


### PR DESCRIPTION
### What this PR does

Bump go.uber.org/mock/mockgen from v0.3.0 to v0.4.0.
