### PR TITLE
refactor: remove redundant FindLogStream function

### DIFF
--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -811,7 +811,7 @@ func (adm *Admin) hasSealedReplica(ctx context.Context, lsdesc *varlogpb.LogStre
 			continue
 		}
 
-		lsmeta, ok := meta.FindLogStream(lsdesc.LogStreamID)
+		lsmeta, ok := meta.GetLogStream(lsdesc.LogStreamID)
 		if !ok {
 			continue
 		}

--- a/proto/snpb/log_io_test.go
+++ b/proto/snpb/log_io_test.go
@@ -1,0 +1,73 @@
+package snpb_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/kakao/varlog/pkg/types"
+	"github.com/kakao/varlog/proto/snpb"
+)
+
+func TestValidateTopicLogStream(t *testing.T) {
+	type testMessage interface {
+		GetTopicID() types.TopicID
+		GetLogStreamID() types.LogStreamID
+	}
+	tcs := []struct {
+		msg   testMessage
+		isErr bool
+	}{
+		{
+			msg: &snpb.AppendRequest{
+				TopicID:     types.TopicID(1),
+				LogStreamID: types.LogStreamID(2),
+			},
+			isErr: false,
+		},
+		{
+			msg: &snpb.AppendRequest{
+				TopicID:     types.TopicID(0),
+				LogStreamID: types.LogStreamID(2),
+			},
+			isErr: true,
+		},
+		{
+			msg: &snpb.AppendRequest{
+				TopicID:     types.TopicID(-1),
+				LogStreamID: types.LogStreamID(2),
+			},
+			isErr: true,
+		},
+		{
+			msg: &snpb.AppendRequest{
+				TopicID:     types.TopicID(1),
+				LogStreamID: types.LogStreamID(0),
+			},
+			isErr: true,
+		},
+		{
+			msg: &snpb.AppendRequest{
+				TopicID:     types.TopicID(1),
+				LogStreamID: types.LogStreamID(-1),
+			},
+			isErr: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		name := "unknown"
+		if s, ok := tc.msg.(fmt.Stringer); ok {
+			name = s.String()
+		}
+		t.Run(name, func(t *testing.T) {
+			err := snpb.ValidateTopicLogStream(tc.msg)
+			if tc.isErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/proto/snpb/log_stream_reporter.go
+++ b/proto/snpb/log_stream_reporter.go
@@ -6,6 +6,7 @@ import (
 
 // InvalidLogStreamUncommitReport is empty report. Do **NOT** modify this.
 var InvalidLogStreamUncommitReport = LogStreamUncommitReport{}
+
 var InvalidLogStreamCommitResult = LogStreamCommitResult{}
 
 // Invalid returns whether the LogStreamUncommitReport is acceptable.
@@ -15,6 +16,13 @@ func (m *LogStreamUncommitReport) Invalid() bool {
 	return m.GetLogStreamID().Invalid() || m.GetUncommittedLLSNOffset().Invalid()
 }
 
+// UncommittedLLSNEnd returns the exclusive end of uncommitted LLSN spans. If
+// the LogStreamUncommitReport is nil, it returns types.InvalidLLSN. Otherwise,
+// it calculates the end by adding the UncommittedLLSNOffset and the
+// UncommittedLLSNLength.
+//
+// Example: If UncommittedLLSNOffset is 10 and UncommittedLLSNLength is 5, the
+// method will return 15 (10 + 5).
 func (m *LogStreamUncommitReport) UncommittedLLSNEnd() types.LLSN {
 	if m == nil {
 		return types.InvalidLLSN
@@ -23,6 +31,21 @@ func (m *LogStreamUncommitReport) UncommittedLLSNEnd() types.LLSN {
 	return m.UncommittedLLSNOffset + types.LLSN(m.UncommittedLLSNLength)
 }
 
+// Seal finalizes the uncommitted LLSN spans in the LogStreamUncommitReport up
+// to the specified end LLSN. The 'end' parameter specifies the LLSN up to
+// which the uncommitted spans should be sealed. The method returns the new end
+// LLSN if the operation is successful, or types.InvalidLLSN if the provided
+// end LLSN is invalid.
+//
+// This method adjusts the internal state to reflect that the spans up to 'end'
+// are now sealed. If the LogStreamUncommitReport is nil, or if the provided
+// end LLSN is outside the valid range (less than the starting offset or beyond
+// the current uncommitted end), the method returns types.InvalidLLSN and makes
+// no changes.
+//
+// For example, given a report with a starting offset of 10 and an uncommitted
+// length of 5 (covering spans 10 to 15), calling Seal(12) will mark spans up
+// to 12 as sealed, set the uncommitted length to 2 (12 - 10), and return 12.
 func (m *LogStreamUncommitReport) Seal(end types.LLSN) types.LLSN {
 	if m == nil {
 		return types.InvalidLLSN

--- a/proto/snpb/log_stream_reporter_test.go
+++ b/proto/snpb/log_stream_reporter_test.go
@@ -1,0 +1,134 @@
+package snpb_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kakao/varlog/pkg/types"
+	"github.com/kakao/varlog/proto/snpb"
+)
+
+func TestLogStreamUncommitReport_Invalid(t *testing.T) {
+	tcs := []struct {
+		report *snpb.LogStreamUncommitReport
+		name   string
+		want   bool
+	}{
+		{
+			name: "ValidReport",
+			report: &snpb.LogStreamUncommitReport{
+				LogStreamID:           types.MinLogStreamID,
+				UncommittedLLSNOffset: types.MinLLSN,
+			},
+			want: false,
+		},
+		{
+			name: "InvalidLogStreamID",
+			report: &snpb.LogStreamUncommitReport{
+				LogStreamID:           types.LogStreamID(0),
+				UncommittedLLSNOffset: types.MinLLSN,
+			},
+			want: true,
+		},
+		{
+			name: "InvalidUncommittedLLSNOffset",
+			report: &snpb.LogStreamUncommitReport{
+				LogStreamID:           types.MinLogStreamID,
+				UncommittedLLSNOffset: types.InvalidLLSN,
+			},
+			want: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.report.Invalid())
+		})
+	}
+}
+
+func TestLogStreamUncommitReport_UncommittedLLSNEnd(t *testing.T) {
+	tcs := []struct {
+		report *snpb.LogStreamUncommitReport
+		name   string
+		want   types.LLSN
+	}{
+		{
+			name:   "NilReport",
+			report: nil,
+			want:   types.InvalidLLSN,
+		},
+		{
+			name: "ValidReport",
+			report: &snpb.LogStreamUncommitReport{
+				UncommittedLLSNOffset: types.LLSN(10),
+				UncommittedLLSNLength: 5,
+			},
+			want: types.LLSN(15),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, tc.report.UncommittedLLSNEnd())
+		})
+	}
+}
+
+func TestLogStreamUncommitReport_Seal(t *testing.T) {
+	tcs := []struct {
+		report     *snpb.LogStreamUncommitReport
+		name       string
+		end        types.LLSN
+		want       types.LLSN
+		wantLength uint64
+	}{
+		{
+			name:       "NilReport",
+			report:     nil,
+			end:        types.LLSN(10),
+			want:       types.InvalidLLSN,
+			wantLength: 0,
+		},
+		{
+			name: "EndLessThanUncommittedOffset",
+			report: &snpb.LogStreamUncommitReport{
+				UncommittedLLSNOffset: types.LLSN(10),
+			},
+			end:        types.LLSN(5),
+			want:       types.InvalidLLSN,
+			wantLength: 0,
+		},
+		{
+			name: "EndGreaterThanUncommittedEnd",
+			report: &snpb.LogStreamUncommitReport{
+				UncommittedLLSNOffset: types.LLSN(10),
+				UncommittedLLSNLength: 5,
+			},
+			end:        types.LLSN(20),
+			want:       types.InvalidLLSN,
+			wantLength: 5,
+		},
+		{
+			name: "ValidSeal",
+			report: &snpb.LogStreamUncommitReport{
+				UncommittedLLSNOffset: types.LLSN(10),
+				UncommittedLLSNLength: 5,
+			},
+			end:        types.LLSN(12),
+			want:       types.LLSN(12),
+			wantLength: 2,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.report.Seal(tc.end)
+			assert.Equal(t, tc.want, got)
+			if tc.report != nil {
+				assert.Equal(t, tc.wantLength, tc.report.UncommittedLLSNLength)
+			}
+		})
+	}
+}

--- a/proto/snpb/metadata.go
+++ b/proto/snpb/metadata.go
@@ -29,15 +29,6 @@ func (snmd *StorageNodeMetadataDescriptor) GetLogStream(logStreamID types.LogStr
 	return LogStreamReplicaMetadataDescriptor{}, false
 }
 
-func (snmd StorageNodeMetadataDescriptor) FindLogStream(logStreamID types.LogStreamID) (LogStreamReplicaMetadataDescriptor, bool) {
-	for _, lsmeta := range snmd.GetLogStreamReplicas() {
-		if lsmeta.GetLogStreamID() == logStreamID {
-			return lsmeta, true
-		}
-	}
-	return LogStreamReplicaMetadataDescriptor{}, false
-}
-
 func (lsrmd *LogStreamReplicaMetadataDescriptor) Head() varlogpb.LogEntryMeta {
 	if lsrmd == nil {
 		return varlogpb.LogEntryMeta{}

--- a/tests/it/management/management_test.go
+++ b/tests/it/management/management_test.go
@@ -449,7 +449,7 @@ func TestSyncLogStream(t *testing.T) {
 						if err != nil {
 							return false
 						}
-						lsmd, exist := snmd.FindLogStream(lsID)
+						lsmd, exist := snmd.GetLogStream(lsID)
 						if !exist {
 							return false
 						}
@@ -544,7 +544,6 @@ func TestSyncLogStreamWithAutoUnseal(t *testing.T) {
 		assert.True(t, ok)
 		return lsrmd.LocalHighWatermark.GLSN == types.GLSN(numLogs) &&
 			lsrmd.Status == varlogpb.LogStreamStatusRunning
-
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
@@ -706,7 +705,7 @@ func TestGCZombieLogStream(t *testing.T) {
 			meta, err = snMCL.GetMetadata(context.TODO())
 			So(err, ShouldBeNil)
 
-			_, exist := meta.FindLogStream(lsID)
+			_, exist := meta.GetLogStream(lsID)
 			So(exist, ShouldBeTrue)
 
 			Convey("Then the LogStream should removed after GCTimeout", func(ctx C) {
@@ -714,7 +713,7 @@ func TestGCZombieLogStream(t *testing.T) {
 				meta, err := snMCL.GetMetadata(context.TODO())
 				So(err, ShouldBeNil)
 
-				_, exist := meta.FindLogStream(lsID)
+				_, exist := meta.GetLogStream(lsID)
 				So(exist, ShouldBeTrue)
 
 				So(testutil.CompareWait(func() bool {
@@ -722,7 +721,7 @@ func TestGCZombieLogStream(t *testing.T) {
 					if err != nil {
 						return false
 					}
-					_, exist := meta.FindLogStream(lsID)
+					_, exist := meta.GetLogStream(lsID)
 					return !exist
 				}, gcTimeout), ShouldBeTrue)
 			})


### PR DESCRIPTION
### What this PR does

The FindLogStream function in proto/snpb/metadata.go was removed as it was
redundant and no longer needed. The functionality is already covered by the
GetLogStream method.