### PR TITLE
perf(storagenode): replace inline error with predefined constant

### DIFF
--- a/internal/storagenode/logstream/errors.go
+++ b/internal/storagenode/logstream/errors.go
@@ -6,6 +6,8 @@ var (
 	errStorageIsNil  = fmt.Errorf("log stream: storage is nil")
 	errExecutorIsNil = fmt.Errorf("log stream: executor is nil")
 	errLoggerIsNil   = fmt.Errorf("log stream: logger is nil")
+
+	errTooOldCommit = fmt.Errorf("log stream: too old commit result")
 )
 
 func validateQueueCapacity(name string, capacity int) error {

--- a/internal/storagenode/logstream/executor.go
+++ b/internal/storagenode/logstream/executor.go
@@ -453,7 +453,7 @@ func (lse *Executor) Commit(ctx context.Context, commitResult snpb.LogStreamComm
 
 	version, _, _, invalid := lse.lsc.reportCommitBase()
 	if commitResult.Version <= version {
-		return errors.New("too old commit result")
+		return errTooOldCommit
 	}
 	if invalid {
 		return errors.New("invalid replica status")


### PR DESCRIPTION
### What this PR does

This change replaces inline error creation with the predefined error constant
`errTooOldCommit` to reduce redundant object creations and improve efficiency.

```
File: varlogsn
Build ID: 738fe0766e67e717e91653e50f8bfbbbfed542a9
Type: alloc_objects
Time: 2025-03-18 12:32:31 KST
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top logstream\.\(\*Executor\)\.Commit
Active filters:
   focus=logstream\.\(\*Executor\)\.Commit
Showing nodes accounting for -8053079, 1.70% of 472672864 total
Dropped 4 nodes (cum <= 2363364)
      flat  flat%   sum%        cum   cum%
  -9796082  2.07%  2.07%   -9796082  2.07%  errors.New (inline)
   1743003  0.37%  1.70%   -8053147  1.70%  github.com/kakao/varlog/internal/storagenode/logstream.(*Executor).Commit
```
