### PR TITLE
refactor(logstream): consolidate append wait groups into a single object

### DIFF
--- a/internal/storagenode/logstream/committer_test.go
+++ b/internal/storagenode/logstream/committer_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/kakao/varlog/pkg/types"
+	"github.com/kakao/varlog/proto/varlogpb"
 )
 
 func TestCommitter_InvalidConfig(t *testing.T) {
@@ -61,9 +62,11 @@ func TestCommitter_ShouldNotAcceptTasksWhileNotAppendable(t *testing.T) {
 	})
 
 	cwt := &commitWaitTask{
-		awgs: []*appendWaitGroup{{
-			llsn: types.MinLLSN,
-		}},
+		awg: &appendWaitGroup{
+			beginLSN: varlogpb.LogSequenceNumber{
+				LLSN: types.MinLLSN,
+			},
+		},
 		size: 1,
 	}
 
@@ -144,8 +147,8 @@ func TestCommitter_DrainCommitWaitQ(t *testing.T) {
 	cm.lse = lse
 	cm.logger = zap.NewNop()
 
-	awg := newAppendWaitGroup(newWriteWaitGroup())
-	cwt := newCommitWaitTask([]*appendWaitGroup{awg}, 1)
+	awg := newAppendWaitGroup(newWriteWaitGroup(), 1)
+	cwt := newCommitWaitTask(awg, 1)
 	err := cm.sendCommitWaitTask(context.Background(), cwt, false /*ignoreSealing*/)
 	assert.NoError(t, err)
 

--- a/internal/storagenode/logstream/sequencer_test.go
+++ b/internal/storagenode/logstream/sequencer_test.go
@@ -70,13 +70,13 @@ func testSequenceTask(stg *storage.Storage) *sequenceTask {
 	st := newSequenceTask()
 
 	st.wwg = newWriteWaitGroup()
-	awg := newAppendWaitGroup(st.wwg)
-	st.awgs = append(st.awgs, awg)
+	awg := newAppendWaitGroup(st.wwg, 1)
+	st.awg = awg
 
 	st.wb = stg.NewWriteBatch()
 	st.dataBatch = [][]byte{nil}
 
-	st.cwt = newCommitWaitTask([]*appendWaitGroup{awg}, 1)
+	st.cwt = newCommitWaitTask(awg, 1)
 
 	st.rts = &replicateTaskSlice{}
 

--- a/internal/storagenode/logstream/writer_test.go
+++ b/internal/storagenode/logstream/writer_test.go
@@ -121,7 +121,7 @@ func TestWriter_UnexpectedLLSN(t *testing.T) {
 
 	assert.Panics(t, func() {
 		st := testSequenceTask(stg)
-		st.awgs[0].llsn = uncommittedLLSNEnd - 1 // not expected LLSN
+		st.awg.setBeginLLSN(uncommittedLLSNEnd - 1) // not expected LLSN
 		wr.writeLoopInternal(context.Background(), st)
 	})
 }


### PR DESCRIPTION
### What this PR does

This PR reduces append wait groups to a single object for each append batch. The
append wait groups are part of the following structs:

- appendContext
- commitWaitTask
- sequenceTask

Previously, multiple append wait groups existed because each log entry in a
batch had its own wait group. With the changes for issue #843, a single append
wait group now corresponds to an entire batch. This PR consolidates the list of
append wait groups into a single append wait group.

TODO: We are still on the road to resolving #843. The rest of the work mostly
involves cleaning up the code base.
