### PR TITLE
refactor(telemetry): migrate telemetry package to internal/stats/opentelemetry

### DIFF
--- a/cmd/varlogadm/cli.go
+++ b/cmd/varlogadm/cli.go
@@ -13,9 +13,9 @@ import (
 	"github.com/kakao/varlog/internal/admin/snwatcher"
 	"github.com/kakao/varlog/internal/buildinfo"
 	"github.com/kakao/varlog/internal/flags"
+	"github.com/kakao/varlog/internal/stats/opentelemetry"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/log"
-	"github.com/kakao/varlog/pkg/util/telemetry"
 )
 
 func newAdminApp() *cli.App {
@@ -115,11 +115,11 @@ func start(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	mp, stop, err := telemetry.NewMeterProvider(meterProviderOpts...)
+	mp, stop, err := opentelemetry.NewMeterProvider(meterProviderOpts...)
 	if err != nil {
 		return err
 	}
-	telemetry.SetGlobalMeterProvider(mp)
+	opentelemetry.SetGlobalMeterProvider(mp)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), c.Duration(flags.TelemetryExporterStopTimeout.Name))
 		defer cancel()

--- a/cmd/varlogmr/metadata_repository.go
+++ b/cmd/varlogmr/metadata_repository.go
@@ -13,9 +13,9 @@ import (
 	"github.com/kakao/varlog/internal/buildinfo"
 	"github.com/kakao/varlog/internal/flags"
 	"github.com/kakao/varlog/internal/metarepos"
+	"github.com/kakao/varlog/internal/stats/opentelemetry"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/log"
-	"github.com/kakao/varlog/pkg/util/telemetry"
 )
 
 func main() {
@@ -54,11 +54,11 @@ func start(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	mp, stop, err := telemetry.NewMeterProvider(meterProviderOpts...)
+	mp, stop, err := opentelemetry.NewMeterProvider(meterProviderOpts...)
 	if err != nil {
 		return err
 	}
-	telemetry.SetGlobalMeterProvider(mp)
+	opentelemetry.SetGlobalMeterProvider(mp)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), c.Duration(flags.TelemetryExporterStopTimeout.Name))
 		defer cancel()

--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -16,12 +16,12 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/kakao/varlog/internal/flags"
+	"github.com/kakao/varlog/internal/stats/opentelemetry"
 	"github.com/kakao/varlog/internal/storage"
 	"github.com/kakao/varlog/internal/storagenode"
 	"github.com/kakao/varlog/internal/storagenode/logstream"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/log"
-	"github.com/kakao/varlog/pkg/util/telemetry"
 	"github.com/kakao/varlog/pkg/util/units"
 )
 
@@ -78,11 +78,11 @@ func start(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	mp, stop, err := telemetry.NewMeterProvider(meterProviderOpts...)
+	mp, stop, err := opentelemetry.NewMeterProvider(meterProviderOpts...)
 	if err != nil {
 		return err
 	}
-	telemetry.SetGlobalMeterProvider(mp)
+	opentelemetry.SetGlobalMeterProvider(mp)
 	defer func() {
 		ctx, cancel := context.WithTimeout(context.Background(), c.Duration(flags.TelemetryExporterStopTimeout.Name))
 		defer cancel()

--- a/internal/admin/admin.go
+++ b/internal/admin/admin.go
@@ -22,12 +22,12 @@ import (
 
 	"github.com/kakao/varlog/internal/admin/sfgkey"
 	"github.com/kakao/varlog/internal/admin/snwatcher"
+	"github.com/kakao/varlog/internal/stats/opentelemetry"
 	"github.com/kakao/varlog/pkg/rpc"
 	"github.com/kakao/varlog/pkg/rpc/interceptors/logging"
 	"github.com/kakao/varlog/pkg/rpc/interceptors/otelgrpc"
 	"github.com/kakao/varlog/pkg/types"
 	"github.com/kakao/varlog/pkg/util/netutil"
-	"github.com/kakao/varlog/pkg/util/telemetry"
 	"github.com/kakao/varlog/pkg/verrors"
 	"github.com/kakao/varlog/proto/admpb"
 	"github.com/kakao/varlog/proto/mrpb"
@@ -80,7 +80,7 @@ func New(ctx context.Context, opts ...Option) (*Admin, error) {
 	grpcServerOpts := slices.Concat([]grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
 			logging.UnaryServerInterceptor(cfg.logger),
-			otelgrpc.UnaryServerInterceptor(telemetry.GetGlobalMeterProvider()),
+			otelgrpc.UnaryServerInterceptor(opentelemetry.GetGlobalMeterProvider()),
 		),
 	}, cfg.defaultGRPCServerOptions)
 	cm := &Admin{

--- a/internal/metarepos/telemetry.go
+++ b/internal/metarepos/telemetry.go
@@ -5,8 +5,8 @@ import (
 
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/kakao/varlog/internal/stats/opentelemetry"
 	"github.com/kakao/varlog/pkg/types"
-	"github.com/kakao/varlog/pkg/util/telemetry"
 )
 
 type telemetryStub struct {
@@ -15,7 +15,7 @@ type telemetryStub struct {
 }
 
 func newTelemetryStub(ctx context.Context, name string, nodeID types.NodeID, endpoint string) (*telemetryStub, error) {
-	mp := telemetry.GetGlobalMeterProvider()
+	mp := opentelemetry.GetGlobalMeterProvider()
 
 	ts := &telemetryStub{
 		mp: mp,

--- a/internal/stats/opentelemetry/config.go
+++ b/internal/stats/opentelemetry/config.go
@@ -1,4 +1,4 @@
-package telemetry
+package opentelemetry
 
 import (
 	"go.opentelemetry.io/contrib/instrumentation/runtime"

--- a/internal/stats/opentelemetry/exporter.go
+++ b/internal/stats/opentelemetry/exporter.go
@@ -1,4 +1,4 @@
-package telemetry
+package opentelemetry
 
 import (
 	"context"

--- a/internal/stats/opentelemetry/metric_provider.go
+++ b/internal/stats/opentelemetry/metric_provider.go
@@ -1,4 +1,4 @@
-package telemetry
+package opentelemetry
 
 import (
 	"context"

--- a/internal/stats/opentelemetry/semconv.go
+++ b/internal/stats/opentelemetry/semconv.go
@@ -1,4 +1,4 @@
-package telemetry
+package opentelemetry
 
 import (
 	"go.opentelemetry.io/otel/attribute"

--- a/internal/storagenode/telemetry/metrics.go
+++ b/internal/storagenode/telemetry/metrics.go
@@ -14,8 +14,8 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"google.golang.org/grpc/codes"
 
+	"github.com/kakao/varlog/internal/stats/opentelemetry"
 	"github.com/kakao/varlog/pkg/types"
-	"github.com/kakao/varlog/pkg/util/telemetry"
 )
 
 // LogStreamMetrics is a set of metrics measured in each log stream.
@@ -617,12 +617,12 @@ func (m *Metrics) GetLogStreamMetrics(lsid types.LogStreamID) (*LogStreamMetrics
 
 func RegisterLogStreamMetrics(m *Metrics, tpid types.TopicID, lsid types.LogStreamID) (*LogStreamMetrics, error) {
 	attrs := attribute.NewSet(
-		telemetry.TopicID(tpid),
-		telemetry.LogStreamID(lsid),
+		opentelemetry.TopicID(tpid),
+		opentelemetry.LogStreamID(lsid),
 	)
 	kvs := []attribute.KeyValue{
-		telemetry.TopicID(tpid),
-		telemetry.LogStreamID(lsid),
+		opentelemetry.TopicID(tpid),
+		opentelemetry.LogStreamID(lsid),
 		semconv.RPCSystemGRPC,
 	}
 	lsm, loaded := m.metricsMap.LoadOrStore(lsid, &LogStreamMetrics{


### PR DESCRIPTION
### What this PR does

It moves the package from `pkg/util/telemetry` to
`internal/stats/opentelemetry`.
