### PR TITLE
fix(sn): prevent panic on closed queue channel of replication server

### DIFF
--- a/internal/storagenode/replication_server.go
+++ b/internal/storagenode/replication_server.go
@@ -144,12 +144,16 @@ func (rs *replicationServer) replicate(ctx context.Context, requestC <-chan *rep
 		}()
 		var rst *replicationServerTask
 		var lse *logstream.Executor
+		var ok bool
 		for {
 			select {
 			case <-ctx.Done():
 				err = ctx.Err()
 				return
-			case rst = <-requestC:
+			case rst, ok = <-requestC:
+			}
+			if !ok {
+				return
 			}
 			err = rst.err
 			if err != nil {


### PR DESCRIPTION
Ensure the replication server
(github.com/kakao/varlog/internal/storagenode.(*replicationServer)) handles
closed request channels properly, preventing a panic caused by nil dereference.

This will prevent flaky test failures
(https://github.com/kakao/varlog/actions/runs/9547361613/job/26312306907) such
as:

```
2024/06/17 12:13:12 SN.Close: 1
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x14d171e]

goroutine 35903 [running]:
github.com/kakao/varlog/internal/storagenode.(*replicationServer).replicate.func1()
	/home/runner/work/varlog/varlog/internal/storagenode/replication_server.go:154 +0x21e
created by github.com/kakao/varlog/internal/storagenode.(*replicationServer).replicate in goroutine 35936
	/home/runner/work/varlog/varlog/internal/storagenode/replication_server.go:138 +0x1c5
FAIL	github.com/kakao/varlog/tests/it/cluster	67.361s
ok  	github.com/kakao/varlog/tests/it/failover	35.632s	coverage: 20.9% of statements
ok  	github.com/kakao/varlog/tests/it/management	158.394s	coverage: 30.3% of statements
ok  	github.com/kakao/varlog/tests/it/mrconnector	3.207s	coverage: 20.9% of statements
FAIL
make: *** [Makefile:74: test_coverage] Error 1
```

### What this PR does

### Which issue(s) this PR resolves

Resolves #

### Anything else

Include any links or documentation that might be helpful for reviewers.
