### PR TITLE
fix: unregistering topic translates to multiple redundant Raft proposals

### DIFF
--- a/internal/metarepos/raft_metadata_repository.go
+++ b/internal/metarepos/raft_metadata_repository.go
@@ -636,16 +636,15 @@ func (mr *RaftMetadataRepository) applyUnregisterTopic(r *mrpb.UnregisterTopic, 
 		return verrors.ErrNotExist
 	}
 
-UnregisterLS:
 	for _, lsID := range topic.LogStreams {
 		ls := mr.storage.lookupLogStream(lsID)
 		if ls == nil {
-			continue UnregisterLS
+			continue
 		}
 
 		err := mr.storage.unregisterLogStream(lsID)
 		if err != nil {
-			continue UnregisterLS
+			continue
 		}
 
 		for _, replica := range ls.Replicas {
@@ -656,8 +655,6 @@ UnregisterLS:
 				mr.logger.Panic("could not unregister reporter", zap.String("err", err.Error()))
 			}
 		}
-
-		return nil
 	}
 
 	err := mr.storage.UnregisterTopic(r.TopicID, nodeIndex, requestIndex)


### PR DESCRIPTION
### What this PR does

The current implementation of topic unregistration relies on proposeWithGuarantee's retry mechanism when deleting topics with multiple log streams. When a topic containing multiple log streams is unregistered, the control flow returns prematurely after deleting each log stream. This premature return prevents cacheCompleteCB from being called, which proposeWithGuarantee interprets as an incomplete operation that needs to be retried causing the unregistration time to scale linearly with the number of log streams (approximately 100ms per stream) and generates unnecessary consensus overhead.

The fix consolidates all log stream unregistrations into a single Raft proposal by removing the premature return.

### Anything else

With topics containing over 1 billion log streams, state machine operations could still take longer than 100ms, potentially triggering the same retry behavior addressed in this fix. However, this would not affect correctness as the retry mechanism would continue to function as intended. At such scale, other system constraints would likely manifest before this particular issue would resurface.