### PR TITLE
refactor(testing): move vtesting to internal/vtesting

### DIFF
--- a/internal/metarepos/raft_metadata_repository_test.go
+++ b/internal/metarepos/raft_metadata_repository_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
+	"github.com/kakao/varlog/internal/vtesting"
 	"github.com/kakao/varlog/pkg/rpc"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/testutil"
@@ -26,7 +27,6 @@ import (
 	"github.com/kakao/varlog/proto/mrpb"
 	"github.com/kakao/varlog/proto/snpb"
 	"github.com/kakao/varlog/proto/varlogpb"
-	"github.com/kakao/varlog/vtesting"
 )
 
 const rpcTimeout = 3 * time.Second

--- a/internal/metarepos/raft_test.go
+++ b/internal/metarepos/raft_test.go
@@ -13,10 +13,10 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
+	"github.com/kakao/varlog/internal/vtesting"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/testutil"
 	"github.com/kakao/varlog/pkg/util/testutil/ports"
-	"github.com/kakao/varlog/vtesting"
 )
 
 type (

--- a/internal/metarepos/report_collector_test.go
+++ b/internal/metarepos/report_collector_test.go
@@ -12,6 +12,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kakao/varlog/internal/reportcommitter"
+	"github.com/kakao/varlog/internal/vtesting"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/runner"
 	"github.com/kakao/varlog/pkg/util/testutil"
@@ -19,7 +20,6 @@ import (
 	"github.com/kakao/varlog/proto/mrpb"
 	"github.com/kakao/varlog/proto/snpb"
 	"github.com/kakao/varlog/proto/varlogpb"
-	"github.com/kakao/varlog/vtesting"
 )
 
 type dummyMetadataRepository struct {
@@ -539,7 +539,6 @@ func TestReportIgnore(t *testing.T) {
 				}
 			}
 		}
-
 	})
 }
 
@@ -1059,7 +1058,7 @@ func TestCommitWithDelay(t *testing.T) {
 
 func TestRPCFail(t *testing.T) {
 	Convey("Given ReportCollector", t, func(ctx C) {
-		//knownVer := types.InvalidVersion
+		// knownVer := types.InvalidVersion
 
 		clientFac := NewDummyStorageNodeClientFactory(1, false)
 		mr := NewDummyMetadataRepository(clientFac)

--- a/internal/metarepos/storage_test.go
+++ b/internal/metarepos/storage_test.go
@@ -15,12 +15,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/kakao/varlog/internal/vtesting"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/testutil"
 	"github.com/kakao/varlog/proto/mrpb"
 	"github.com/kakao/varlog/proto/snpb"
 	"github.com/kakao/varlog/proto/varlogpb"
-	"github.com/kakao/varlog/vtesting"
 )
 
 func TestStorageRegisterSN(t *testing.T) {

--- a/internal/vtesting/init.go
+++ b/internal/vtesting/init.go
@@ -12,9 +12,13 @@ import (
 )
 
 const defaultRaftTick = time.Millisecond * 100
+
 const defaultCommitTick = time.Millisecond * 10
+
 const defaultTimeoutUnit = time.Millisecond * 400
+
 const defaultProcCount = 8
+
 const defaultRaftDir = "raftdata"
 
 var (
@@ -70,10 +74,6 @@ func TimeoutAccordingToProcCnt(timeout time.Duration) time.Duration {
 	}
 
 	return timeout
-}
-
-func TestLogger() *zap.Logger {
-	return testLogger
 }
 
 func TestRaftTick() time.Duration {

--- a/pkg/mrc/mrconnector/mr_connector_test.go
+++ b/pkg/mrc/mrconnector/mr_connector_test.go
@@ -12,10 +12,10 @@ import (
 	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/kakao/varlog/internal/metarepos"
+	"github.com/kakao/varlog/internal/vtesting"
 	"github.com/kakao/varlog/pkg/rpc"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/testutil/ports"
-	"github.com/kakao/varlog/vtesting"
 )
 
 func TestMain(m *testing.M) {

--- a/pkg/util/testutil/testutil.go
+++ b/pkg/util/testutil/testutil.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/kakao/varlog/vtesting"
+	"github.com/kakao/varlog/internal/vtesting"
 )
 
 func CompareWait(cmp func() bool, timeout time.Duration) bool {

--- a/pkg/varlog/subscribe_test.go
+++ b/pkg/varlog/subscribe_test.go
@@ -3,7 +3,7 @@ package varlog
 import (
 	"testing"
 
-	_ "github.com/kakao/varlog/vtesting"
+	_ "github.com/kakao/varlog/internal/vtesting"
 )
 
 func TestSubscribe(t *testing.T) {

--- a/pkg/varlog/trim_test.go
+++ b/pkg/varlog/trim_test.go
@@ -3,7 +3,7 @@ package varlog
 import (
 	"testing"
 
-	_ "github.com/kakao/varlog/vtesting"
+	_ "github.com/kakao/varlog/internal/vtesting"
 )
 
 func TestTrim(t *testing.T) {

--- a/tests/it/failover/failover_test.go
+++ b/tests/it/failover/failover_test.go
@@ -13,15 +13,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 
-	"github.com/kakao/varlog/internal/storagenode/volume"
-
 	"github.com/kakao/varlog/internal/admin"
 	"github.com/kakao/varlog/internal/admin/snwatcher"
+	"github.com/kakao/varlog/internal/storagenode/volume"
+	"github.com/kakao/varlog/internal/vtesting"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/testutil"
 	"github.com/kakao/varlog/proto/varlogpb"
 	"github.com/kakao/varlog/tests/it"
-	"github.com/kakao/varlog/vtesting"
 )
 
 func TestMain(m *testing.M) {

--- a/tests/it/management/vms_test.go
+++ b/tests/it/management/vms_test.go
@@ -13,13 +13,13 @@ import (
 
 	"github.com/kakao/varlog/internal/admin/mrmanager"
 	"github.com/kakao/varlog/internal/metarepos"
+	"github.com/kakao/varlog/internal/vtesting"
 	"github.com/kakao/varlog/pkg/mrc"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/testutil"
 	"github.com/kakao/varlog/pkg/util/testutil/ports"
 	"github.com/kakao/varlog/pkg/verrors"
 	"github.com/kakao/varlog/tests/it"
-	"github.com/kakao/varlog/vtesting"
 )
 
 // FIXME: This test checks MRManager, move unit test or something similar.
@@ -101,7 +101,6 @@ func TestVarlogNewMRManager(t *testing.T) {
 				So(mrm.Close(), ShouldBeNil)
 			})
 		})
-
 	})
 
 	Convey("Given MR cluster", t, func(ctx C) {

--- a/tests/it/testenv.go
+++ b/tests/it/testenv.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kakao/varlog/internal/storagenode"
 	"github.com/kakao/varlog/internal/storagenode/client"
 	"github.com/kakao/varlog/internal/storagenode/volume"
+	"github.com/kakao/varlog/internal/vtesting"
 	"github.com/kakao/varlog/pkg/mrc"
 	"github.com/kakao/varlog/pkg/rpc"
 	"github.com/kakao/varlog/pkg/types"
@@ -33,7 +34,6 @@ import (
 	"github.com/kakao/varlog/proto/admpb"
 	"github.com/kakao/varlog/proto/snpb"
 	"github.com/kakao/varlog/proto/varlogpb"
-	"github.com/kakao/varlog/vtesting"
 )
 
 type VarlogCluster struct {
@@ -1568,7 +1568,8 @@ func (clus *VarlogCluster) AppendUncommittedLog(t *testing.T, topicID types.Topi
 
 func (clus *VarlogCluster) CommitWithoutMR(t *testing.T, lsID types.LogStreamID,
 	committedLLSNOffset types.LLSN, committedGLSNOffset types.GLSN, committedGLSNLen uint64,
-	version types.Version, highWatermark types.GLSN) {
+	version types.Version, highWatermark types.GLSN,
+) {
 	clus.muSN.Lock()
 	defer clus.muSN.Unlock()
 
@@ -1665,7 +1666,6 @@ func (clus *VarlogCluster) WaitSealed(t *testing.T, lsID types.LogStreamID) {
 }
 
 func (clus *VarlogCluster) GetUncommittedLLSNOffset(t *testing.T, lsID types.LogStreamID) types.LLSN {
-
 	clus.muSN.Lock()
 	defer clus.muSN.Unlock()
 


### PR DESCRIPTION
### What this PR does

This PR relocates the package github.com/kakao/varlog/vtesting to
github.com/kakao/varlog/internal/vtesting as it does not need to be exported.
The package supports flexibility in testing environments by providing features
like a test logger, assertion wait timeout, raft tick, and commit tick of the
metadata repository. However, these parameters are infrequently configured and
can be managed using Go's built-in testing package and helpers.

By moving it to an internal package, we aim to reduce the exposed API surface
and encourage using standard testing tools, eventually leading to the potential
deprecation of the github.com/kakao/varlog/internal/vtesting package. The
package is now being moved to the internal directory without any functional
changes.
