### PR TITLE
feat(storagenode): enable batching of writes in primary/backup writer

### DIFF
--- a/internal/storagenode/logstream/backup_writer_test.go
+++ b/internal/storagenode/logstream/backup_writer_test.go
@@ -133,7 +133,7 @@ func TestBackupWriter_UnexpectedLLSN(t *testing.T) {
 	rst := NewReplicationTask()
 	rst.Req.BeginLLSN = types.LLSN(uncommittedLLSNEnd + 1)
 	rst.Req.Data = [][]byte{nil}
-	bw.writeLoopInternal(context.Background(), rst)
+	bw.writeLoopInternal(context.Background(), []*ReplicationTask{rst})
 
 	// Keep the uncommittedLLSNEnd unchanged.
 	require.Equal(t, uncommittedLLSNEnd, bw.lse.lsc.uncommittedLLSNEnd.Load())

--- a/internal/storagenode/logstream/writer_test.go
+++ b/internal/storagenode/logstream/writer_test.go
@@ -124,7 +124,7 @@ func TestWriter_UnexpectedLLSN(t *testing.T) {
 
 	st := testSequenceTask()
 	st.awg.setBeginLLSN(uncommittedLLSNEnd - 1) // not expected LLSN
-	wr.writeLoopInternal(context.Background(), st)
+	wr.writeLoopInternal(context.Background(), []*sequenceTask{st})
 
 	// Keep the uncommittedLLSNEnd unchanged.
 	require.Equal(t, uncommittedLLSNEnd, lse.lsc.uncommittedLLSNEnd.Load())

--- a/internal/storagenode/storagenode.go
+++ b/internal/storagenode/storagenode.go
@@ -334,6 +334,7 @@ func (sn *StorageNode) runLogStreamReplica(_ context.Context, tpid types.TopicID
 			sn.defaultGRPCDialOptions...,
 		),
 		logstream.WithLogStreamMetrics(lsm),
+		logstream.WithMaxWriteTaskBatchLength(3),
 	)
 
 	lse, err := logstream.NewExecutor(lseOpts...)


### PR DESCRIPTION
### What this PR does

This change introduces batching of write tasks in primary and backup writers.
The number of tasks is limited by `WithMaxWriteTaskBatchLength`. Since each
write task can already have batched writes, its value is limited from 1 to 3.
This is an internal configuration, thus not exposed as a CLI flag. This commit
sets `WithMaxWriteTaskBatchLength` to 3. We will observe this further and can
change it.
