### PR TITLE
fix: prevent panic on partial append failures

### DIFF
--- a/pkg/varlog/operations.go
+++ b/pkg/varlog/operations.go
@@ -74,7 +74,7 @@ RETRY:
 
 		for idx := 0; idx < len(res); idx++ {
 			if len(res[idx].Error) > 0 {
-				if strings.Contains(err.Error(), "sealed") {
+				if strings.Contains(res[idx].Error, "sealed") {
 					result.Err = fmt.Errorf("append: %s: %w", res[idx].Error, verrors.ErrSealed)
 				} else {
 					result.Err = fmt.Errorf("append: %s", res[idx].Error)


### PR DESCRIPTION
### What this PR does

This PR prevents client-side panics in append error handling by correctly accessing error messages from the result struct instead of a nil error variable during partial append failures.

### Anything else

Couldn't find a clean way to simulate partial failures on a specific log stream in the test environment, so test coverage was not added for this fix.