### PR TITLE
fix(admin): fix snwatcher handle heartbeat timeout

### DIFF
--- a/cmd/varlogadm/cli.go
+++ b/cmd/varlogadm/cli.go
@@ -54,7 +54,8 @@ func newStartCommand() *cli.Command {
 			flagMRConnTimeout.DurationFlag(false, mrmanager.DefaultMRConnTimeout),
 			flagMRCallTimeout.DurationFlag(false, mrmanager.DefaultMRCallTimeout),
 
-			flagSNWatcherHeartbeatCheckDeadline.DurationFlag(false, snwatcher.DefaultHeartbeatDeadline),
+			flagSNWatcherHeartbeatCheckDeadline.DurationFlag(false, snwatcher.DefaultHeartbeatCheckDeadline),
+			flagSNWatcherHeartbeatTimeout.DurationFlag(false, snwatcher.DefaultHeartbeatTimeout),
 			flagSNWatcherReportDeadline.DurationFlag(false, snwatcher.DefaultReportDeadline),
 
 			flags.GRPCServerReadBufferSize,
@@ -177,6 +178,7 @@ func start(c *cli.Context) error {
 		admin.WithMetadataRepositoryManager(mrMgr),
 		admin.WithStorageNodeManager(snMgr),
 		admin.WithStorageNodeWatcherOptions(
+			snwatcher.WithHeartbeatTimeout(c.Duration(flagSNWatcherHeartbeatTimeout.Name)),
 			snwatcher.WithHeartbeatCheckDeadline(c.Duration(flagSNWatcherHeartbeatCheckDeadline.Name)),
 			snwatcher.WithReportDeadline(c.Duration(flagSNWatcherReportDeadline.Name)),
 		),

--- a/cmd/varlogadm/flags.go
+++ b/cmd/varlogadm/flags.go
@@ -61,11 +61,18 @@ var (
 	}
 
 	flagSNWatcherHeartbeatCheckDeadline = flags.FlagDesc{
-		Name: "sn-watcher-heartbeat-check-deadline",
-		Envs: []string{"SN_WATCHER_HEARTBEAT_CHECK_DEADLINE"},
+		Name:  "sn-watcher-heartbeat-check-deadline",
+		Envs:  []string{"SN_WATCHER_HEARTBEAT_CHECK_DEADLINE"},
+		Usage: "dealine for heartbeat check request to storage node",
 	}
 	flagSNWatcherReportDeadline = flags.FlagDesc{
-		Name: "sn-watcher-report-deadline",
-		Envs: []string{"SN_WATCHER_REPORT_DEADLINE"},
+		Name:  "sn-watcher-report-deadline",
+		Envs:  []string{"SN_WATCHER_REPORT_DEADLINE"},
+		Usage: "dealine for report request to storage node",
+	}
+	flagSNWatcherHeartbeatTimeout = flags.FlagDesc{
+		Name:  "sn-watcher-heartbeat-timeout",
+		Envs:  []string{"SN_WATCHER_HEARTBEAT_TIMEOUT"},
+		Usage: "dealine to decide whether a storage node is live",
 	}
 )

--- a/cmd/varlogadm/testdata/varlogadm.ct
+++ b/cmd/varlogadm/testdata/varlogadm.ct
@@ -34,8 +34,9 @@ OPTIONS:
    --mr-call-timeout value                                                                                                                                                                                mr call timeout (default: 3s) [$MR_CALL_TIMEOUT]
    --mr-conn-timeout value                                                                                                                                                                                mr connection timeout (default: 1s) [$MR_CONN_TIMEOUT]
    --replica-selector value, --repsel value                                                                                                                                                               random | lfu (default: "lfu") [$REPLICA_SELECTOR]
-   --sn-watcher-heartbeat-check-deadline value                                                                                                                                                            (default: 3s) [$SN_WATCHER_HEARTBEAT_CHECK_DEADLINE]
-   --sn-watcher-report-deadline value                                                                                                                                                                     (default: 3s) [$SN_WATCHER_REPORT_DEADLINE]
+   --sn-watcher-heartbeat-check-deadline value                                                                                                                                                            dealine for heartbeat check request to storage node (default: 1s) [$SN_WATCHER_HEARTBEAT_CHECK_DEADLINE]
+   --sn-watcher-heartbeat-timeout value                                                                                                                                                                   dealine to decide whether a storage node is live (default: 5s) [$SN_WATCHER_HEARTBEAT_TIMEOUT]
+   --sn-watcher-report-deadline value                                                                                                                                                                     dealine for report request to storage node (default: 1s) [$SN_WATCHER_REPORT_DEADLINE]
 
    Cluster:
 

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -2,6 +2,7 @@ package admin
 
 import (
 	"context"
+	"math/rand"
 	"net"
 	"slices"
 	"sort"
@@ -903,6 +904,22 @@ func (adm *Admin) seal(ctx context.Context, tpid types.TopicID, lsid types.LogSt
 	return adm.sealInternal(ctx, tpid, lsid)
 }
 
+// sealMeta seals the logstream metadata in metadata repository only.
+func (adm *Admin) sealMeta(ctx context.Context, lsid types.LogStreamID) (types.GLSN, error) {
+	adm.lockLogStreamStatus(lsid)
+	defer adm.unlockLogStreamStatus(lsid)
+
+	adm.statRepository.SetLogStreamStatus(lsid, varlogpb.LogStreamStatusSealing)
+
+	lastGLSN, err := adm.mrmgr.Seal(ctx, lsid)
+	if err != nil {
+		adm.statRepository.SetLogStreamStatus(lsid, varlogpb.LogStreamStatusRunning)
+		return types.InvalidGLSN, err
+	}
+
+	return lastGLSN, nil
+}
+
 func (adm *Admin) sealInternal(ctx context.Context, tpid types.TopicID, lsid types.LogStreamID) ([]snpb.LogStreamReplicaMetadataDescriptor, types.GLSN, error) {
 	adm.statRepository.SetLogStreamStatus(lsid, varlogpb.LogStreamStatusSealing)
 
@@ -1093,18 +1110,40 @@ func (adm *Admin) removeMRPeer(ctx context.Context, raftURL string) error {
 	return nil
 }
 
+// HandleHeartbeatTimeout is called by snwatcher.
+// It seals all logstreams belonging to sn defined by snid.
+// Seal on metarepos first, as seal request on sn may be delayed.
+// Sealing metarepos is a high priority.
 func (adm *Admin) HandleHeartbeatTimeout(ctx context.Context, snid types.StorageNodeID) {
 	meta, err := adm.mrmgr.ClusterMetadataView().ClusterMetadata(ctx)
 	if err != nil {
 		return
 	}
 
-	// TODO: store sn status
+	target := make([]*varlogpb.LogStreamDescriptor, 0, len(meta.GetLogStreams()))
 	for _, ls := range meta.GetLogStreams() {
 		if ls.IsReplica(snid) {
-			adm.logger.Debug("seal due to heartbeat timeout", zap.Any("snid", snid), zap.Any("lsid", ls.LogStreamID))
-			_, _, _ = adm.seal(ctx, ls.TopicID, ls.LogStreamID)
+			target = append(target, ls)
 		}
+	}
+	rand.Shuffle(len(target), func(i, j int) { target[i], target[j] = target[j], target[i] })
+
+	for _, ls := range target {
+		_, err = adm.sealMeta(ctx, ls.LogStreamID)
+		if err != nil {
+			adm.logger.Error("seal to metarepos failed",
+				zap.Any("snid", snid),
+				zap.Any("lsid", ls.LogStreamID),
+				zap.Error(err))
+		}
+	}
+
+	hctx, cancel := context.WithTimeout(ctx, adm.storagenodeFailureHandleTimeout)
+	defer cancel()
+
+	for _, ls := range target {
+		adm.logger.Debug("seal due to heartbeat timeout", zap.Any("snid", snid), zap.Any("lsid", ls.LogStreamID))
+		_, _, _ = adm.seal(hctx, ls.TopicID, ls.LogStreamID)
 	}
 }
 

--- a/internal/admin/config.go
+++ b/internal/admin/config.go
@@ -17,35 +17,38 @@ import (
 )
 
 const (
-	defaultClusterID          = flags.DefaultClusterID
-	DefaultListenAddress      = "127.0.0.1:9090"
-	DefaultReplicationFactor  = flags.DefaultReplicationFactor
-	DefaultLogStreamGCTimeout = 24 * time.Hour
+	defaultClusterID                       = flags.DefaultClusterID
+	DefaultListenAddress                   = "127.0.0.1:9090"
+	DefaultReplicationFactor               = flags.DefaultReplicationFactor
+	DefaultLogStreamGCTimeout              = 24 * time.Hour
+	DefaultStorageNodeFailureHandleTimeout = 2 * time.Second
 )
 
 type config struct {
-	cid                      types.ClusterID
-	listenAddress            string
-	replicationFactor        int
-	logStreamGCTimeout       time.Duration
-	disableAutoLogStreamSync bool
-	enableAutoUnseal         bool
-	mrmgr                    mrmanager.MetadataRepositoryManager
-	snmgr                    snmanager.StorageNodeManager
-	snSelector               ReplicaSelector
-	statRepository           stats.Repository
-	snwatcherOpts            []snwatcher.Option
-	defaultGRPCServerOptions []grpc.ServerOption
-	logger                   *zap.Logger
+	cid                             types.ClusterID
+	listenAddress                   string
+	replicationFactor               int
+	logStreamGCTimeout              time.Duration
+	storagenodeFailureHandleTimeout time.Duration
+	disableAutoLogStreamSync        bool
+	enableAutoUnseal                bool
+	mrmgr                           mrmanager.MetadataRepositoryManager
+	snmgr                           snmanager.StorageNodeManager
+	snSelector                      ReplicaSelector
+	statRepository                  stats.Repository
+	snwatcherOpts                   []snwatcher.Option
+	defaultGRPCServerOptions        []grpc.ServerOption
+	logger                          *zap.Logger
 }
 
 func newConfig(opts []Option) (config, error) {
 	cfg := config{
-		cid:                defaultClusterID,
-		listenAddress:      DefaultListenAddress,
-		replicationFactor:  DefaultReplicationFactor,
-		logStreamGCTimeout: DefaultLogStreamGCTimeout,
-		logger:             zap.NewNop(),
+		cid:                             defaultClusterID,
+		listenAddress:                   DefaultListenAddress,
+		replicationFactor:               DefaultReplicationFactor,
+		logStreamGCTimeout:              DefaultLogStreamGCTimeout,
+		storagenodeFailureHandleTimeout: DefaultStorageNodeFailureHandleTimeout,
+		logger:                          zap.NewNop(),
 	}
 
 	for _, opt := range opts {
@@ -137,6 +140,12 @@ func WithReplicationFactor(replicationFactor int) Option {
 func WithLogStreamGCTimeout(logStreamGCTimeout time.Duration) Option {
 	return newFuncOption(func(cfg *config) {
 		cfg.logStreamGCTimeout = logStreamGCTimeout
+	})
+}
+
+func WithStorageNodeFailureHandleTimeout(timeout time.Duration) Option {
+	return newFuncOption(func(cfg *config) {
+		cfg.storagenodeFailureHandleTimeout = timeout
 	})
 }
 

--- a/internal/admin/mrmanager/manager.go
+++ b/internal/admin/mrmanager/manager.go
@@ -161,7 +161,10 @@ func (mrm *mrManager) clusterMetadata(ctx context.Context) (*varlogpb.MetadataDe
 		return nil, errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	meta, err := cli.GetMetadata(ctx)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	meta, err := cli.GetMetadata(rpcCtx)
 	if err != nil {
 		_ = cli.Close()
 		return nil, err
@@ -176,7 +179,10 @@ func (mrm *mrManager) RegisterStorageNode(ctx context.Context, storageNodeMeta *
 		return errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	err = cli.RegisterStorageNode(ctx, storageNodeMeta)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	err = cli.RegisterStorageNode(rpcCtx, storageNodeMeta)
 	if err != nil {
 		_ = cli.Close()
 		return err
@@ -192,7 +198,10 @@ func (mrm *mrManager) UnregisterStorageNode(ctx context.Context, storageNodeID t
 		return errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	err = cli.UnregisterStorageNode(ctx, storageNodeID)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	err = cli.UnregisterStorageNode(rpcCtx, storageNodeID)
 	if err != nil {
 		_ = cli.Close()
 		return err
@@ -208,7 +217,10 @@ func (mrm *mrManager) RegisterTopic(ctx context.Context, topicID types.TopicID) 
 		return errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	err = cli.RegisterTopic(ctx, topicID)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	err = cli.RegisterTopic(rpcCtx, topicID)
 	if err != nil {
 		_ = cli.Close()
 		return err
@@ -224,7 +236,10 @@ func (mrm *mrManager) UnregisterTopic(ctx context.Context, topicID types.TopicID
 		return errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	err = cli.UnregisterTopic(ctx, topicID)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	err = cli.UnregisterTopic(rpcCtx, topicID)
 	if err != nil {
 		_ = cli.Close()
 		return err
@@ -240,7 +255,10 @@ func (mrm *mrManager) RegisterLogStream(ctx context.Context, logStreamDesc *varl
 		return errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	err = cli.RegisterLogStream(ctx, logStreamDesc)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	err = cli.RegisterLogStream(rpcCtx, logStreamDesc)
 	if err != nil {
 		_ = cli.Close()
 		return err
@@ -256,7 +274,10 @@ func (mrm *mrManager) UnregisterLogStream(ctx context.Context, logStreamID types
 		return errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	err = cli.UnregisterLogStream(ctx, logStreamID)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	err = cli.UnregisterLogStream(rpcCtx, logStreamID)
 	if err != nil {
 		_ = cli.Close()
 		return err
@@ -272,7 +293,10 @@ func (mrm *mrManager) UpdateLogStream(ctx context.Context, logStreamDesc *varlog
 		return errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	err = cli.UpdateLogStream(ctx, logStreamDesc)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	err = cli.UpdateLogStream(rpcCtx, logStreamDesc)
 	if err != nil {
 		_ = cli.Close()
 		return err
@@ -289,7 +313,10 @@ func (mrm *mrManager) Seal(ctx context.Context, logStreamID types.LogStreamID) (
 		return types.InvalidGLSN, errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	lastCommittedGLSN, err := cli.Seal(ctx, logStreamID)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	lastCommittedGLSN, err := cli.Seal(rpcCtx, logStreamID)
 	if err != nil {
 		_ = cli.Close()
 		return types.InvalidGLSN, err
@@ -305,7 +332,10 @@ func (mrm *mrManager) Unseal(ctx context.Context, logStreamID types.LogStreamID)
 		return errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	err = cli.Unseal(ctx, logStreamID)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	err = cli.Unseal(rpcCtx, logStreamID)
 	if err != nil {
 		_ = cli.Close()
 		return err
@@ -321,7 +351,10 @@ func (mrm *mrManager) GetClusterInfo(ctx context.Context) (*mrpb.ClusterInfo, er
 		return nil, errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	rsp, err := cli.GetClusterInfo(ctx, mrm.cid)
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	rsp, err := cli.GetClusterInfo(rpcCtx, mrm.cid)
 	if err != nil {
 		_ = cli.Close()
 		return nil, err
@@ -335,7 +368,10 @@ func (mrm *mrManager) AddPeer(ctx context.Context, nodeID types.NodeID, peerURL,
 		return errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	if err := cli.AddPeer(ctx, mrm.cid, nodeID, peerURL); err != nil {
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	if err := cli.AddPeer(rpcCtx, mrm.cid, nodeID, peerURL); err != nil {
 		if !errors.Is(err, verrors.ErrAlreadyExists) {
 			_ = cli.Close()
 			return err
@@ -353,7 +389,10 @@ func (mrm *mrManager) RemovePeer(ctx context.Context, nodeID types.NodeID) error
 		return errors.WithMessage(err, "mrmanager: not accessible")
 	}
 
-	if err := cli.RemovePeer(ctx, mrm.cid, nodeID); err != nil {
+	rpcCtx, cancel := context.WithTimeout(ctx, mrm.callTimeout)
+	defer cancel()
+
+	if err := cli.RemovePeer(rpcCtx, mrm.cid, nodeID); err != nil {
 		_ = cli.Close()
 		return err
 	}

--- a/internal/admin/snwatcher/snwatcher_test.go
+++ b/internal/admin/snwatcher/snwatcher_test.go
@@ -66,7 +66,7 @@ func TestStorageNodeWatcher_InvalidConfig(t *testing.T) {
 		WithClusterMetadataView(cmview),
 		WithStorageNodeManager(snmgr),
 		WithStatisticsRepository(statsRepos),
-		WithHeartbeatTimeout(0),
+		WithHeartbeatTimeout(time.Duration(0)),
 	)
 	assert.Error(t, err)
 
@@ -86,7 +86,7 @@ func TestStorageNodeWatcher_InvalidConfig(t *testing.T) {
 		WithClusterMetadataView(cmview),
 		WithStorageNodeManager(snmgr),
 		WithStatisticsRepository(statsRepos),
-		WithReportInterval(0),
+		WithReportInterval(time.Duration(0)),
 	)
 	assert.Error(t, err)
 
@@ -106,7 +106,7 @@ func TestStorageNodeWatcher_BadClusterMetadataView(t *testing.T) {
 	defer ctrl.Finish()
 
 	const tick = 10 * time.Millisecond
-	const interval = 3
+	const interval = 3 * tick
 
 	eventHandler := NewMockEventHandler(ctrl)
 	cmview := mrmanager.NewMockClusterMetadataView(ctrl)
@@ -125,7 +125,7 @@ func TestStorageNodeWatcher_BadClusterMetadataView(t *testing.T) {
 	)
 	assert.NoError(t, err)
 	assert.NoError(t, sw.Start())
-	time.Sleep(2 * interval * tick)
+	time.Sleep(2 * interval)
 	assert.NoError(t, sw.Stop())
 }
 
@@ -134,7 +134,7 @@ func TestStorageNodeWatcher(t *testing.T) {
 	defer ctrl.Finish()
 
 	const tick = 10 * time.Millisecond
-	const interval = 3
+	const interval = 3 * tick
 
 	eventHandler := NewMockEventHandler(ctrl)
 	cmview := mrmanager.NewMockClusterMetadataView(ctrl)
@@ -199,7 +199,7 @@ func TestStorageNodeWatcher(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		return atomic.LoadInt64(&numHeartbeatHandlerCalled) > 0 &&
 			atomic.LoadInt64(&numReportHandlerCalled) > 0
-	}, tick*interval*10, tick)
+	}, interval*10, tick)
 	assert.NoError(t, snw.Stop())
 }
 

--- a/tests/it/config.go
+++ b/tests/it/config.go
@@ -2,7 +2,6 @@ package it
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -220,9 +219,7 @@ func WithoutVMS() Option {
 func NewTestVMSOptions(opts ...admin.Option) []admin.Option {
 	ret := []admin.Option{
 		admin.WithStorageNodeWatcherOptions(
-			snwatcher.WithTick(100*time.Millisecond),
-			snwatcher.WithHeartbeatTimeout(30),
-			snwatcher.WithReportInterval(10),
+			snwatcher.WithReportInterval(snwatcher.DefaultTick),
 		),
 		admin.WithLogger(zap.L()),
 	}


### PR DESCRIPTION
### What this PR does

### Which issue(s) this PR resolves
This change fixes an issue where not all expected logstreams could be sealed within HandleHeartbeatTimeout due to storagenode delaying the response. Also fixes an issue where unexpected logstreams were being sealed by heartbeat false positives. In particular, it increases the priority of seal requests for metarepos so that commit results in metarepos do not pile up even if sealing is delayed.

Resolves #1068 #1069 

### Anything else

Include any links or documentation that might be helpful for reviewers.
