### PR TITLE
test: replace custom CompareWait with testify's assertions

### DIFF
--- a/tests/it/management/management_test.go
+++ b/tests/it/management/management_test.go
@@ -745,14 +745,13 @@ func TestGCZombieLogStream(t *testing.T) {
 				_, exist := meta.GetLogStream(lsID)
 				So(exist, ShouldBeTrue)
 
-				So(testutil.CompareWait(func() bool {
+				require.EventuallyWithT(t, func(collect *assert.CollectT) {
 					meta, err := snMCL.GetMetadata(context.TODO())
-					if err != nil {
-						return false
-					}
+					assert.NoError(collect, err)
+
 					_, exist := meta.GetLogStream(lsID)
-					return !exist
-				}, gcTimeout*2), ShouldBeTrue)
+					assert.False(collect, exist)
+				}, gcTimeout*2, reportInterval)
 			})
 		})
 	}))


### PR DESCRIPTION
This change replaces the custom `testutil.CompareWait` utility with
`require.EventuallyWithT` from the `testify` package in
`pkg/util/runner/runner_test.go` and `tests/it/management/management_test.go`.

This improves readability, simplifies test assertions, and leverages a
well-supported testing library for asserting eventual conditions.

