### PR TITLE
perf(storagenode): move write batch logic from sequencer to writer

### DIFF
--- a/internal/storagenode/logstream/append.go
+++ b/internal/storagenode/logstream/append.go
@@ -185,7 +185,6 @@ func (lse *Executor) prepareAppendContext(dataBatch [][]byte, apc *appendContext
 	apc.wwg = st.wwg
 
 	var totalBytes int64
-	st.wb = lse.stg.NewWriteBatch()
 	for i := 0; i < len(dataBatch); i++ {
 		logEntrySize := int64(len(dataBatch[i]))
 		totalBytes += logEntrySize
@@ -203,7 +202,6 @@ func (lse *Executor) prepareAppendContext(dataBatch [][]byte, apc *appendContext
 func (lse *Executor) sendSequenceTask(ctx context.Context, st *sequenceTask) {
 	if err := lse.sq.send(ctx, st); err != nil {
 		st.wwg.done(err)
-		_ = st.wb.Close()
 		st.cwt.release()
 		releaseReplicateTasks(st.rts.tasks)
 		releaseReplicateTaskSlice(st.rts)

--- a/internal/storagenode/logstream/writer_test.go
+++ b/internal/storagenode/logstream/writer_test.go
@@ -81,6 +81,7 @@ func TestWriter_DrainForce(t *testing.T) {
 	lse := &Executor{
 		esm: newExecutorStateManager(executorStateAppendable),
 	}
+	lse.stg = stg
 
 	wr := &writer{}
 	wr.lse = lse
@@ -88,7 +89,7 @@ func TestWriter_DrainForce(t *testing.T) {
 	wr.queue = make(chan *sequenceTask, numTasks)
 
 	for i := 0; i < numTasks; i++ {
-		st := testSequenceTask(stg)
+		st := testSequenceTask()
 		err := wr.send(context.Background(), st)
 		assert.NoError(t, err)
 	}
@@ -114,13 +115,14 @@ func TestWriter_UnexpectedLLSN(t *testing.T) {
 		lsc: newLogStreamContext(),
 	}
 	lse.lsc.uncommittedLLSNEnd.Store(uncommittedLLSNEnd)
+	lse.stg = stg
 
 	wr := &writer{}
 	wr.queue = make(chan *sequenceTask, 1)
 	wr.logger = zap.NewNop()
 	wr.lse = lse
 
-	st := testSequenceTask(stg)
+	st := testSequenceTask()
 	st.awg.setBeginLLSN(uncommittedLLSNEnd - 1) // not expected LLSN
 	wr.writeLoopInternal(context.Background(), st)
 


### PR DESCRIPTION
### What this PR does

This change delegates the responsibility of write batch management from the
sequencer to the writer, improving separation of concerns. By doing so, the
sequencer can focus on processing fanout tasks more efficiently, such as sending
data to replicators. This is expected to enhance replication speed to backup
replicas.

Additionally, batch writes are now handled more effectively by aggregating write
batches within the writer. Aggressive batching write operations can improve the
performance of the writer.
