### PR TITLE
ci(lint): bump golangci-lint from v1.56 to v1.59

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6.0.1
         with:
-          version: v1.56
+          version: v1.59
           skip-cache: true
           skip-pkg-cache: true
   build:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,10 +1,5 @@
 run:
   timeout: 5m
-  skip-files:
-    - ".*\\.pb\\.go$"
-    - ".*_mock\\.go$"
-
-
 linters:
   disable-all: true
   enable:
@@ -21,8 +16,6 @@ linters:
     - staticcheck
     - typecheck
     - unused
-
-
 linters-settings:
   depguard:
     rules:
@@ -60,8 +53,6 @@ linters-settings:
           - "fmt.Println"
           - "strings.Builder.WriteString"
           - "strings.Builder.WriteByte"
-
-
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
@@ -69,3 +60,6 @@ issues:
     - path: _test\.go
       linters:
         - gomnd
+  exclude-files:
+    - ".*\\.pb\\.go$"
+    - ".*_mock\\.go$"

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ fmt:
 	@$(foreach path,$(PKGS),gofmt -w -s ./$(path);)
 
 lint:
-	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v1.56.2-alpine golangci-lint run
+	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v1.59.0-alpine golangci-lint run
 
 vet:
 	@echo govet

--- a/cmd/benchmark/serve_command.go
+++ b/cmd/benchmark/serve_command.go
@@ -74,7 +74,7 @@ func runCommandServe(c *cli.Context) error {
 		server.WithDatabaseName(c.String(flagDatabaseName.Name)),
 	)
 	if err != nil {
-		slog.Error("could not create server", err)
+		slog.Error("could not create server", slog.Any("error", err))
 		os.Exit(1)
 	}
 
@@ -101,7 +101,7 @@ func runCommandServe(c *cli.Context) error {
 	}()
 	wg.Wait()
 	if err != nil {
-		slog.Error("server stopped abnormally", err)
+		slog.Error("server stopped abnormally", slog.Any("error", err))
 		os.Exit(1)
 	}
 	return nil

--- a/internal/benchmark/loader.go
+++ b/internal/benchmark/loader.go
@@ -201,9 +201,9 @@ func (loader *Loader) makeAppendFunc(ctx context.Context, c varlog.Log, am *Appe
 		err := lsa.AppendBatch(loader.batch, func(lem []varlogpb.LogEntryMeta, err error) {
 			if err != nil {
 				if errors.Is(err, varlog.ErrClosed) {
-					loader.logger.Debug("closed client", err, slog.Any("tpid", tpid), slog.Any("lsid", lsid))
+					loader.logger.Debug("closed client", slog.Any("error", err), slog.Any("tpid", tpid), slog.Any("lsid", lsid))
 				} else {
-					loader.logger.Error("could not append", err, slog.Any("tpid", tpid), slog.Any("lsid", lsid))
+					loader.logger.Error("could not append", slog.Any("error", err), slog.Any("tpid", tpid), slog.Any("lsid", lsid))
 				}
 				return
 			}


### PR DESCRIPTION
### What this PR does

Bump golangci-lint from v1.56 to v1.59.
