### PR TITLE
feat(storage): add cache to storage

### DIFF
--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -81,6 +81,7 @@ func newStartCommand() *cli.Command {
 			flagStorageVerbose,
 			flagStorageTrimDelay,
 			flagStorageTrimRate,
+			flagStorageCacheSize,
 
 			// logger options
 			flags.LogDir,

--- a/cmd/varlogsn/flags.go
+++ b/cmd/varlogsn/flags.go
@@ -136,6 +136,13 @@ var (
 		Category: categoryStorage,
 		EnvVars:  []string{"STORAGE_VERBOSE"},
 	}
+	flagStorageCacheSize = &cli.StringFlag{
+		Name:     "storage-cache-size",
+		Category: categoryStorage,
+		EnvVars:  []string{"STORAGE_CACHE_SIZE"},
+		Value:    units.ToByteSizeString(storage.DefaultCacheSize),
+		Usage:    "Size of storage cache shared across all storages.",
+	}
 
 	flagStorageL0CompactionFileThreshold = &cli.IntSliceFlag{
 		Name:     "storage-l0-compaction-file-threshold",

--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -113,6 +113,13 @@ func start(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	cacheSize, err := units.FromByteSizeString(c.String(flagStorageCacheSize.Name))
+	if err != nil {
+		return err
+	}
+	storageCache := storage.NewCache(cacheSize)
+	defer storageCache.Unref()
+	storageOpts = append(storageOpts, storage.WithCache(storageCache))
 
 	snOpts := []storagenode.Option{
 		storagenode.WithClusterID(clusterID),

--- a/internal/storage/cache.go
+++ b/internal/storage/cache.go
@@ -1,0 +1,37 @@
+package storage
+
+import (
+	"sync"
+
+	"github.com/cockroachdb/pebble"
+)
+
+const (
+	DefaultCacheSize = 128 << 20
+)
+
+type Cache struct {
+	c    *pebble.Cache
+	once sync.Once
+}
+
+func NewCache(size int64) *Cache {
+	return &Cache{
+		c: pebble.NewCache(size),
+	}
+}
+
+func (cache *Cache) Unref() {
+	if cache != nil && cache.c != nil {
+		cache.once.Do(func() {
+			cache.c.Unref()
+		})
+	}
+}
+
+func (cache *Cache) get() *pebble.Cache {
+	if cache == nil {
+		return nil
+	}
+	return cache.c
+}

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -147,6 +147,7 @@ type config struct {
 	trimRateByte       int
 	logger             *zap.Logger
 	readOnly           bool
+	cache              *Cache
 }
 
 func newConfig(opts []Option) (config, error) {
@@ -270,6 +271,15 @@ func WithTrimRateByte(trimRateByte int) Option {
 func ReadOnly() Option {
 	return newFuncOption(func(cfg *config) {
 		cfg.readOnly = true
+	})
+}
+
+// WithCache sets the cache for storage. Users can use the same cache across
+// different storage. If the cache is not set, each storage uses its cache,
+// which is 8 MB in size.
+func WithCache(cache *Cache) Option {
+	return newFuncOption(func(cfg *config) {
+		cfg.cache = cache
 	})
 }
 

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -66,11 +66,11 @@ func New(opts ...Option) (*Storage, error) {
 				return nil, fmt.Errorf("forbidden entry: %s", name)
 			}
 		}
-		dataDB, err = s.newDB(filepath.Join(s.path, dataDBDirName), &s.dataDBConfig)
+		dataDB, err = s.newDB(filepath.Join(s.path, dataDBDirName), &s.dataDBConfig, s.cache)
 		if err != nil {
 			return nil, err
 		}
-		commitDB, err = s.newDB(filepath.Join(s.path, commitDBDirName), &s.commitDBConfig)
+		commitDB, err = s.newDB(filepath.Join(s.path, commitDBDirName), &s.commitDBConfig, s.cache)
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +82,7 @@ func New(opts ...Option) (*Storage, error) {
 				return nil, fmt.Errorf("non-separating database, but %s exists", dbDirName)
 			}
 		}
-		dataDB, err = s.newDB(s.path, &s.dataDBConfig)
+		dataDB, err = s.newDB(s.path, &s.dataDBConfig, s.cache)
 		if err != nil {
 			return nil, err
 		}
@@ -99,8 +99,9 @@ func New(opts ...Option) (*Storage, error) {
 	return stg, nil
 }
 
-func (s *Storage) newDB(path string, cfg *dbConfig) (*pebble.DB, error) {
+func (s *Storage) newDB(path string, cfg *dbConfig, cache *Cache) (*pebble.DB, error) {
 	pebbleOpts := &pebble.Options{
+		Cache:                       cache.get(),
 		DisableWAL:                  !s.wal,
 		L0CompactionFileThreshold:   cfg.l0CompactionFileThreshold,
 		L0CompactionThreshold:       cfg.l0CompactionThreshold,

--- a/internal/storage/testing.go
+++ b/internal/storage/testing.go
@@ -13,9 +13,12 @@ import (
 )
 
 func TestNewStorage(tb testing.TB, opts ...Option) *Storage {
+	cache := NewCache(1 << 20)
+	defer cache.Unref()
 	defaultOpts := []Option{
 		WithPath(tb.TempDir()),
 		WithoutSync(), // FIXME: Use only in mac since sync is too slow in mac os.
+		WithCache(cache),
 	}
 	s, err := New(append(defaultOpts, opts...)...)
 	assert.NoError(tb, err)


### PR DESCRIPTION
### What this PR does

This pull request adds a cache to shared storage across all storage, which is
set by the CLI flag '--storage-cache-size. Internally, it is a block cache of
Pebble that stores data in the Varlog. The cache's default size is 128
megabytes.
