### PR TITLE
feat(storage): always separate data and commit stores

### DIFF
--- a/bin/start_varlogsn.py
+++ b/bin/start_varlogsn.py
@@ -175,8 +175,6 @@ def start(args: argparse.Namespace) -> None:
                 cmd.append(f"--append-pipeline-size={args.append_pipeline_size}")
 
             # storage options
-            if args.experimental_storage_separate_db:
-                cmd.append("--experimental-storage-separate-db")
             if args.storage_datadb_disable_wal:
                 cmd.append("--storage-datadb-disable-wal")
             if args.storage_datadb_no_sync:
@@ -268,7 +266,6 @@ def main() -> None:
     parser.add_argument("--append-pipeline-size", type=int)
 
     # storage options
-    parser.add_argument("--experimental-storage-separate-db", action="store_true")
     parser.add_argument("--storage-datadb-disable-wal", action="store_true")
     parser.add_argument("--storage-datadb-no-sync", action="store_true")
     parser.add_argument("--storage-commitdb-disable-wal", action="store_true")

--- a/cmd/varlogsn/cli.go
+++ b/cmd/varlogsn/cli.go
@@ -65,7 +65,6 @@ func newStartCommand() *cli.Command {
 			flagAppendPipelineSize,
 
 			// storage options
-			flagExperimentalStorageSeparateDB,
 			flagStorageDataDBDisableWAL,
 			flagStorageDataDBNoSync,
 			flagStorageCommitDBDisableWAL,

--- a/cmd/varlogsn/flags.go
+++ b/cmd/varlogsn/flags.go
@@ -81,13 +81,6 @@ var (
 	}
 
 	// flags for storage.
-	flagExperimentalStorageSeparateDB = &cli.BoolFlag{
-		Name:     "experimental-storage-separate-db",
-		Category: categoryStorage,
-		EnvVars:  []string{"EXPERIMENTAL_STORAGE_SEPARATE_DB"},
-		Usage:    "Separate databases of storage experimentally.",
-	}
-
 	flagStorageDataDBDisableWAL = &cli.BoolFlag{
 		Name:     "storage-datadb-disable-wal",
 		Category: categoryStorage,

--- a/cmd/varlogsn/testdata/varlogsn.ct
+++ b/cmd/varlogsn/testdata/varlogsn.ct
@@ -55,7 +55,6 @@ OPTIONS:
 
    Storage:
 
-   --experimental-storage-separate-db                                                                                                                                                                   Separate databases of storage experimentally. (default: false) [$EXPERIMENTAL_STORAGE_SEPARATE_DB]
    --storage-cache-size value                                                                                                                                                                           Size of storage cache shared across all storages. (default: "128MiB") [$STORAGE_CACHE_SIZE]
    --storage-commitdb-disable-wal                                                                                                                                                                       Disable the Write-Ahead Logging (WAL) for the commit database in storage. If --experimental-storage-separate-db is not used, this setting is ignored. (default: false) [$STORAGE_COMMITDB_DISABLE_WAL]
    --storage-commitdb-no-sync                                                                                                                                                                           Disable synchronization for the commit database in storage. If true, written data might be lost on process termination. If --experimental-storage-separate-db is not used, this setting is ignored. (default: false) [$STORAGE_COMMITDB_NO_SYNC]

--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -237,17 +237,14 @@ func parseStorageOptions(c *cli.Context) (opts []storage.Option, err error) {
 		),
 		storage.WithMetricsLogInterval(c.Duration(flagStorageMetricsLogInterval.Name)),
 	}
-	if c.Bool(flagExperimentalStorageSeparateDB.Name) {
-		opts = append(opts,
-			storage.SeparateStore(),
-			storage.WithCommitStoreOptions(
-				slices.Concat([]storage.StoreOption{
-					storage.WithWAL(!c.Bool(flagStorageDataDBDisableWAL.Name)),
-					storage.WithSync(!c.Bool(flagStorageDataDBNoSync.Name)),
-				}, getStorageDBOptions(1))...,
-			),
-		)
-	}
+	opts = append(opts,
+		storage.WithCommitStoreOptions(
+			slices.Concat([]storage.StoreOption{
+				storage.WithWAL(!c.Bool(flagStorageDataDBDisableWAL.Name)),
+				storage.WithSync(!c.Bool(flagStorageDataDBNoSync.Name)),
+			}, getStorageDBOptions(1))...,
+		),
+	)
 	if c.Bool(flagStorageVerbose.Name) {
 		opts = append(opts, storage.WithVerboseLogging())
 	}

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -162,7 +162,6 @@ func WithMaxConcurrentCompaction(maxConcurrentCompaction int) StoreOption {
 
 type config struct {
 	path               string
-	separateStore      bool
 	dataStoreOptions   []StoreOption
 	commitStoreOptions []StoreOption
 	verbose            bool
@@ -217,12 +216,6 @@ func (fo *funcOption) apply(cfg *config) {
 func WithPath(path string) Option {
 	return newFuncOption(func(cfg *config) {
 		cfg.path = path
-	})
-}
-
-func SeparateStore() Option {
-	return newFuncOption(func(cfg *config) {
-		cfg.separateStore = true
 	})
 }
 

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -94,70 +94,13 @@ func TestStorage_New(t *testing.T) {
 					WithPath(path),
 					WithLogger(zap.NewNop()),
 					WithCache(cache),
-					SeparateStore(),
 				)
 				require.NoError(t, err)
 				require.NoError(t, s.Close())
 			},
 		},
 		{
-			name: "SeparateAndNotSeparate",
-			testf: func(t *testing.T) {
-				path := t.TempDir()
-
-				s, err := New(
-					WithPath(path),
-					SeparateStore(),
-				)
-				require.NoError(t, err)
-				require.NoError(t, s.Close())
-
-				_, err = New(
-					WithPath(path),
-				)
-				require.Error(t, err)
-			},
-		},
-		{
-			name: "NotSeparateAndSeparate",
-			testf: func(t *testing.T) {
-				path := t.TempDir()
-
-				s, err := New(
-					WithPath(path),
-				)
-				require.NoError(t, err)
-				require.NoError(t, s.Close())
-
-				_, err = New(
-					WithPath(path),
-					SeparateStore(),
-				)
-				require.Error(t, err)
-			},
-		},
-		{
-			name: "NewAndCloseSeparateDB",
-			testf: func(t *testing.T) {
-				path := t.TempDir()
-				opts := []Option{
-					WithPath(path),
-					SeparateStore(),
-					WithVerboseLogging(),
-					WithMetricsLogInterval(time.Second),
-				}
-
-				s, err := New(opts...)
-				require.NoError(t, err)
-				require.NoError(t, s.Close())
-
-				s, err = New(opts...)
-				require.NoError(t, err)
-				require.NoError(t, s.Close())
-			},
-		},
-		{
-			name: "NewAndCloseNotSeparateDB",
+			name: "NewAndClose",
 			testf: func(t *testing.T) {
 				path := t.TempDir()
 				opts := []Option{


### PR DESCRIPTION
### What this PR does

This change makes the storage layer always use separate stores for data and
commit. The experimental flag and related code paths for non-separated stores
have been removed, simplifying configuration and aligning with current usage
patterns.
