### PR TITLE
fix(subscriber): fix refresh subscriber

### DIFF
--- a/pkg/varlog/options.go
+++ b/pkg/varlog/options.go
@@ -20,7 +20,7 @@ const (
 	defaultMetadataRefreshInterval = 1 * time.Minute
 	defaultMetadataRefreshTimeout  = 1 * time.Second
 
-	defaultSubscribeTimeout = 10 * time.Millisecond
+	defaultSubscribeTimeout = 100 * time.Millisecond
 
 	defaultDenyTTL            = 10 * time.Minute
 	defaultExpireDenyInterval = 1 * time.Second


### PR DESCRIPTION
### What this PR does

This patch changes the condition for refreshing the subscriber of varlogclient.

The subscriber is created per logstream. If a timeout occurs in the subscribing storagenode, it refreshes so that it can subscribe through another replica. On the other hand, if all logstreams belonging to the topic are subject to change, they are restricted from being replaced. As a result, for a topic with HAFactor=1, even if a timeout occurs in the subscribed storagenode, another replica cannot be selected.

To solve this, the condition was changed so that the subscribers of all logstreams belonging to the topic can be replaced. In addition, metadata requests to metarepos are not made for each refresh. The latest information can be sufficiently received through the refresher running in the background.

### Which issue(s) this PR resolves

Resolves #

### Anything else

Include any links or documentation that might be helpful for reviewers.
