### PR TITLE
refactor(storagenode): move replicationServerTask to logstream as ReplicationTask

### DIFF
--- a/internal/storagenode/logstream/replication_task.go
+++ b/internal/storagenode/logstream/replication_task.go
@@ -1,0 +1,28 @@
+package logstream
+
+import (
+	"sync"
+
+	"github.com/kakao/varlog/proto/snpb"
+)
+
+var replicationTaskPool = sync.Pool{
+	New: func() any {
+		return &ReplicationTask{}
+	},
+}
+
+type ReplicationTask struct {
+	Req snpb.ReplicateRequest
+	Err error
+}
+
+func NewReplicationTask() *ReplicationTask {
+	return replicationTaskPool.Get().(*ReplicationTask)
+}
+
+func (rst *ReplicationTask) Release() {
+	rst.Req.ResetReuse()
+	rst.Err = nil
+	replicationTaskPool.Put(rst)
+}


### PR DESCRIPTION
### What this PR does

This change moves replicationServerTask from `internal/storagenode` to
`internal/storagenode/logstream` and renames it to ReplicationTask for better
modularity and reuse.
