### PR TITLE
refactor(metarepos): suppress logging in GetMetadata method

### DIFF
--- a/internal/metarepos/raft_metadata_repository.go
+++ b/internal/metarepos/raft_metadata_repository.go
@@ -1315,10 +1315,12 @@ func (mr *RaftMetadataRepository) GetMetadata(context.Context) (*varlogpb.Metada
 	}
 
 	m := mr.storage.GetMetadata()
-	mr.logger.Info("GetMetadata",
-		zap.Int("SN", len(m.GetStorageNodes())),
-		zap.Int("LS", len(m.GetLogStreams())),
-	)
+	if ce := mr.logger.Check(zap.DebugLevel, "GetMetadata"); ce != nil {
+		ce.Write(
+			zap.Int("SN", len(m.GetStorageNodes())),
+			zap.Int("LS", len(m.GetLogStreams())),
+		)
+	}
 	return m, nil
 }
 


### PR DESCRIPTION
### What this PR does

Change logging level to Debug for the GetMetadata method in
raft_metadata_repository.go to reduce verbosity.
