### PR TITLE
build(go): bump go from 1.23 to 1.24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
   PYTHON_VERSION: 3.9
   GRPC_HEALTH_PROBE_VERSION: v0.4.13
 jobs:
@@ -41,9 +41,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.3.1
+        uses: golangci/golangci-lint-action@v6.5.0
         with:
-          version: v1.60.1
+          version: v1.64.5
           skip-cache: true
           skip-pkg-cache: true
   build:

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ fmt:
 	@$(foreach path,$(PKGS),gofmt -w -s ./$(path);)
 
 lint:
-	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v1.60.1-alpine golangci-lint run
+	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v1.64.5-alpine golangci-lint run
 
 vet:
 	@echo govet

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,14 +17,14 @@ RUN wget --no-check-certificate -qO/bin/grpc_health_probe https://github.com/grp
     && chmod +x /bin/jq
 
 
-FROM golang:1.23 AS builder-cgo
+FROM golang:1.24 AS builder-cgo
 ARG DEBIAN_FRONTEND
 WORKDIR /varlog
 COPY . .
 RUN make build GCFLAGS=""
 
 
-FROM golang:1.23 AS builder-noncgo
+FROM golang:1.24 AS builder-noncgo
 ARG DEBIAN_FRONTEND
 WORKDIR /varlog
 COPY . .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kakao/varlog
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cockroachdb/pebble v1.1.4


### PR DESCRIPTION
### What this PR does

Bump Go from 1.23 to 1.24 and golangci-lint.
