### PR TITLE
refactor(metarepos): optimize report processing by reducing lock contention

### DIFF
--- a/internal/metarepos/raft_metadata_repository.go
+++ b/internal/metarepos/raft_metadata_repository.go
@@ -345,18 +345,17 @@ func (mr *RaftMetadataRepository) processReport(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			var reports *mrpb.Reports
-
+			var reportQueue []*mrpb.Report
 			mr.muReportQueue.Lock()
-			num := len(mr.reportQueue)
-			if num > 0 {
-				reports = mrpb.NewReports(mr.nodeID, time.Now())
-				reports.Reports = mr.reportQueue
+			if len(mr.reportQueue) > 0 {
+				reportQueue = mr.reportQueue
 				mr.reportQueue = mrpb.NewReportQueue()
 			}
 			mr.muReportQueue.Unlock()
 
-			if reports != nil {
+			if len(reportQueue) > 0 {
+				reports := mrpb.NewReports(mr.nodeID, time.Now())
+				reports.Reports = reportQueue
 				mr.propose(context.TODO(), reports, false) //nolint:errcheck,revive // TODO:: Handle an error returned.
 			}
 		}

--- a/internal/reportcommitter/client.go
+++ b/internal/reportcommitter/client.go
@@ -4,7 +4,6 @@ package reportcommitter
 
 import (
 	"context"
-	"io"
 
 	"go.uber.org/multierr"
 	"google.golang.org/grpc"
@@ -83,15 +82,7 @@ func (c *client) GetReport() (*snpb.GetReportResponse, error) {
 	if err := c.reportStream.Send(&c.getReportReq); err != nil {
 		return nil, err
 	}
-	rsp, err := c.reportStream.Recv()
-	if err != nil {
-		if err == io.EOF {
-			// NOTE(jun,pharrell): Zero value of GetReportResponse should be handled.
-			return &snpb.GetReportResponse{}, nil
-		}
-		return nil, err
-	}
-	return rsp, nil
+	return c.reportStream.Recv()
 }
 
 // CommitBatch sends commit results to the connected storage node. This method


### PR DESCRIPTION
### What this PR does

The report processing logic has been updated to minimize the time the report
queue lock is held. Previously, the lock was held while creating the `Reports`
object, which could lead to contention. Now, the report queue is copied while
holding the lock, and the `Reports` object is created outside the critical
section. This change improves concurrency and reduces potential bottlenecks.
