### PR TITLE
fix(rpc): use google.golang.org/grpc.NewClient instead of DialContext

### DIFF
--- a/internal/storagenode/client/manager_test.go
+++ b/internal/storagenode/client/manager_test.go
@@ -37,11 +37,15 @@ func TestManager_UnreachableServer(t *testing.T) {
 		),
 	)
 	assert.NoError(t, err)
+	t.Cleanup(func() {
+		err = mgr.Close()
+		assert.NoError(t, err)
+	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 	_, err = mgr.GetOrConnect(ctx, 1, "127.0.0.1:0")
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func TestManager_Client(t *testing.T) {

--- a/pkg/rpc/rpc_conn.go
+++ b/pkg/rpc/rpc_conn.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"slices"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -9,27 +10,33 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-var (
-	defaultDialOption = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-)
+var defaultDialOption = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
 
 type Conn struct {
 	Conn *grpc.ClientConn
 	once sync.Once
 }
 
+// NewConn creates a new gRPC connection to the specified address using
+// google.golang.org/grpc.NewClient. Note that this method does not perform any
+// I/O, meaning the connection is not immediately established. If the server is
+// unavailable, this method will not return an error. The connection is
+// established automatically when an RPC is made using the returned Conn.
+// DialOptions such as WithBlock, WithTimeout, and WithReturnConnectionError
+// are not considered.
+// Ensure to close the returned Conn after usage to avoid resource leaks.
 func NewConn(ctx context.Context, address string, opts ...grpc.DialOption) (*Conn, error) {
-	conn, err := grpc.DialContext(ctx, address, append(defaultDialOption, opts...)...)
+	conn, err := grpc.NewClient(address, slices.Concat(defaultDialOption, opts)...)
 	if err != nil {
 		return nil, errors.Wrapf(err, "rpc: %s", address)
 	}
 	return &Conn{Conn: conn}, nil
 }
 
-func NewBlockingConn(ctx context.Context, address string) (*Conn, error) {
-	return NewConn(ctx, address, grpc.WithBlock(), grpc.WithReturnConnectionError())
-}
-
+// Close terminates the gRPC connection. This method ensures that the
+// connection is closed only once, even if called multiple times.
+// It is important to call Close after the connection is no longer needed to
+// release resources properly.
 func (c *Conn) Close() (err error) {
 	c.once.Do(func() {
 		if c.Conn != nil {

--- a/tests/it/mrconnector/mr_connector_test.go
+++ b/tests/it/mrconnector/mr_connector_test.go
@@ -111,7 +111,7 @@ func TestMRConnector(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.TODO(), time.Second)
 			defer cancel()
 			// TODO (jun): Use NewConn
-			conn, err := rpc.NewBlockingConn(ctx, ep)
+			conn, err := rpc.NewConn(ctx, ep)
 			if err == nil {
 				So(conn.Close(), ShouldBeNil)
 			}
@@ -181,7 +181,6 @@ func TestMRConnector(t *testing.T) {
 					}
 				}
 				return true
-
 			}), ShouldBeTrue)
 		}
 


### PR DESCRIPTION
### What this PR does

Replace grpc.DialContext with grpc.NewClient in the rpc package to align with
updated gRPC practices. The NewClient method creates a gRPC channel without
performing I/O operations immediately, improving the connection management
logic.

- Update NewConn to use grpc.NewClient instead of grpc.DialContext.
- Add detailed comments to explain the behavior of NewClient.
- Modify TestManager to ensure each test case has an independent Manager
  instance.
- Adjust UnreachableServer test case to reflect non-blocking behavior of
  NewClient.

This change ensures better resource management and aligns with the latest gRPC
client connection practices.

### Anything else

See:

- <https://pkg.go.dev/google.golang.org/grpc#NewClient>
- <https://pkg.go.dev/google.golang.org/grpc#DialContext>
