### PR TITLE
refactor(storagenode): add structured logging for recovery points and commit context

### DIFF
--- a/cmd/varlogadm/cli.go
+++ b/cmd/varlogadm/cli.go
@@ -79,6 +79,7 @@ func newStartCommand() *cli.Command {
 			flags.LogFileCompression,
 			flags.LogHumanReadable,
 			flags.LogLevel,
+			flags.EnableDevelopmentMode,
 
 			// telemetry
 			flags.TelemetryExporter,
@@ -101,7 +102,6 @@ func start(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	logOpts = append(logOpts, log.WithZapLoggerOptions(zap.AddStacktrace(zap.DPanicLevel)))
 	logger, err := log.New(logOpts...)
 	if err != nil {
 		return err

--- a/cmd/varlogadm/testdata/varlogadm.ct
+++ b/cmd/varlogadm/testdata/varlogadm.ct
@@ -44,6 +44,7 @@ OPTIONS:
 
    Logger:
 
+   --enable-development-mode            Enable development mode for the logger. Panics on DPanic-level logs if true. (default: false) [$ENABLE_DEVELOPMENT_MODE]
    --log-human-readable                 Human-readable output. (default: false) [$LOG_HUMAN_READABLE]
    --logdir value, --log-dir value      Directory for the log files. [$LOGDIR, $LOG_DIR]
    --logfile-compression                Compress backup log files. (default: false) [$LOGFILE_COMPRESSION]

--- a/cmd/varlogmr/metadata_repository.go
+++ b/cmd/varlogmr/metadata_repository.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/urfave/cli/v2"
 	_ "go.uber.org/automaxprocs"
-	"go.uber.org/zap"
 
 	"github.com/kakao/varlog/internal/buildinfo"
 	"github.com/kakao/varlog/internal/flags"
@@ -31,7 +30,6 @@ func start(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	logOpts = append(logOpts, log.WithZapLoggerOptions(zap.AddStacktrace(zap.DPanicLevel)))
 	logger, err := log.New(logOpts...)
 	if err != nil {
 		return err
@@ -168,6 +166,7 @@ func initCLI() *cli.App {
 				flags.LogFileCompression,
 				flags.LogHumanReadable,
 				flags.LogLevel,
+				flags.EnableDevelopmentMode,
 			},
 		}},
 	}

--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -95,6 +95,7 @@ func newStartCommand() *cli.Command {
 			flags.LogFileCompression,
 			flags.LogHumanReadable,
 			flags.LogLevel,
+			flags.EnableDevelopmentMode,
 
 			// telemetry
 			flags.TelemetryExporter,

--- a/cmd/varlogsn/testdata/varlogsn.ct
+++ b/cmd/varlogsn/testdata/varlogsn.ct
@@ -42,6 +42,7 @@ OPTIONS:
 
    Logger:
 
+   --enable-development-mode            Enable development mode for the logger. Panics on DPanic-level logs if true. (default: false) [$ENABLE_DEVELOPMENT_MODE]
    --log-human-readable                 Human-readable output. (default: false) [$LOG_HUMAN_READABLE]
    --logdir value, --log-dir value      Directory for the log files. [$LOGDIR, $LOG_DIR]
    --logfile-compression                Compress backup log files. (default: false) [$LOGFILE_COMPRESSION]

--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -42,7 +42,6 @@ func start(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	logOpts = append(logOpts, log.WithZapLoggerOptions(zap.AddStacktrace(zap.DPanicLevel)))
 	logger, err := log.New(logOpts...)
 	if err != nil {
 		return err

--- a/internal/flags/logger.go
+++ b/internal/flags/logger.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/urfave/cli/v2"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/kakao/varlog/pkg/util/log"
@@ -113,6 +114,14 @@ var (
 		Value:    DefaultLogLevel,
 		Usage:    "Log levels, either debug, info, warn, or error case-insensitively.",
 	}
+
+	EnableDevelopmentMode = &cli.BoolFlag{
+		Name:     "enable-development-mode",
+		Category: CategoryLogger,
+		EnvVars:  []string{"ENABLE_DEVELOPMENT_MODE"},
+		Value:    false,
+		Usage:    "Enable development mode for the logger. Panics on DPanic-level logs if true.",
+	}
 )
 
 func ParseLoggerFlags(c *cli.Context, maybeLogFileName string) (opts []log.Option, err error) {
@@ -151,6 +160,12 @@ func ParseLoggerFlags(c *cli.Context, maybeLogFileName string) (opts []log.Optio
 		return nil, err
 	}
 	opts = append(opts, log.WithLogLevel(level))
+
+	var zapOpts []zap.Option
+	if c.Bool(EnableDevelopmentMode.Name) {
+		zapOpts = append(zapOpts, zap.Development())
+	}
+	opts = append(opts, log.WithZapLoggerOptions(zapOpts...))
 
 	return opts, nil
 }

--- a/internal/storage/commit_context.go
+++ b/internal/storage/commit_context.go
@@ -1,6 +1,10 @@
 package storage
 
-import "github.com/kakao/varlog/pkg/types"
+import (
+	"go.uber.org/zap/zapcore"
+
+	"github.com/kakao/varlog/pkg/types"
+)
 
 // CommitContext is metadata that represents the environment in which the
 // commit is issued; for instance, the commit's version, the largest GLSN
@@ -126,4 +130,13 @@ func (cc CommitContext) Equal(other CommitContext) bool {
 		cc.CommittedGLSNBegin == other.CommittedGLSNBegin &&
 		cc.CommittedGLSNEnd == other.CommittedGLSNEnd &&
 		cc.CommittedLLSNBegin == other.CommittedLLSNBegin
+}
+
+func (cc CommitContext) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint64("version", uint64(cc.Version))
+	enc.AddUint64("highWatermark", uint64(cc.HighWatermark))
+	enc.AddUint64("committedGLSNBegin", uint64(cc.CommittedGLSNBegin))
+	enc.AddUint64("committedGLSNEnd", uint64(cc.CommittedGLSNEnd))
+	enc.AddUint64("committedLLSNBegin", uint64(cc.CommittedLLSNBegin))
+	return nil
 }

--- a/internal/storage/commit_context_test.go
+++ b/internal/storage/commit_context_test.go
@@ -1,0 +1,32 @@
+package storage
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/kakao/varlog/pkg/types"
+)
+
+func TestCommitContext_MarshalLogObject(t *testing.T) {
+	cc := CommitContext{
+		Version:            types.Version(rand.Uint64()),
+		HighWatermark:      types.GLSN(rand.Uint64()),
+		CommittedGLSNBegin: types.GLSN(rand.Uint64()),
+		CommittedGLSNEnd:   types.GLSN(rand.Uint64()),
+		CommittedLLSNBegin: types.LLSN(rand.Uint64()),
+	}
+
+	logger := zaptest.NewLogger(t)
+	t.Cleanup(func() {
+		_ = logger.Sync()
+	})
+
+	logger.Info("test", zap.Object("commitContext", cc))
+	require.Panics(t, func() {
+		logger.Info("test", zap.Object("commitContext", nil))
+	})
+}

--- a/internal/storage/recovery_points_test.go
+++ b/internal/storage/recovery_points_test.go
@@ -1,0 +1,67 @@
+package storage
+
+import (
+	"math/rand/v2"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/kakao/varlog/pkg/types"
+	"github.com/kakao/varlog/proto/varlogpb"
+)
+
+func TestRecoveryPoints_MarshalLogObject(t *testing.T) {
+	getRandomRecoveryPoints := func() RecoveryPoints {
+		rp := RecoveryPoints{}
+		if rand.N(2) == 0 {
+			rp.LastCommitContext = &CommitContext{
+				Version:            types.Version(rand.Uint64()),
+				HighWatermark:      types.GLSN(rand.Uint64()),
+				CommittedGLSNBegin: types.GLSN(rand.Uint64()),
+				CommittedGLSNEnd:   types.GLSN(rand.Uint64()),
+				CommittedLLSNBegin: types.LLSN(rand.Uint64()),
+			}
+		}
+		if rand.N(2) == 0 {
+			rp.CommittedLogEntry.First = &varlogpb.LogSequenceNumber{
+				LLSN: types.LLSN(rand.Uint64()),
+				GLSN: types.GLSN(rand.Uint64()),
+			}
+		}
+		if rand.N(2) == 0 {
+			rp.CommittedLogEntry.Last = &varlogpb.LogSequenceNumber{
+				LLSN: types.LLSN(rand.Uint64()),
+				GLSN: types.GLSN(rand.Uint64()),
+			}
+		}
+		rp.UncommittedLLSN.Begin = types.LLSN(rand.Uint64())
+		rp.UncommittedLLSN.End = types.LLSN(rand.Uint64())
+		return rp
+	}
+
+	tcs := []struct {
+		name string
+		rp   RecoveryPoints
+	}{
+		{
+			name: "ZeroValue",
+			rp:   RecoveryPoints{},
+		},
+		{
+			name: "RandomValue",
+			rp:   getRandomRecoveryPoints(),
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := zaptest.NewLogger(t)
+			t.Cleanup(func() {
+				_ = logger.Sync()
+			})
+
+			logger.Info("test", zap.Object("recoveryPoints", tc.rp))
+		})
+	}
+}

--- a/internal/storagenode/log_server.go
+++ b/internal/storagenode/log_server.go
@@ -103,6 +103,11 @@ func (ls *logServer) appendStreamRecvLoop(stream snpb.LogIO_AppendServer, cq cha
 			goto Out
 		}
 
+		if len(req.Payload) == 0 {
+			err = status.Error(codes.InvalidArgument, "no payload")
+			goto Out
+		}
+
 		if tpid.Invalid() && lsid.Invalid() {
 			err = snpb.ValidateTopicLogStream(req)
 			if err != nil {

--- a/internal/storagenode/logstream/backup_writer_test.go
+++ b/internal/storagenode/logstream/backup_writer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/kakao/varlog/internal/storage"
@@ -127,11 +128,12 @@ func TestBackupWriter_UnexpectedLLSN(t *testing.T) {
 	bw.logger = zap.NewNop()
 	bw.lse = lse
 
-	assert.Panics(t, func() {
-		wb := stg.NewWriteBatch()
-		err := wb.Set(uncommittedLLSNEnd+1, nil)
-		assert.NoError(t, err)
-		bwt := newBackupWriteTask(wb, uncommittedLLSNEnd+1, uncommittedLLSNEnd+2)
-		bw.writeLoopInternal(context.Background(), bwt)
-	})
+	wb := stg.NewWriteBatch()
+	err := wb.Set(uncommittedLLSNEnd+1, nil)
+	assert.NoError(t, err)
+	bwt := newBackupWriteTask(wb, uncommittedLLSNEnd+1, uncommittedLLSNEnd+2)
+	bw.writeLoopInternal(context.Background(), bwt)
+
+	// Keep the uncommittedLLSNEnd unchanged.
+	require.Equal(t, uncommittedLLSNEnd, bw.lse.lsc.uncommittedLLSNEnd.Load())
 }

--- a/internal/storagenode/logstream/executor.go
+++ b/internal/storagenode/logstream/executor.go
@@ -102,8 +102,10 @@ func NewExecutor(opts ...ExecutorOption) (lse *Executor, err error) {
 
 	rp, err := lse.stg.ReadRecoveryPoints()
 	if err != nil {
+		lse.logger.Error("could not read recovery points", zap.Error(err))
 		return nil, err
 	}
+	lse.logger.Info("read recovery points", zap.Object("recoveryPoints", rp))
 	lse.lsc = lse.restoreLogStreamContext(rp)
 
 	lse.decider = newDecidableCondition(lse.lsc)
@@ -643,7 +645,16 @@ func (lse *Executor) restoreLogStreamContext(rp storage.RecoveryPoints) *logStre
 	lsc := newLogStreamContext()
 	restoreMode := "init"
 	defer func() {
-		lse.logger.Info("restore log stream context", zap.String("mode", restoreMode))
+		lsn := lsc.localLWM.Load().(varlogpb.LogSequenceNumber)
+		lse.logger.Info("restore log stream context",
+			zap.String("mode", restoreMode),
+			zap.Uint64("reportCommitBase.commitVersion", uint64(lsc.base.commitVersion)),
+			zap.Uint64("reportCommitBase.highWatermark", uint64(lsc.base.highWatermark)),
+			zap.String("reportCommitBase.uncommittedBegin", lsc.base.uncommittedBegin.String()),
+			zap.Bool("reportCommitBase.invalid", lsc.base.invalid),
+			zap.Uint64("uncommittedLLSNEnd", uint64(lsc.uncommittedLLSNEnd.Load())),
+			zap.String("localLWM", lsn.String()),
+		)
 	}()
 
 	// Log stream replica that has not committed any logs yet. For example, a

--- a/internal/storagenode/logstream/writer_test.go
+++ b/internal/storagenode/logstream/writer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/kakao/varlog/internal/storage"
@@ -119,9 +120,10 @@ func TestWriter_UnexpectedLLSN(t *testing.T) {
 	wr.logger = zap.NewNop()
 	wr.lse = lse
 
-	assert.Panics(t, func() {
-		st := testSequenceTask(stg)
-		st.awg.setBeginLLSN(uncommittedLLSNEnd - 1) // not expected LLSN
-		wr.writeLoopInternal(context.Background(), st)
-	})
+	st := testSequenceTask(stg)
+	st.awg.setBeginLLSN(uncommittedLLSNEnd - 1) // not expected LLSN
+	wr.writeLoopInternal(context.Background(), st)
+
+	// Keep the uncommittedLLSNEnd unchanged.
+	require.Equal(t, uncommittedLLSNEnd, lse.lsc.uncommittedLLSNEnd.Load())
 }

--- a/internal/storagenode/storagenode_test.go
+++ b/internal/storagenode/storagenode_test.go
@@ -459,6 +459,14 @@ func TestStorageNode_Append(t *testing.T) {
 		testf func(t *testing.T, addr string, lc *client.LogClient)
 	}{
 		{
+			name: "NoPayload",
+			testf: func(t *testing.T, addr string, lc *client.LogClient) {
+				_, err := lc.Append(context.Background(), tpid, lsid, nil)
+				require.Error(t, err)
+				require.Equal(t, codes.InvalidArgument, status.Code(err))
+			},
+		},
+		{
 			name: "InvalidTopicID",
 			testf: func(t *testing.T, _ string, lc *client.LogClient) {
 				const invalidTopicID = types.TopicID(0)

--- a/pkg/util/log/log_test.go
+++ b/pkg/util/log/log_test.go
@@ -3,6 +3,8 @@ package log
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
 	"go.uber.org/zap"
 )
@@ -17,6 +19,39 @@ func ExampleLogger() {
 	}()
 
 	logger.Info("this is log", zap.String("example", "first"))
+}
+
+func TestEnableDevelopmentMode(t *testing.T) {
+	tcs := []struct {
+		name       string
+		zapOpts    []zap.Option
+		assertFunc func(t require.TestingT, f assert.PanicTestFunc, msgAndArgs ...any)
+	}{
+		{
+			name:       "DevelopmentMode",
+			zapOpts:    []zap.Option{zap.Development()},
+			assertFunc: require.Panics,
+		},
+		{
+			name:       "ProductionMode",
+			zapOpts:    nil,
+			assertFunc: require.NotPanics,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			logger, err := New(WithZapLoggerOptions(tc.zapOpts...))
+			require.NoError(t, err)
+			defer func() {
+				_ = logger.Sync()
+			}()
+
+			tc.assertFunc(t, func() {
+				logger.DPanic("panic occur")
+			})
+		})
+	}
 }
 
 func TestMain(m *testing.M) {

--- a/proto/snpb/log_io.pb.go
+++ b/proto/snpb/log_io.pb.go
@@ -940,18 +940,18 @@ type LogIOClient interface {
 	// is, some of the log entries could not be stored due to failures.
 	//
 	// It returns the following gRPC errors:
-	// - InvalidArgument: AppendRequest has invalid fields; for instance, TopicID
-	// is invalid.
-	// - NotFound: The log stream replica specified by the AppendRequest does not
-	// exist in the storage node. Note that it does not mean that the log stream
-	// does not exist in the cluster.
-	// - FailedPrecondition: The log stream may be sealed; thus, clients cannot
-	// write the log entry. Clients should unseal the log stream to append a log
-	// entry to the log stream.
-	// - Unavailable: The storage node is shutting down, or the log stream replica
-	// is not primary.
-	// - Canceled: The client canceled the request.
-	// - DeadlineExceeded: The client's timeout has expired.
+	//   - InvalidArgument: AppendRequest has invalid fields; for instance,
+	//   TopicID or LogStreamID is invalid, or there is no payload.
+	//   - NotFound: The log stream replica specified by the AppendRequest does
+	//   not exist in the storage node. Note that it does not mean that the log
+	//   stream does not exist in the cluster.
+	//   - FailedPrecondition: The log stream may be sealed; thus, clients cannot
+	//   write the log entry. Clients should unseal the log stream to append a log
+	//   entry to the log stream.
+	//   - Unavailable: The storage node is shutting down, or the log stream
+	//   replica is not primary.
+	//   - Canceled: The client canceled the request.
+	//   - DeadlineExceeded: The client's timeout has expired.
 	//
 	// FIXME: Partial failures are not specified by the gRPC error codes.
 	Append(ctx context.Context, opts ...grpc.CallOption) (LogIO_AppendClient, error)
@@ -1115,18 +1115,18 @@ type LogIOServer interface {
 	// is, some of the log entries could not be stored due to failures.
 	//
 	// It returns the following gRPC errors:
-	// - InvalidArgument: AppendRequest has invalid fields; for instance, TopicID
-	// is invalid.
-	// - NotFound: The log stream replica specified by the AppendRequest does not
-	// exist in the storage node. Note that it does not mean that the log stream
-	// does not exist in the cluster.
-	// - FailedPrecondition: The log stream may be sealed; thus, clients cannot
-	// write the log entry. Clients should unseal the log stream to append a log
-	// entry to the log stream.
-	// - Unavailable: The storage node is shutting down, or the log stream replica
-	// is not primary.
-	// - Canceled: The client canceled the request.
-	// - DeadlineExceeded: The client's timeout has expired.
+	//   - InvalidArgument: AppendRequest has invalid fields; for instance,
+	//   TopicID or LogStreamID is invalid, or there is no payload.
+	//   - NotFound: The log stream replica specified by the AppendRequest does
+	//   not exist in the storage node. Note that it does not mean that the log
+	//   stream does not exist in the cluster.
+	//   - FailedPrecondition: The log stream may be sealed; thus, clients cannot
+	//   write the log entry. Clients should unseal the log stream to append a log
+	//   entry to the log stream.
+	//   - Unavailable: The storage node is shutting down, or the log stream
+	//   replica is not primary.
+	//   - Canceled: The client canceled the request.
+	//   - DeadlineExceeded: The client's timeout has expired.
 	//
 	// FIXME: Partial failures are not specified by the gRPC error codes.
 	Append(LogIO_AppendServer) error

--- a/proto/snpb/log_io.proto
+++ b/proto/snpb/log_io.proto
@@ -184,18 +184,18 @@ service LogIO {
   // is, some of the log entries could not be stored due to failures.
   //
   // It returns the following gRPC errors:
-  // - InvalidArgument: AppendRequest has invalid fields; for instance, TopicID
-  // is invalid.
-  // - NotFound: The log stream replica specified by the AppendRequest does not
-  // exist in the storage node. Note that it does not mean that the log stream
-  // does not exist in the cluster.
-  // - FailedPrecondition: The log stream may be sealed; thus, clients cannot
-  // write the log entry. Clients should unseal the log stream to append a log
-  // entry to the log stream.
-  // - Unavailable: The storage node is shutting down, or the log stream replica
-  // is not primary.
-  // - Canceled: The client canceled the request.
-  // - DeadlineExceeded: The client's timeout has expired.
+  //   - InvalidArgument: AppendRequest has invalid fields; for instance,
+  //   TopicID or LogStreamID is invalid, or there is no payload.
+  //   - NotFound: The log stream replica specified by the AppendRequest does
+  //   not exist in the storage node. Note that it does not mean that the log
+  //   stream does not exist in the cluster.
+  //   - FailedPrecondition: The log stream may be sealed; thus, clients cannot
+  //   write the log entry. Clients should unseal the log stream to append a log
+  //   entry to the log stream.
+  //   - Unavailable: The storage node is shutting down, or the log stream
+  //   replica is not primary.
+  //   - Canceled: The client canceled the request.
+  //   - DeadlineExceeded: The client's timeout has expired.
   //
   // FIXME: Partial failures are not specified by the gRPC error codes.
   rpc Append(stream AppendRequest) returns (stream AppendResponse) {}


### PR DESCRIPTION
### What this PR does

Enhance logging while bootstrapping log stream replica:

- Add `MarshalLogObject` method to `CommitContext` and `RecoveryPoints` for
  structured logging.
- Add logs to print more useful information during data loading on restarts.
