### PR TITLE
fix(storagenode): prevent panic during replica sealing in synchronization

### DIFF
--- a/internal/storagenode/logstream/executor.go
+++ b/internal/storagenode/logstream/executor.go
@@ -241,10 +241,23 @@ func (lse *Executor) Seal(_ context.Context, lastCommittedGLSN types.GLSN) (stat
 
 	lse.esm.compareAndSwap(executorStateAppendable, executorStateSealing)
 	if lse.esm.load() == executorStateSealed {
+		// BUG: A log stream replica returns the local high watermark that can
+		// be zero if all log entries are trimmed. However, an already sealed
+		// replica returns the last committed GLSN instead of the local high
+		// watermark, thus it might not be zero.
 		return varlogpb.LogStreamStatusSealed, lastCommittedGLSN, nil
 	}
 
 	_, _, uncommittedBegin, invalid := lse.lsc.reportCommitBase()
+
+	// This log stream should be synchronized from other replicas since
+	// `uncommittedBegin.GLSN` is invalid.
+	//
+	// TODO: Simplify `uncommittedBegin` usage.
+	if uncommittedBegin.GLSN.Invalid() {
+		return varlogpb.LogStreamStatusSealing, types.InvalidGLSN, nil
+	}
+
 	if uncommittedBegin.GLSN-1 > lastCommittedGLSN {
 		lse.logger.Panic("log stream: seal: metadata repository may be behind of log stream",
 			zap.Any("local", uncommittedBegin.GLSN-1),


### PR DESCRIPTION
### What this PR does

This commit fixes a bug that could cause panic during replica sealing in
synchronization. Specifically, if the replica has no log entries (e.g., just
joined or trimmed all), `uncommittedBegin.GLSN` is zero. When the replica
receives a Seal RPC, it can be panicked due to an invalid comparison.
`uncommittedBegin.GLSN-1` is MaxUInt64 since it's a 64-bit unsigned integer.

See
[this code](https://github.com/kakao/varlog/blob/15d90d2b7aed9ebaec57130dc09f3f06b3b750f8/internal/storagenode/logstream/executor.go#L245-L251)

```go
_, _, uncommittedBegin, invalid := lse.lsc.reportCommitBase()
if uncommittedBegin.GLSN-1 > lastCommittedGLSN {
 lse.logger.Panic("log stream: seal: metadata repository may be behind of log stream",
  zap.Any("local", uncommittedBegin.GLSN-1),
  zap.Any("mr", lastCommittedGLSN),
 )
}
```
