### PR TITLE
refactor(mrc): remove redundant health check from metadata repository client

### DIFF
--- a/pkg/mrc/metadata_repository_client.go
+++ b/pkg/mrc/metadata_repository_client.go
@@ -6,9 +6,7 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
 	"github.com/kakao/varlog/pkg/rpc"
@@ -42,18 +40,6 @@ func NewMetadataRepositoryClient(ctx context.Context, address string) (MetadataR
 	rpcConn, err := rpc.NewConn(ctx, address)
 	if err != nil {
 		return nil, err
-	}
-
-	client := grpc_health_v1.NewHealthClient(rpcConn.Conn)
-	rsp, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
-	if err != nil {
-		err = errors.Wrap(err, "mrmcl")
-		return nil, multierr.Append(err, rpcConn.Close())
-	}
-	status := rsp.GetStatus()
-	if status != grpc_health_v1.HealthCheckResponse_SERVING {
-		err := errors.Errorf("mrmcl: not ready (%+v)", status)
-		return nil, multierr.Append(err, rpcConn.Close())
 	}
 	return NewMetadataRepositoryClientFromRPCConn(rpcConn)
 }

--- a/pkg/mrc/metadata_repository_management_client.go
+++ b/pkg/mrc/metadata_repository_management_client.go
@@ -6,8 +6,6 @@ import (
 	"context"
 
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
-	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/kakao/varlog/pkg/rpc"
 	"github.com/kakao/varlog/pkg/types"
@@ -31,18 +29,6 @@ func NewMetadataRepositoryManagementClient(ctx context.Context, address string) 
 	rpcConn, err := rpc.NewConn(ctx, address)
 	if err != nil {
 		return nil, err
-	}
-
-	client := grpc_health_v1.NewHealthClient(rpcConn.Conn)
-	rsp, err := client.Check(ctx, &grpc_health_v1.HealthCheckRequest{})
-	if err != nil {
-		err = errors.Wrapf(err, "mrmcl: addr = %s", address)
-		return nil, multierr.Append(err, rpcConn.Close())
-	}
-	status := rsp.GetStatus()
-	if status != grpc_health_v1.HealthCheckResponse_SERVING {
-		err := errors.Errorf("mrmcl: not ready (%+v)", status)
-		return nil, multierr.Append(err, rpcConn.Close())
 	}
 
 	return NewMetadataRepositoryManagementClientFromRPCConn(rpcConn)

--- a/pkg/mrc/mrconnector/mr_connector.go
+++ b/pkg/mrc/mrconnector/mr_connector.go
@@ -12,7 +12,6 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/sync/singleflight"
-	"google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/kakao/varlog/pkg/mrc"
 	"github.com/kakao/varlog/pkg/rpc"
@@ -259,15 +258,6 @@ func (c *connectorImpl) connectToMR(ctx context.Context, addr string) (cl mrc.Me
 		return nil, nil, err
 	}
 
-	// health check
-	// FIXME: Which timeout should it use?
-	rsp, err := grpc_health_v1.NewHealthClient(conn.Conn).Check(connCtx, &grpc_health_v1.HealthCheckRequest{})
-	if err != nil || rsp.GetStatus() != grpc_health_v1.HealthCheckResponse_SERVING {
-		err = multierr.Append(conn.Close(), errors.Errorf("not ready, addr=%s status=%s", addr, rsp.GetStatus().String()))
-		return nil, nil, err
-	}
-
-	// It always returns nil as error value.
 	cl, _ = mrc.NewMetadataRepositoryClientFromRPCConn(conn)
 	mcl, _ = mrc.NewMetadataRepositoryManagementClientFromRPCConn(conn)
 	return cl, mcl, nil


### PR DESCRIPTION
### What this PR does

This change eliminates health check logic and related dependencies from
MetadataRepositoryClient, MetadataRepositoryManagementClient, and mr_connector.
Since health check logic is unnecessary in the metadata repository client, it
has been removed. Connection management, including health checks, keepalive, and
reconnection, is handled by gRPC itself. This commit simplifies the metadata
repository client.
