### PR TITLE
fix(metarepos): reportCollector handles invalid report propertly

### DIFF
--- a/internal/metarepos/dummy_storagenode_client_factory_impl.go
+++ b/internal/metarepos/dummy_storagenode_client_factory_impl.go
@@ -408,6 +408,13 @@ func (r *DummyStorageNodeClient) getKnownVersion(idx int) types.Version {
 	return r.knownVersion[idx]
 }
 
+func (r *DummyStorageNodeClient) setKnownVersion(idx int, ver types.Version) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.knownVersion[idx] = ver
+}
+
 func (r *DummyStorageNodeClient) makeInvalid(idx int) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/internal/metarepos/raft_metadata_repository.go
+++ b/internal/metarepos/raft_metadata_repository.go
@@ -779,17 +779,19 @@ func (mr *RaftMetadataRepository) applyReport(reports *mrpb.Reports) error {
 				s.UncommittedLLSNEnd() < u.UncommittedLLSNEnd()) ||
 				s.Version < u.Version {
 				if s.UncommittedLLSNEnd() > u.UncommittedLLSNEnd() {
-					mr.logger.Error("unexpeted report",
-						zap.Any("nodeID", reports.GetNodeID()),
-						zap.Any("sn", snID),
-						zap.Any("ls", u.GetLogStreamID()),
-						zap.Any("ver", u.GetVersion()),
-						zap.Any("off", u.GetUncommittedLLSNOffset()),
-						zap.Any("end", u.UncommittedLLSNEnd()),
-						zap.Any("cver", s.GetVersion()),
-						zap.Any("coff", s.GetUncommittedLLSNOffset()),
-						zap.Any("cend", s.UncommittedLLSNEnd()),
-					)
+					if ce := mr.logger.Check(zap.DebugLevel, "unexpected report"); ce != nil {
+						ce.Write(
+							zap.Any("nodeID", reports.GetNodeID()),
+							zap.Any("sn", snID),
+							zap.Any("ls", u.GetLogStreamID()),
+							zap.Any("ver", u.GetVersion()),
+							zap.Any("off", u.GetUncommittedLLSNOffset()),
+							zap.Any("end", u.UncommittedLLSNEnd()),
+							zap.Any("cver", s.GetVersion()),
+							zap.Any("coff", s.GetUncommittedLLSNOffset()),
+							zap.Any("cend", s.UncommittedLLSNEnd()),
+						)
+					}
 					continue LS
 				}
 				mr.storage.UpdateUncommitReport(u.LogStreamID, snID, u)

--- a/internal/metarepos/report_collector.go
+++ b/internal/metarepos/report_collector.go
@@ -3,7 +3,6 @@ package metarepos
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -681,14 +680,10 @@ func (rce *reportCollectExecutor) processReport(response *snpb.GetReportResponse
 			i++
 		} else {
 			if cur.Version < prev.Version {
-				fmt.Printf("invalid report prev:%v, cur:%v\n",
-					prev.Version, cur.Version)
-				rce.logger.Panic("invalid report",
+				rce.logger.Error("invalid report",
 					zap.Any("prev", prev.Version),
 					zap.Any("cur", cur.Version))
-			}
-
-			if cur.UncommittedLLSNOffset > prev.UncommittedLLSNOffset ||
+			} else if cur.UncommittedLLSNOffset > prev.UncommittedLLSNOffset ||
 				cur.UncommittedLLSNEnd() > prev.UncommittedLLSNEnd() {
 				diff.UncommitReports = append(diff.UncommitReports, cur)
 			}


### PR DESCRIPTION
### What this PR does

This patch makes the report collector handle invalid reports properly. The report collector determines whether a report is invalid based on previously received report.

If valogsn terminates abnormally, the report collector may receive an invalid report and must handle it properly.

### Which issue(s) this PR resolves

Resolves #1011 

### Anything else

Include any links or documentation that might be helpful for reviewers.
