### PR TITLE
fix(storagenode): prevent panic during concurrent commit & seal ops

### DIFF
--- a/internal/storagenode/logstream/executor.go
+++ b/internal/storagenode/logstream/executor.go
@@ -291,9 +291,8 @@ func (lse *Executor) Seal(_ context.Context, lastCommittedGLSN types.GLSN) (stat
 		return status, localHWM, nil
 	}
 
-	lse.resetInternalState(uncommittedBegin.LLSN-1, true)
-
 	lse.esm.store(executorStateSealed)
+	lse.resetInternalState(uncommittedBegin.LLSN-1, true)
 	return status, localHWM, nil
 }
 


### PR DESCRIPTION
This update resolves a race condition that occurred during concurrent commit and
seal operations in the storage node. The issue was caused by improper state
management, where the seal handler could drain the commit wait queue while the
committer simultaneously processed tasks from it.

This race condition led to a negative counter in `sync.WaitGroup`, causing a
panic. Although the Go race detector did not flag this issue, it was logically a
race condition. The fix involves setting the state to "sealed" before resetting
the internal status of the log stream executor. This ensures proper
synchronization between the committer and seal handler, preventing potential
panics.

Test failure:

```txt
 panic: sync: negative WaitGroup counter

goroutine 84102 [running]:
sync.(*WaitGroup).Add(0xc0000c3ae0, 0xffffffffffffffff)
	/opt/hostedtoolcache/go/1.24.1/x64/src/sync/waitgroup.go:64 +0x19a
sync.(*WaitGroup).Done(0xc0000c3ae0)
	/opt/hostedtoolcache/go/1.24.1/x64/src/sync/waitgroup.go:89 +0x2e
github.com/kakao/varlog/internal/storagenode/logstream.(*appendWaitGroup).commitDone(...)
	/home/runner/work/varlog/varlog/internal/storagenode/logstream/append_waitgroup.go:104
github.com/kakao/varlog/internal/storagenode/logstream.(*committer).drainCommitWaitQ(0xc000d05280, {0x1f153c0, 0x28e1d80})
	/home/runner/work/varlog/varlog/internal/storagenode/logstream/committer.go:354 +0x499
github.com/kakao/varlog/internal/storagenode/logstream.(*Executor).resetInternalState(0xc002eec600, 0xf, 0x1)
	/home/runner/work/varlog/varlog/internal/storagenode/logstream/executor.go:380 +0x4e5
github.com/kakao/varlog/internal/storagenode/logstream.(*Executor).Seal(0xc002eec600, {0x100000001?, 0x48c5d5?}, 0xf)
	/home/runner/work/varlog/varlog/internal/storagenode/logstream/executor.go:281 +0xad8
github.com/kakao/varlog/internal/storagenode.(*StorageNode).seal(0xc000894340, {0x1f24e00, 0xc003660660}, 0x1, 0x1, 0xf)
	/home/runner/work/varlog/varlog/internal/storagenode/storagenode.go:385 +0x26a
github.com/kakao/varlog/internal/storagenode.(*adminServer).Seal(0xc000196c00, {0x1f24e00, 0xc003660660}, 0xc0010cdce0)
	/home/runner/work/varlog/varlog/internal/storagenode/admin_server.go:76 +0x3ae
github.com/kakao/varlog/proto/snpb._Management_Seal_Handler.func1({0x1f24e00, 0xc003660660}, {0x1c8dc00, 0xc0010cdce0})
	/home/runner/work/varlog/varlog/proto/snpb/management.pb.go:1168 +0xd7
github.com/kakao/varlog/internal/storagenode.NewStorageNode.UnaryServerInterceptor.func2({0x1f24e00, 0xc003660660}, {0x1c8dc00, 0xc0010cdce0}, 0xc00047d1e0, 0xc0004fcbb8)
	/home/runner/work/varlog/varlog/pkg/rpc/interceptors/logging/interceptor.go:26 +0xbd
github.com/kakao/varlog/proto/snpb._Management_Seal_Handler({0x1c006e0, 0xc000196c00}, {0x1f24e00, 0xc003660660}, 0xc002998580, 0xc0030b88b0)
	/home/runner/work/varlog/varlog/proto/snpb/management.pb.go:1170 +0x27d
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0000f0600, {0x1f24e00, 0xc0036605d0}, 0xc000e44780, 0xc001d9ce40, 0x2901108, 0x0)
	/home/runner/work/varlog/varlog/vendor/google.golang.org/grpc/server.go:1405 +0x1bc3
google.golang.org/grpc.(*Server).handleStream(0xc0000f0600, {0x1f256b0, 0xc000896820}, 0xc000e44780)
	/home/runner/work/varlog/varlog/vendor/google.golang.org/grpc/server.go:1815 +0x1373
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	/home/runner/work/varlog/varlog/vendor/google.golang.org/grpc/server.go:1035 +0x159
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 83669
	/home/runner/work/varlog/varlog/vendor/google.golang.org/grpc/server.go:1046 +0x215
FAIL	github.com/kakao/varlog/tests/it/cluster	193.934s
```

