### PR TITLE
perf(storagenode): reuse CommitResults to reduce allocations

### DIFF
--- a/internal/storagenode/reportcommit_server.go
+++ b/internal/storagenode/reportcommit_server.go
@@ -67,7 +67,11 @@ func (rcs reportCommitServer) CommitBatch(stream snpb.LogStreamReporter_CommitBa
 	req := &snpb.CommitBatchRequest{}
 	ctx := stream.Context()
 	for {
+		commitResults := req.CommitResults
+		commitResults = commitResults[:0]
 		req.Reset()
+		req.CommitResults = commitResults
+
 		err = stream.RecvMsg(req)
 		if err == io.EOF {
 			return nil


### PR DESCRIPTION
### What this PR does

Optimizes memory usage by reusing the CommitResults slice in CommitBatchRequest.
This reduces heap allocations when appending entries, improving performance in
high-throughput scenarios. Since the metadata repository continuously sends
CommitBatch to storage nodes, this change significantly reduces heap
allocations.
