### PR TITLE
refactor(flags): rework common CLI flags for improved clarity and usability

### DIFF
--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kakao/varlog/internal/flags"
 	"github.com/kakao/varlog/internal/storagenode"
 	"github.com/kakao/varlog/internal/storagenode/logstream"
-	"github.com/kakao/varlog/pkg/types"
 )
 
 const (
@@ -38,7 +37,7 @@ func newStartCommand() *cli.Command {
 		Action:  start,
 		Flags: []cli.Flag{
 			flagClusterID,
-			flagStorageNodeID.StringFlag(false, types.StorageNodeID(1).String()),
+			flagStorageNodeID,
 			flagListen.StringFlag(false, "127.0.0.1:9091"),
 			flagAdvertise.StringFlag(false, ""),
 			flagBallastSize.StringFlag(false, storagenode.DefaultBallastSize),

--- a/cmd/varlogsn/flags.go
+++ b/cmd/varlogsn/flags.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kakao/varlog/internal/flags"
 	"github.com/kakao/varlog/internal/storage"
 	"github.com/kakao/varlog/internal/storagenode"
+	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/units"
 )
 
@@ -17,8 +18,12 @@ const (
 
 var (
 	flagClusterID     = flags.ClusterID
-	flagStorageNodeID = flags.StorageNodeID()
-	flagListen        = flags.FlagDesc{
+	flagStorageNodeID = func() *cli.IntFlag {
+		f := flags.GetStorageNodeIDFlag()
+		f.Value = int(types.MinStorageNodeID)
+		return f
+	}()
+	flagListen = flags.FlagDesc{
 		Name:    "listen",
 		Aliases: []string{"listen-address"},
 		Envs:    []string{"LISTEN", "LISTEN_ADDRESS"},

--- a/cmd/varlogsn/testdata/varlogsn.ct
+++ b/cmd/varlogsn/testdata/varlogsn.ct
@@ -33,12 +33,12 @@ OPTIONS:
    --logstream-executor-sequence-queue-capacity value, --lse-sequence-queue-capacity value                  (default: 1024)
    --logstream-executor-write-queue-capacity value, --lse-write-queue-capacity value                        (default: 1024)
    --max-logstream-replicas-count value                                                                     The maximum number of log stream replicas in a storage node, infinity if a negative value (default: -1)
-   --storage-node-id value, --storage-node value, --storagenode value, --snid value                         (default: "1")
    --volumes value, --volume value [ --volumes value, --volume value ]                                       [$VOLUMES, $VOLUME]
 
    Cluster:
 
-   --cluster-id value, --cluster value, --cid value  (default: 1) [$CLUSTER_ID]
+   --cluster-id value, --cluster value, --cid value               (default: 1) [$CLUSTER_ID]
+   --storagenode-id value, --storage-node-id value, --snid value  StorageNode ID (default: 1) [$STORAGENODE_ID, $STORAGE_NODE_ID, $SNID]
 
    Logger:
 

--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -56,10 +56,7 @@ func start(c *cli.Context) error {
 		return err
 	}
 
-	storageNodeID, err := types.ParseStorageNodeID(c.String(flagStorageNodeID.Name))
-	if err != nil {
-		return err
-	}
+	storageNodeID := types.StorageNodeID(flagStorageNodeID.Get(c))
 
 	ballastSize, err := units.FromByteSizeString(c.String(flagBallastSize.Name))
 	if err != nil {

--- a/internal/flags/cluster.go
+++ b/internal/flags/cluster.go
@@ -44,3 +44,57 @@ var (
 		},
 	}
 )
+
+// GetClusterIDFlag returns a flag for specifying the Cluster ID. Users can
+// modify the returned flag without affecting the predefined flag.
+func GetStorageNodeIDFlag() *cli.IntFlag {
+	return &cli.IntFlag{
+		Name:     "storagenode-id",
+		Category: CategoryCluster,
+		Aliases:  []string{"storage-node-id", "snid"},
+		EnvVars:  []string{"STORAGENODE_ID", "STORAGE_NODE_ID", "SNID"},
+		Usage:    "StorageNode ID",
+		Action: func(c *cli.Context, value int) error {
+			if c.IsSet("storagenode-id") && types.StorageNodeID(value).Invalid() {
+				return fmt.Errorf("invalid value \"%d\" for flag --storagenode-id", value)
+			}
+			return nil
+		},
+	}
+}
+
+// GetTopicIDFlag returns a flag for specifying the Topic ID. Users can modify
+// the returned flag without affecting the predefined flag.
+func GetTopicIDFlag() *cli.IntFlag {
+	return &cli.IntFlag{
+		Name:     "topic-id",
+		Category: CategoryCluster,
+		Aliases:  []string{"topic", "tpid"},
+		EnvVars:  []string{"TOPIC_ID", "TOPIC", "TPID"},
+		Usage:    "Topic ID",
+		Action: func(c *cli.Context, value int) error {
+			if c.IsSet("topic-id") && types.TopicID(value).Invalid() {
+				return fmt.Errorf("invalid value \"%d\" for flag --topic-id", value)
+			}
+			return nil
+		},
+	}
+}
+
+// GetLogStreamIDFlag returns a flag for specifying the LogStream ID. Users can
+// modify the returned flag without affecting the predefined flag.
+func GetLogStreamIDFlag() *cli.IntFlag {
+	return &cli.IntFlag{
+		Name:     "logstream-id",
+		Category: CategoryCluster,
+		Aliases:  []string{"log-stream-id", "logstream", "lsid"},
+		EnvVars:  []string{"LOGSTREAM_ID", "LOG_STREAM_ID", "LOGSTREAM", "LSID"},
+		Usage:    "LogStream ID",
+		Action: func(c *cli.Context, value int) error {
+			if c.IsSet("logstream-id") && types.LogStreamID(value).Invalid() {
+				return fmt.Errorf("invalid value \"%d\" for flag --logstream-id", value)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/flags/flags.go
+++ b/internal/flags/flags.go
@@ -102,24 +102,3 @@ func MetadataRepositoryAddress() *FlagDesc {
 		Aliases: []string{"mr-address", "metadata-repository", "mr"},
 	}
 }
-
-func StorageNodeID() *FlagDesc {
-	return &FlagDesc{
-		Name:    "storage-node-id",
-		Aliases: []string{"storage-node", "storagenode", "snid"},
-	}
-}
-
-func TopicID() *FlagDesc {
-	return &FlagDesc{
-		Name:    "topic-id",
-		Aliases: []string{"topic", "tpid"},
-	}
-}
-
-func LogStreamID() *FlagDesc {
-	return &FlagDesc{
-		Name:    "log-stream-id",
-		Aliases: []string{"logstream-id", "logstream", "lsid"},
-	}
-}


### PR DESCRIPTION
### What this PR does

This PR refactors several common CLI flags to enhance their clarity and
usability. The changes include:

- `--storagenode-id`: Specifies the storage node ID.
- `--topic-id`: Specifies the topic ID.
- `--logstream-id`: Specifies the log stream ID.

These adjustments aim to standardize the flag names and improve the overall user
experience.
