### PR TITLE
feat(storagenode): migrate metrics to OpenTelemetry histogram wrappers

### DIFF
--- a/internal/storagenode/logstream/backup_writer.go
+++ b/internal/storagenode/logstream/backup_writer.go
@@ -74,7 +74,7 @@ func (bw *backupWriter) writeLoop(ctx context.Context) {
 	}
 }
 
-func (bw *backupWriter) writeLoopInternal(_ context.Context, bwt *backupWriteTask) {
+func (bw *backupWriter) writeLoopInternal(ctx context.Context, bwt *backupWriteTask) {
 	startTime := time.Now()
 	var err error
 	wb, oldLLSN, newLLSN := bwt.wb, bwt.oldLLSN, bwt.newLLSN
@@ -88,8 +88,7 @@ func (bw *backupWriter) writeLoopInternal(_ context.Context, bwt *backupWriteTas
 		if bw.lse.lsm == nil {
 			return
 		}
-		bw.lse.lsm.WriterOperationDuration.Add(time.Since(startTime).Microseconds())
-		bw.lse.lsm.WriterOperations.Add(1)
+		bw.lse.lsm.WriterOperationDuration.Record(ctx, time.Since(startTime).Microseconds())
 	}()
 
 	if uncommittedLLSNEnd := bw.lse.lsc.uncommittedLLSNEnd.Load(); uncommittedLLSNEnd != oldLLSN {

--- a/internal/storagenode/logstream/committer.go
+++ b/internal/storagenode/logstream/committer.go
@@ -253,9 +253,8 @@ func (cm *committer) commitInternal(cc storage.CommitContext) (err error) {
 		if cm.lse.lsm == nil {
 			return
 		}
-		cm.lse.lsm.CommitterOperationDuration.Add(int64(time.Since(startTime).Microseconds()))
-		cm.lse.lsm.CommitterOperations.Add(1)
-		cm.lse.lsm.CommitterLogs.Add(int64(numCommits))
+		cm.lse.lsm.CommitterOperationDuration.Record(context.Background(), int64(time.Since(startTime).Microseconds()))
+		cm.lse.lsm.CommitterLogs.Record(context.Background(), int64(numCommits))
 	}()
 
 	iter := cm.commitWaitQ.peekIterator()

--- a/internal/storagenode/logstream/replicate_client.go
+++ b/internal/storagenode/logstream/replicate_client.go
@@ -127,7 +127,7 @@ func (rc *replicateClient) sendLoop(ctx context.Context) {
 }
 
 // sendLoopInternal sends a replicate task to the backup replica.
-func (rc *replicateClient) sendLoopInternal(_ context.Context, rt *replicateTask, req *snpb.ReplicateRequest) error {
+func (rc *replicateClient) sendLoopInternal(ctx context.Context, rt *replicateTask, req *snpb.ReplicateRequest) error {
 	startTime := time.Now()
 	req.Data = rt.dataList
 	req.BeginLLSN = rt.beginLLSN
@@ -136,8 +136,7 @@ func (rc *replicateClient) sendLoopInternal(_ context.Context, rt *replicateTask
 	inflight := rc.inflight.Add(-1)
 	if rc.lse.lsm != nil {
 		rc.lse.lsm.ReplicateClientInflightOperations.Store(inflight)
-		rc.lse.lsm.ReplicateClientOperationDuration.Add(time.Since(startTime).Microseconds())
-		rc.lse.lsm.ReplicateClientOperations.Add(1)
+		rc.lse.lsm.ReplicateClientOperationDuration.Record(ctx, time.Since(startTime).Microseconds())
 	}
 	return err
 }

--- a/internal/storagenode/logstream/sequencer.go
+++ b/internal/storagenode/logstream/sequencer.go
@@ -94,9 +94,8 @@ func (sq *sequencer) sequenceLoopInternal(ctx context.Context, st *sequenceTask)
 		if sq.lse.lsm == nil {
 			return
 		}
-		sq.lse.lsm.SequencerFanoutDuration.Add(time.Since(operationEndTime).Microseconds())
-		sq.lse.lsm.SequencerOperationDuration.Add(int64(operationEndTime.Sub(startTime).Microseconds()))
-		sq.lse.lsm.SequencerOperations.Add(1)
+		sq.lse.lsm.SequencerFanoutDuration.Record(ctx, time.Since(operationEndTime).Microseconds())
+		sq.lse.lsm.SequencerOperationDuration.Record(ctx, int64(operationEndTime.Sub(startTime).Microseconds()))
 		sq.lse.lsm.ReplicateClientInflightOperations.Store(inflight)
 	}()
 

--- a/internal/storagenode/logstream/writer.go
+++ b/internal/storagenode/logstream/writer.go
@@ -83,7 +83,7 @@ func (w *writer) writeLoop(ctx context.Context) {
 }
 
 // writeLoopInternal stores a batch of writes to the storage and modifies uncommittedLLSNEnd of the log stream which presents the next expected LLSN to be written.
-func (w *writer) writeLoopInternal(_ context.Context, st *sequenceTask) {
+func (w *writer) writeLoopInternal(ctx context.Context, st *sequenceTask) {
 	startTime := time.Now()
 	var err error
 	cnt := len(st.dataBatch)
@@ -98,8 +98,7 @@ func (w *writer) writeLoopInternal(_ context.Context, st *sequenceTask) {
 		if w.lse.lsm == nil {
 			return
 		}
-		w.lse.lsm.WriterOperationDuration.Add(time.Since(startTime).Microseconds())
-		w.lse.lsm.WriterOperations.Add(1)
+		w.lse.lsm.WriterOperationDuration.Record(ctx, time.Since(startTime).Microseconds())
 		w.lse.lsm.WriterInflightOperations.Store(inflight)
 	}()
 


### PR DESCRIPTION
### What this PR does

Replace existing metrics with OpenTelemetry histogram wrappers. Convert several
metric types from counters to histograms to capture measurement distributions.

Converted from counter to histogram:

- sn.append.preparation
- sn.sequencer.operation.duration
- sn.sequencer.fanout.duration
- sn.writer.operation.duration
- sn.committer.operation.duration
- sn.committer.logs
- sn.replicate.client.operation.duration
- sn.replicate.duration
- sn.replicate.fanout.duration

Migrated to OpenTelemetry histogram wrapper (already histogram):

- log_rpc.server.duration
- log_rpc.server.log_entry.size
- log_rpc.server.batch.size
- log_rpc.server.log_entries_per_batch

This improves observability by enabling distribution analysis for these metrics.
