### PR TITLE
refactor(all): remove --grpc-server-max-recv-msg-size flag

### DIFF
--- a/cmd/varlogadm/cli.go
+++ b/cmd/varlogadm/cli.go
@@ -61,7 +61,6 @@ func newStartCommand() *cli.Command {
 			flags.GRPCServerReadBufferSize,
 			flags.GRPCServerWriteBufferSize,
 			flags.GRPCServerSharedWriteBuffer,
-			flags.GRPCServerMaxRecvMsgSize,
 			flags.GRPCServerInitialConnWindowSize,
 			flags.GRPCServerInitialWindowSize,
 			flags.GRPCClientReadBufferSize,

--- a/cmd/varlogadm/testdata/varlogadm.ct
+++ b/cmd/varlogadm/testdata/varlogadm.ct
@@ -74,7 +74,6 @@ OPTIONS:
    --grpc-client-write-buffer-size value         Set the gRPC client's write buffer size for a single write syscall. If not set, the default value of 32KiB defined by gRPC will be used. [$GRPC_CLIENT_WRITE_BUFFER_SIZE]
    --grpc-server-initial-conn-window-size value  Set the gRPC server's initial window size for a connection. If not set, the default value of 64KiB defined by gRPC will be used. [$GRPC_SERVER_INITIAL_CONN_WINDOW_SIZE]
    --grpc-server-initial-window-size value       Set the gRPC server's initial window size for a stream. If not set, the default value of 64KiB defined by gRPC will be used. [$GRPC_SERVER_INITIAL_WINDOW_SIZE]
-   --grpc-server-max-recv-msg-size value         Set the maximum message size in bytes that the gRPC server can receive. If not set, the default value of 4MiB defined by gRPC will be used. [$GRPC_SERVER_MAX_RECV_MSG_SIZE]
    --grpc-server-read-buffer-size value          Set the gRPC server's read buffer size for a single read syscall. If not set, the default value of 32KiB defined by gRPC will be used. [$GRPC_SERVER_READ_BUFFER_SIZE]
    --grpc-server-shared-write-buffer             Enable sharing gRPC server's transport write buffer across connections. If not set, each connection will allocate its own write buffer. (default: false) [$GRPC_SERVER_SHARED_WRITE_BUFFER]
    --grpc-server-write-buffer-size value         Set the gRPC server's write buffer size for a single write syscall. If not set, the default value of 32KiB defined by gRPC will be used. [$GRPC_SERVER_WRITE_BUFFER_SIZE]

--- a/cmd/varlogmr/metadata_repository.go
+++ b/cmd/varlogmr/metadata_repository.go
@@ -137,7 +137,6 @@ func initCLI() *cli.App {
 				flags.GRPCServerReadBufferSize,
 				flags.GRPCServerWriteBufferSize,
 				flags.GRPCServerSharedWriteBuffer,
-				flags.GRPCServerMaxRecvMsgSize,
 				flags.GRPCServerInitialConnWindowSize,
 				flags.GRPCServerInitialWindowSize,
 				flags.GRPCClientReadBufferSize,

--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -48,7 +48,6 @@ func newStartCommand() *cli.Command {
 			flags.GRPCServerReadBufferSize,
 			flags.GRPCServerWriteBufferSize,
 			flags.GRPCServerSharedWriteBuffer,
-			flags.GRPCServerMaxRecvMsgSize,
 			flags.GRPCServerInitialConnWindowSize,
 			flags.GRPCServerInitialWindowSize,
 			flags.GRPCClientReadBufferSize,

--- a/cmd/varlogsn/testdata/varlogsn.ct
+++ b/cmd/varlogsn/testdata/varlogsn.ct
@@ -94,7 +94,6 @@ OPTIONS:
    --grpc-client-write-buffer-size value         Set the gRPC client's write buffer size for a single write syscall. If not set, the default value of 32KiB defined by gRPC will be used. [$GRPC_CLIENT_WRITE_BUFFER_SIZE]
    --grpc-server-initial-conn-window-size value  Set the gRPC server's initial window size for a connection. If not set, the default value of 64KiB defined by gRPC will be used. [$GRPC_SERVER_INITIAL_CONN_WINDOW_SIZE]
    --grpc-server-initial-window-size value       Set the gRPC server's initial window size for a stream. If not set, the default value of 64KiB defined by gRPC will be used. [$GRPC_SERVER_INITIAL_WINDOW_SIZE]
-   --grpc-server-max-recv-msg-size value         Set the maximum message size in bytes that the gRPC server can receive. If not set, the default value of 4MiB defined by gRPC will be used. [$GRPC_SERVER_MAX_RECV_MSG_SIZE]
    --grpc-server-read-buffer-size value          Set the gRPC server's read buffer size for a single read syscall. If not set, the default value of 32KiB defined by gRPC will be used. [$GRPC_SERVER_READ_BUFFER_SIZE]
    --grpc-server-shared-write-buffer             Enable sharing gRPC server's transport write buffer across connections. If not set, each connection will allocate its own write buffer. (default: false) [$GRPC_SERVER_SHARED_WRITE_BUFFER]
    --grpc-server-write-buffer-size value         Set the gRPC server's write buffer size for a single write syscall. If not set, the default value of 32KiB defined by gRPC will be used. [$GRPC_SERVER_WRITE_BUFFER_SIZE]

--- a/internal/flags/grpc.go
+++ b/internal/flags/grpc.go
@@ -60,22 +60,6 @@ var (
 		EnvVars:  []string{"GRPC_SERVER_SHARED_WRITE_BUFFER"},
 		Usage:    "Enable sharing gRPC server's transport write buffer across connections. If not set, each connection will allocate its own write buffer.",
 	}
-	// GRPCServerMaxRecvMsgSize is a flag to set the maximum message size the server can receive.
-	//
-	// See:
-	//   - https://pkg.go.dev/google.golang.org/grpc#MaxRecvMsgSize
-	GRPCServerMaxRecvMsgSize = &cli.StringFlag{
-		Name:     "grpc-server-max-recv-msg-size",
-		Category: CategoryGRPC,
-		EnvVars:  []string{"GRPC_SERVER_MAX_RECV_MSG_SIZE"},
-		Usage:    "Set the maximum message size in bytes that the gRPC server can receive. If not set, the default value of 4MiB defined by gRPC will be used.",
-		Action: func(c *cli.Context, value string) error {
-			if _, err := units.FromByteSizeString(value); err != nil {
-				return fmt.Errorf("invalid value \"%s\" for flag --grpc-server-max-recv-msg-size", value)
-			}
-			return nil
-		},
-	}
 	// GRPCServerInitialConnWindowSize is a flag to set the gRPC server's initial window size for a connection.
 	//
 	// See:
@@ -203,13 +187,6 @@ func ParseGRPCServerOptionFlags(c *cli.Context) (opts []grpc.ServerOption, _ err
 		opts = append(opts, grpc.WriteBufferSize(int(writeBufferSize)))
 	}
 	opts = append(opts, grpc.SharedWriteBuffer(c.Bool(GRPCServerSharedWriteBuffer.Name)))
-	if c.IsSet(GRPCServerMaxRecvMsgSize.Name) {
-		maxRecvMsgSize, err := units.FromByteSizeString(c.String(GRPCServerMaxRecvMsgSize.Name))
-		if err != nil {
-			return nil, err
-		}
-		opts = append(opts, grpc.MaxRecvMsgSize(int(maxRecvMsgSize)))
-	}
 	if c.IsSet(GRPCServerInitialConnWindowSize.Name) {
 		initialConnWindowSize, err := units.FromByteSizeString(c.String(GRPCServerInitialConnWindowSize.Name), 0, math.MaxInt32)
 		if err != nil {

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -1,6 +1,11 @@
 package rpc
 
-import "google.golang.org/grpc"
+import (
+	"math"
+	"slices"
+
+	"google.golang.org/grpc"
+)
 
 // NewServer calls grpc.NewServer function. The package
 // github.com/kakao/varlog/pkg/rpc registers the gogoproto codec to the gRPC.
@@ -8,5 +13,10 @@ import "google.golang.org/grpc"
 // application server use the gogoproto codec instead of the regular proto
 // codec.
 func NewServer(opts ...grpc.ServerOption) *grpc.Server {
+	defaultServerOptions := []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(math.MaxInt32),
+		grpc.MaxSendMsgSize(math.MaxInt32),
+	}
+	opts = slices.Concat(defaultServerOptions, opts)
 	return grpc.NewServer(opts...)
 }


### PR DESCRIPTION
### What this PR does

This removes a CLI flag `--grpc-server-max-recv-msg-size`, which specifies the
maximum size for incoming messages. All servers now have no size limit for
receiving and sending messages.
