### PR TITLE
feat(rpc): add gRPC keepalive parameters for client and server

### DIFF
--- a/pkg/rpc/rpc_conn.go
+++ b/pkg/rpc/rpc_conn.go
@@ -4,13 +4,34 @@ import (
 	"context"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/keepalive"
 )
 
-var defaultDialOption = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+const (
+	// clientKeepaliveInterval defines the time interval for client-side
+	// keepalive pings. It is set to 10 seconds since the minimum value
+	// supported by gRPC is 10 seconds.
+	clientKeepaliveInterval = 10 * time.Second
+
+	// clientKeepaliveTimeout specifies the timeout for client-side keepalive
+	// pings. It is set to 1500ms (3*network timeout) to allow sufficient time
+	// for transient network issues to resolve.
+	clientKeepaliveTimeout = 3 * networkTimeout
+)
+
+var defaultDialOption = []grpc.DialOption{
+	grpc.WithTransportCredentials(insecure.NewCredentials()),
+	grpc.WithKeepaliveParams(keepalive.ClientParameters{
+		Time:                clientKeepaliveInterval,
+		Timeout:             clientKeepaliveTimeout,
+		PermitWithoutStream: true,
+	}),
+}
 
 type Conn struct {
 	Conn *grpc.ClientConn

--- a/pkg/rpc/server.go
+++ b/pkg/rpc/server.go
@@ -3,8 +3,38 @@ package rpc
 import (
 	"math"
 	"slices"
+	"time"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+const (
+	// networkTimeout defines the timeout for network operations. Since Varlog
+	// is designed for deployment in Ethernet networks, we set it to 500ms
+	// based on the expected upper bound of ping times (100ms) and 2 x
+	// TCP_RTO_MIN (200ms). This aggressive setting ensures responsiveness to
+	// network changes.
+	//
+	// For a more conservative approach supporting multi-region deployments,
+	// refer to:
+	// https://github.com/cockroachdb/cockroach/blob/70bb4fafea5534d34fab9440975da5526933c955/pkg/base/config.go#L120-L137
+	networkTimeout = 500 * time.Millisecond
+
+	// serverKeepaliveInterval defines the interval between server-side
+	// keepalive pings. We set this to 2000ms (4*networkTimeout) to ensure that
+	// keepalive pings are sent only after waiting long enough for regular
+	// network activity (e.g., RPC heartbeats) to occur, reducing unnecessary
+	// pings while maintaining connection reliability.
+	serverKeepaliveInterval = 4 * networkTimeout
+
+	// serverKeepaliveTimeout specifies the timeout for server-side keepalive
+	// pings. If a response to a keepalive ping is not received within this
+	// duration, the connection is considered failed and will be closed. We set
+	// this to 1500ms (3*networkTimeout) to allow sufficient time for transient
+	// network issues to resolve, ensuring robustness in detecting failed
+	// connections without prematurely closing them.
+	serverKeepaliveTimeout = 3 * networkTimeout
 )
 
 // NewServer calls grpc.NewServer function. The package
@@ -16,6 +46,14 @@ func NewServer(opts ...grpc.ServerOption) *grpc.Server {
 	defaultServerOptions := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(math.MaxInt32),
 		grpc.MaxSendMsgSize(math.MaxInt32),
+		grpc.KeepaliveParams(keepalive.ServerParameters{
+			Time:    serverKeepaliveInterval,
+			Timeout: serverKeepaliveTimeout,
+		}),
+		grpc.KeepaliveEnforcementPolicy(keepalive.EnforcementPolicy{
+			MinTime:             time.Millisecond,
+			PermitWithoutStream: true,
+		}),
 	}
 	opts = slices.Concat(defaultServerOptions, opts)
 	return grpc.NewServer(opts...)


### PR DESCRIPTION
### What this PR does

This commit introduces gRPC keepalive parameters to improve connection
reliability and fault tolerance in Varlog.

On the client side, the `clientKeepaliveInterval` is set to 10s to send periodic
pings, while the `clientKeepaliveTimeout` is set to 1500ms to handle transient
network issues. On the server side, the `serverKeepaliveInterval` is set to
1500ms to reduce unnecessary pings, and the `serverKeepaliveTimeout` is set to
1500ms to reliably detect failed connections.

The timeout values are carefully chosen to balance responsiveness and resource
efficiency, particularly for Ethernet networks. Overall, these improvements
enhance Varlog's fault tolerance by promptly detecting and closing failed
connections, reducing resource usage by minimizing redundant pings, and
improving system stability and responsiveness in dynamic or unreliable network
environments.
