### PR TITLE
test: stabilize TestAdmin_GetStorageNode by adjusting timing

### DIFF
--- a/tests/it/failover/failover_test.go
+++ b/tests/it/failover/failover_test.go
@@ -861,7 +861,7 @@ func TestAdmin_GetStorageNode(t *testing.T) {
 	const (
 		replicationFactor = 1
 		numStorageNodes   = replicationFactor
-		tick              = time.Second
+		tick              = 100 * time.Millisecond
 		reportInterval    = tick
 	)
 
@@ -896,13 +896,13 @@ func TestAdmin_GetStorageNode(t *testing.T) {
 
 	clus.RestartVMS(t)
 
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		snm, err := clus.GetVMSClient(t).GetStorageNode(context.Background(), snid)
-		require.NoError(t, err)
-		require.Equal(t, len(old.LogStreamReplicas), len(snm.LogStreamReplicas))
+		assert.NoError(collect, err)
+		assert.Len(collect, snm.LogStreamReplicas, len(old.LogStreamReplicas))
 		for i := range snm.LogStreamReplicas {
-			require.Equal(t, old.LogStreamReplicas[i].Path, snm.LogStreamReplicas[i].Path)
+			assert.Equal(collect, old.LogStreamReplicas[i].Path, snm.LogStreamReplicas[i].Path)
 		}
-		return snm.LastHeartbeatTime.After(old.LastHeartbeatTime)
-	}, 2*reportInterval, tick)
+		assert.True(collect, snm.LastHeartbeatTime.After(old.LastHeartbeatTime))
+	}, 10*reportInterval, tick)
 }


### PR DESCRIPTION
### What this PR does

This commit fixes flakiness in TestAdmin_GetStorageNode caused by too short
assertion duration. Previously, the test sometimes failed because the admin
server did not refresh the storage node list within the expected time after a
restart. This change increases the assertion timeout and decreases the admin
server's tick interval, making the test both more reliable and faster.
