### PR TITLE
ci(lint): bump golangci-lint from v1.64.5 to v2.0.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,9 +39,9 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6.5.0
+        uses: golangci/golangci-lint-action@v7.0.0
         with:
-          version: v1.64.5
+          version: v2.0.2
           skip-cache: true
           skip-pkg-cache: true
   build:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,65 +1,84 @@
-run:
-  timeout: 5m
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
     - depguard
     - errcheck
     - godot
-    - gofmt
-    - goimports
-    - gosimple
     - govet
     - ineffassign
     - misspell
     - revive
     - staticcheck
-    - typecheck
     - unused
-linters-settings:
-  depguard:
+  settings:
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: golang.org/x/net/context
+              desc: Should be replaced by standard lib context package
+            - pkg: golang.org/x/exp/slog
+              desc: Should be replaced by standard lib slog package
+            - pkg: golang.org/x/exp/slices
+              desc: Should be replaced by standard lib slices package
+    godot:
+      exclude:
+        - ^ TODO
+        - ^ FIXME
+        - ^ NOTE
+        - ^ NB
+        - :$
+        - ^[ ]*[-*]
+    misspell:
+      locale: US
+    revive:
+      confidence: 0.1
+      rules:
+        - name: unhandled-error
+          arguments:
+            - fmt.Fprint
+            - fmt.Fprintf
+            - fmt.Fprintln
+            - fmt.Print
+            - fmt.Printf
+            - fmt.Println
+            - strings.Builder.WriteString
+            - strings.Builder.WriteByte
+          disabled: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      main:
-        deny:
-          - pkg: golang.org/x/net/context
-            desc: Should be replaced by standard lib context package
-          - pkg: golang.org/x/exp/slog
-            desc: Should be replaced by standard lib slog package
-          - pkg: golang.org/x/exp/slices
-            desc: Should be replaced by standard lib slices package
-  godot:
-    exclude:
-      - "^ TODO"
-      - "^ FIXME"
-      - "^ NOTE"
-      - "^ NB"
-      - ":$"
-      - "^[ ]*[-*]"
-  goimports:
-    local-prefixes: github.com/kakao/varlog
-  misspell:
-    locale: US
-  revive:
-    confidence: 0.1
-    rules:
-      - name: unhandled-error
-        disabled: false
-        arguments:
-          - "fmt.Fprint"
-          - "fmt.Fprintf"
-          - "fmt.Fprintln"
-          - "fmt.Print"
-          - "fmt.Printf"
-          - "fmt.Println"
-          - "strings.Builder.WriteString"
-          - "strings.Builder.WriteByte"
+      - linters:
+          - mnd
+        path: _test\.go
+    paths:
+      - .*\.pb\.go$
+      - .*_mock\.go$
+      - third_party$
+      - builtin$
+      - examples$
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - gomnd
-  exclude-files:
-    - ".*\\.pb\\.go$"
-    - ".*_mock\\.go$"
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/kakao/varlog
+  exclusions:
+    generated: lax
+    paths:
+      - .*\.pb\.go$
+      - .*_mock\.go$
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ fmt:
 	@$(foreach path,$(PKGS),gofmt -w -s ./$(path);)
 
 lint:
-	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v1.64.5-alpine golangci-lint run
+	docker run --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v2.0.2-alpine golangci-lint run
 
 vet:
 	@echo govet

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -744,9 +744,10 @@ func (adm *Admin) updateLogStream(ctx context.Context, lsid types.LogStreamID, p
 	popIdx, pushIdx := -1, -1
 	for idx := range oldLSDesc.Replicas {
 		snid := oldLSDesc.Replicas[idx].StorageNodeID
-		if snid == poppedReplica.StorageNodeID {
+		switch snid {
+		case poppedReplica.StorageNodeID:
 			popIdx = idx
-		} else if snid == pushedReplica.StorageNodeID {
+		case pushedReplica.StorageNodeID:
 			pushIdx = idx
 		}
 	}

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -298,7 +298,7 @@ func (adm *Admin) listStorageNodesInternal(ctx context.Context) ([]admpb.Storage
 		})
 	}
 	sort.Slice(snms, func(i, j int) bool {
-		return snms[i].StorageNode.StorageNodeID < snms[j].StorageNode.StorageNodeID
+		return snms[i].StorageNodeID < snms[j].StorageNodeID
 	})
 	return snms, nil
 }
@@ -313,7 +313,7 @@ func (adm *Admin) addStorageNode(ctx context.Context, snid types.StorageNodeID, 
 	// If there is a storage node whose ID and address are the same as the
 	// arguments snid and addr, it will succeed. If only one of them is the
 	// same, it will fail by the metadata repository.
-	if snm, ok := adm.statRepository.GetStorageNode(snid); ok && snm.StorageNode.Address == addr {
+	if snm, ok := adm.statRepository.GetStorageNode(snid); ok && snm.Address == addr {
 		return snm, nil
 	}
 
@@ -332,7 +332,7 @@ func (adm *Admin) addStorageNode(ctx context.Context, snid types.StorageNodeID, 
 	}
 
 	confirm := func() *admpb.StorageNodeMetadata {
-		adm.snmgr.AddStorageNode(ctx, snmd.StorageNode.StorageNodeID, addr)
+		adm.snmgr.AddStorageNode(ctx, snmd.StorageNodeID, addr)
 		_, _ = adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx) // Fetch new cluster metadata.
 		adm.statRepository.Report(ctx, snmd, now)
 		if snm, ok := adm.statRepository.GetStorageNode(snid); ok {
@@ -1249,7 +1249,7 @@ func (adm *Admin) HandleReport(ctx context.Context, snm *snpb.StorageNodeMetadat
 			continue
 		}
 		if time.Since(ls.CreatedTime) > adm.logStreamGCTimeout {
-			_ = adm.removeLogStreamReplica(ctx, snm.StorageNode.StorageNodeID, ls.TopicID, ls.LogStreamID)
+			_ = adm.removeLogStreamReplica(ctx, snm.StorageNodeID, ls.TopicID, ls.LogStreamID)
 		}
 	}
 

--- a/internal/admin/testing.go
+++ b/internal/admin/testing.go
@@ -38,7 +38,7 @@ func (ts *TestServer) Serve(t *testing.T) {
 	}()
 
 	assert.Eventually(t, func() bool {
-		return len(ts.Admin.Address()) > 0
+		return len(ts.Address()) > 0
 	}, time.Second, 10*time.Millisecond)
 }
 

--- a/internal/benchmark/report.go
+++ b/internal/benchmark/report.go
@@ -48,9 +48,9 @@ type EndToEndReport struct {
 }
 
 type Report struct {
-	AppendReport    `json:"append"`
-	SubscribeReport `json:"subscribe"`
-	EndToEndReport  `json:"endToEnd"`
+	AppendReport    AppendReport    `json:"append"`
+	SubscribeReport SubscribeReport `json:"subscribe"`
+	EndToEndReport  EndToEndReport  `json:"endToEnd"`
 }
 
 type TargetReport struct {

--- a/internal/metarepos/dummy_storagenode_client_factory_impl.go
+++ b/internal/metarepos/dummy_storagenode_client_factory_impl.go
@@ -257,9 +257,10 @@ func (r *DummyStorageNodeClient) GetReport() (*snpb.GetReportResponse, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.status == DummyStorageNodeClientStatusCrash {
+	switch r.status {
+	case DummyStorageNodeClientStatusCrash:
 		return nil, errors.New("crash")
-	} else if r.status == DummyStorageNodeClientStatusClosed {
+	case DummyStorageNodeClientStatusClosed:
 		return nil, errors.New("closed")
 	}
 
@@ -297,9 +298,10 @@ func (r *DummyStorageNodeClient) commit(cr snpb.LogStreamCommitResult) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	if r.status == DummyStorageNodeClientStatusCrash {
+	switch r.status {
+	case DummyStorageNodeClientStatusCrash:
 		return errors.New("crash")
-	} else if r.status == DummyStorageNodeClientStatusClosed {
+	case DummyStorageNodeClientStatusClosed:
 		return errors.New("closed")
 	}
 

--- a/internal/storagenode/client/management_client.go
+++ b/internal/storagenode/client/management_client.go
@@ -48,7 +48,7 @@ func NewManagementClient(ctx context.Context, clusterID types.ClusterID, address
 	if err != nil {
 		return nil, multierr.Append(err, rpcConn.Close())
 	}
-	storageNodeID := rsp.GetStorageNodeMetadata().StorageNode.StorageNodeID
+	storageNodeID := rsp.GetStorageNodeMetadata().StorageNodeID
 
 	return &ManagementClient{
 		rpcConn:   rpcConn,

--- a/internal/storagenode/storagenode_test.go
+++ b/internal/storagenode/storagenode_test.go
@@ -107,7 +107,7 @@ func TestStorageNode(t *testing.T) {
 
 	// sn1: get path
 	snmd1 := TestGetStorageNodeMetadataDescriptor(t, cid, sn1.snid, sn1.advertise)
-	assert.Equal(t, snid1, snmd1.StorageNode.StorageNodeID)
+	assert.Equal(t, snid1, snmd1.StorageNodeID)
 	assert.NotEmpty(t, snmd1.Storages)
 	assert.NotEmpty(t, snmd1.Storages[0].Path)
 	// sn1: add ls
@@ -115,7 +115,7 @@ func TestStorageNode(t *testing.T) {
 
 	// sn2: get path
 	snmd2 := TestGetStorageNodeMetadataDescriptor(t, cid, sn2.snid, sn2.advertise)
-	assert.Equal(t, snid2, snmd2.StorageNode.StorageNodeID)
+	assert.Equal(t, snid2, snmd2.StorageNodeID)
 	assert.NotEmpty(t, snmd2.Storages)
 	assert.NotEmpty(t, snmd2.Storages[0].Path)
 	// sn2: add ls

--- a/internal/varlogctl/controller_test.go
+++ b/internal/varlogctl/controller_test.go
@@ -197,17 +197,17 @@ func TestController(t *testing.T) {
 		{
 			name:        "GetStorageNode0",
 			golden:      "varlogctl/getstoragenode.0.golden.json",
-			executeFunc: storagenode.Describe(snm1.StorageNode.StorageNodeID),
+			executeFunc: storagenode.Describe(snm1.StorageNodeID),
 			initMock: func(adm *varlog.MockAdmin) {
-				adm.EXPECT().GetStorageNode(gomock.Any(), snm1.StorageNode.StorageNodeID).Return(snm1, nil)
+				adm.EXPECT().GetStorageNode(gomock.Any(), snm1.StorageNodeID).Return(snm1, nil)
 			},
 		},
 		{
 			name:        "GetStorageNode1",
 			golden:      "varlogctl/getstoragenode.1.golden.json",
-			executeFunc: storagenode.Describe(snm2.StorageNode.StorageNodeID),
+			executeFunc: storagenode.Describe(snm2.StorageNodeID),
 			initMock: func(adm *varlog.MockAdmin) {
-				adm.EXPECT().GetStorageNode(gomock.Any(), snm2.StorageNode.StorageNodeID).Return(snm2, nil)
+				adm.EXPECT().GetStorageNode(gomock.Any(), snm2.StorageNodeID).Return(snm2, nil)
 			},
 		},
 		{
@@ -231,7 +231,7 @@ func TestController(t *testing.T) {
 		{
 			name:        "AddStorageNode0",
 			golden:      "varlogctl/addstoragenode.0.golden.json",
-			executeFunc: storagenode.Add(snm1.StorageNode.Address, snm1.StorageNode.StorageNodeID),
+			executeFunc: storagenode.Add(snm1.Address, snm1.StorageNodeID),
 			initMock: func(adm *varlog.MockAdmin) {
 				adm.EXPECT().AddStorageNode(
 					gomock.Any(),
@@ -243,7 +243,7 @@ func TestController(t *testing.T) {
 		{
 			name:        "UnregisterStorageNode0",
 			golden:      "varlogctl/unregisterstoragenode.0.golden.json",
-			executeFunc: storagenode.Remove(snm1.StorageNode.Address, snm1.StorageNode.StorageNodeID),
+			executeFunc: storagenode.Remove(snm1.Address, snm1.StorageNodeID),
 			initMock: func(adm *varlog.MockAdmin) {
 				adm.EXPECT().UnregisterStorageNode(
 					gomock.Any(),

--- a/pkg/varlog/admin.go
+++ b/pkg/varlog/admin.go
@@ -199,9 +199,10 @@ func (c *admin) GetStorageNode(ctx context.Context, snid types.StorageNodeID, op
 	})
 	if err != nil {
 		code := status.Convert(err).Code()
-		if code == codes.NotFound {
+		switch code {
+		case codes.NotFound:
 			err = verrors.ErrNotExist
-		} else if code == codes.Unavailable {
+		case codes.Unavailable:
 			err = verrors.ErrUnavailable
 		}
 		return nil, errors.WithMessage(err, "admin: get storage node")
@@ -217,9 +218,10 @@ func (c *admin) ListStorageNodes(ctx context.Context, opts ...AdminCallOption) (
 	rsp, err := c.rpcClient.ListStorageNodes(ctx, &admpb.ListStorageNodesRequest{})
 	if err != nil {
 		code := status.Convert(err).Code()
-		if code == codes.NotFound {
+		switch code {
+		case codes.NotFound:
 			err = verrors.ErrNotExist
-		} else if code == codes.Unavailable {
+		case codes.Unavailable:
 			err = verrors.ErrUnavailable
 		}
 		return nil, errors.WithMessage(err, "admin: list storage nodes")

--- a/pkg/varlog/admin.go
+++ b/pkg/varlog/admin.go
@@ -6,8 +6,6 @@ import (
 	"context"
 	stderrors "errors"
 
-	"github.com/kakao/varlog/proto/admpb"
-
 	pbtypes "github.com/gogo/protobuf/types"
 	"github.com/gogo/status"
 	"github.com/pkg/errors"
@@ -16,6 +14,7 @@ import (
 	"github.com/kakao/varlog/pkg/rpc"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/verrors"
+	"github.com/kakao/varlog/proto/admpb"
 	"github.com/kakao/varlog/proto/snpb"
 	"github.com/kakao/varlog/proto/varlogpb"
 )
@@ -239,7 +238,7 @@ func (c *admin) GetStorageNodes(ctx context.Context, opts ...AdminCallOption) (m
 	}
 	ret := make(map[types.StorageNodeID]admpb.StorageNodeMetadata, len(snms))
 	for _, snm := range snms {
-		ret[snm.StorageNode.StorageNodeID] = snm
+		ret[snm.StorageNodeID] = snm
 	}
 	return ret, nil
 }

--- a/pkg/varlog/subscribe.go
+++ b/pkg/varlog/subscribe.go
@@ -486,7 +486,7 @@ func (q *subscribedLogEntriesQueue) pushBack(result client.SubscribeResult) {
 }
 
 func (q *subscribedLogEntriesQueue) pushable(result client.SubscribeResult) bool {
-	return result.LogEntry.GLSN == q.wanted || result.Error != nil
+	return result.GLSN == q.wanted || result.Error != nil
 }
 
 func (q *subscribedLogEntriesQueue) close() {

--- a/pkg/varlogtest/admin.go
+++ b/pkg/varlogtest/admin.go
@@ -90,7 +90,7 @@ func (c *testAdmin) GetStorageNodes(ctx context.Context, opts ...varlog.AdminCal
 	}
 	ret := make(map[types.StorageNodeID]admpb.StorageNodeMetadata, len(snms))
 	for _, snm := range snms {
-		ret[snm.StorageNode.StorageNodeID] = snm
+		ret[snm.StorageNodeID] = snm
 	}
 	return ret, nil
 }
@@ -272,7 +272,7 @@ func (c *testAdmin) AddLogStream(_ context.Context, topicID types.TopicID, logSt
 			snpath := c.vt.storageNodes[snid].Storages[0].Path
 			dataPath := filepath.Join(snpath, volume.LogStreamDirName(topicID, logStreamID))
 			lsd.Replicas[i] = &varlogpb.ReplicaDescriptor{
-				StorageNodeID:   c.vt.storageNodes[snid].StorageNode.StorageNodeID,
+				StorageNodeID:   c.vt.storageNodes[snid].StorageNodeID,
 				StorageNodePath: c.vt.storageNodes[snid].Storages[0].Path,
 				DataPath:        dataPath,
 			}

--- a/pkg/varlogtest/admin.go
+++ b/pkg/varlogtest/admin.go
@@ -328,9 +328,10 @@ func (c *testAdmin) UpdateLogStream(ctx context.Context, topicID types.TopicID, 
 	popIdx, pushIdx := -1, -1
 	for idx := range logStreamDesc.Replicas {
 		snid := logStreamDesc.Replicas[idx].StorageNodeID
-		if snid == poppedReplica.StorageNodeID {
+		switch snid {
+		case poppedReplica.StorageNodeID:
 			popIdx = idx
-		} else if snid == pushedReplica.StorageNodeID {
+		case pushedReplica.StorageNodeID:
 			pushIdx = idx
 		}
 	}

--- a/pkg/varlogtest/varlogtest_test.go
+++ b/pkg/varlogtest/varlogtest_test.go
@@ -300,7 +300,7 @@ func TestVarlotTest_LogStreamAppender(t *testing.T) {
 				require.Equal(t, cid, snMetaDesc.ClusterID)
 				require.Empty(t, snMetaDesc.LogStreamReplicas)
 				require.Equal(t, varlogpb.StorageNodeStatusRunning, snMetaDesc.Status)
-				require.Equal(t, addr, snMetaDesc.StorageNode.Address)
+				require.Equal(t, addr, snMetaDesc.Address)
 				require.NotEmpty(t, snMetaDesc.Storages)
 			}
 
@@ -402,7 +402,7 @@ func TestVarlogTest(t *testing.T) {
 		require.Equal(t, clusterID, snMetaDesc.ClusterID)
 		require.Empty(t, snMetaDesc.LogStreamReplicas)
 		require.Equal(t, varlogpb.StorageNodeStatusRunning, snMetaDesc.Status)
-		require.Equal(t, addr, snMetaDesc.StorageNode.Address)
+		require.Equal(t, addr, snMetaDesc.Address)
 		require.NotEmpty(t, snMetaDesc.Storages)
 	}
 

--- a/proto/varlogpb/replica.go
+++ b/proto/varlogpb/replica.go
@@ -21,7 +21,7 @@ func EqualReplicas(xs []LogStreamReplica, ys []LogStreamReplica) bool {
 				return false
 			}
 		*/
-		if x.StorageNode.StorageNodeID != y.StorageNode.StorageNodeID || x.LogStreamID != y.LogStreamID {
+		if x.StorageNodeID != y.StorageNodeID || x.LogStreamID != y.LogStreamID {
 			return false
 		}
 	}
@@ -39,7 +39,7 @@ func ValidReplicas(replicas []LogStreamReplica) error {
 	snidSet := set.New(len(replicas))
 	for _, replica := range replicas {
 		lsidSet.Add(replica.LogStreamID)
-		snidSet.Add(replica.StorageNode.StorageNodeID)
+		snidSet.Add(replica.StorageNodeID)
 	}
 	if lsidSet.Size() != 1 {
 		return errors.Wrap(verrors.ErrInvalid, "LogStreamID mismatch")

--- a/tests/it/testenv.go
+++ b/tests/it/testenv.go
@@ -532,7 +532,7 @@ func (clus *VarlogCluster) AddSN(t *testing.T) types.StorageNodeID {
 	var addr string
 	require.Eventually(t, func() bool {
 		meta := storagenode.TestGetStorageNodeMetadataDescriptorWithoutAddr(t, sn)
-		addr = meta.StorageNode.Address
+		addr = meta.Address
 		return len(addr) > 0
 	}, time.Second, 10*time.Millisecond)
 
@@ -819,7 +819,7 @@ func (clus *VarlogCluster) AddLSIncomplete(t *testing.T, topicID types.TopicID) 
 	}
 
 	for _, replica := range replicas {
-		snID := replica.StorageNode.StorageNodeID
+		snID := replica.StorageNodeID
 		snmd, err := clus.storageNodeManagementClientOf(t, snID).GetMetadata(context.Background())
 		require.NoError(t, err)
 		path := snmd.Storages[0].Path


### PR DESCRIPTION
### What this PR does

This commit updates golangci-lint in Makefile from v1.64.5 to v2.0.2. It also
refactors the code to comply with staticcheck rules QF1008 and QF1003.
