### PR TITLE
refactor(storage): rename dataStore to valueStore for clarity

### DIFF
--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -229,7 +229,7 @@ func parseStorageOptions(c *cli.Context) (opts []storage.Option, err error) {
 	}
 
 	opts = []storage.Option{
-		storage.WithDataStoreOptions(
+		storage.WithValueStoreOptions(
 			slices.Concat([]storage.StoreOption{
 				storage.WithWAL(!c.Bool(flagStorageDataDBDisableWAL.Name)),
 				storage.WithSync(!c.Bool(flagStorageDataDBNoSync.Name)),

--- a/internal/storage/benchmark_test.go
+++ b/internal/storage/benchmark_test.go
@@ -24,7 +24,7 @@ func BenchmarkStorage_WriteBatch(b *testing.B) {
 			name := fmt.Sprintf("batchLen=%d_dataLen=%d", batchLen, dataLen)
 			b.Run(name, func(b *testing.B) {
 				stg := TestNewStorage(b,
-					WithDataStoreOptions(
+					WithValueStoreOptions(
 						WithSync(false), // Use only in mac since sync is too slow in mac os.
 						WithL0CompactionThreshold(2),
 						WithL0StopWritesThreshold(1000),
@@ -65,7 +65,7 @@ func BenchmarkStorage_ScanWithGLSN(b *testing.B) {
 	for _, numLogs := range numLogsList {
 		b.Run(fmt.Sprintf("numLogs=%d", numLogs), func(b *testing.B) {
 			stg := TestNewStorage(b,
-				WithDataStoreOptions(
+				WithValueStoreOptions(
 					WithSync(false), // Use only in mac since sync is too slow in mac os.
 					WithL0CompactionThreshold(2),
 					WithL0StopWritesThreshold(1000),

--- a/internal/storage/config.go
+++ b/internal/storage/config.go
@@ -22,7 +22,7 @@ const (
 	DefaultMaxConcurrentCompactions    = 1
 	DefaultMetricsLogInterval          = time.Duration(0)
 
-	dataStoreDirName   = "_data"
+	valueStoreDirName  = "_data"
 	commitStoreDirName = "_commit"
 )
 
@@ -162,7 +162,7 @@ func WithMaxConcurrentCompaction(maxConcurrentCompaction int) StoreOption {
 
 type config struct {
 	path               string
-	dataStoreOptions   []StoreOption
+	valueStoreOptions  []StoreOption
 	commitStoreOptions []StoreOption
 	verbose            bool
 	metricsLogInterval time.Duration
@@ -219,9 +219,9 @@ func WithPath(path string) Option {
 	})
 }
 
-func WithDataStoreOptions(dataStoreOpts ...StoreOption) Option {
+func WithValueStoreOptions(valueStoreOpts ...StoreOption) Option {
 	return newFuncOption(func(cfg *config) {
-		cfg.dataStoreOptions = dataStoreOpts
+		cfg.valueStoreOptions = valueStoreOpts
 	})
 }
 

--- a/internal/storage/recovery_points.go
+++ b/internal/storage/recovery_points.go
@@ -84,7 +84,7 @@ func (s *Storage) readLastCommitContext() (*CommitContext, error) {
 }
 
 func (s *Storage) readLogEntryBoundaries() (first, last *varlogpb.LogSequenceNumber, err error) {
-	dit, err := s.dataStore.NewIter(&pebble.IterOptions{
+	dit, err := s.valueStore.NewIter(&pebble.IterOptions{
 		LowerBound: []byte{dataKeyPrefix},
 		UpperBound: []byte{dataKeySentinelPrefix},
 	})
@@ -127,8 +127,8 @@ func (s *Storage) getFirstLogSequenceNumber(cit, dit *pebble.Iterator) *varlogpb
 	cLLSN := decodeDataKey(cit.Value())
 	dLLSN := decodeDataKey(dit.Key())
 	s.logger.Info("read recovery points: try to get first log sequence number",
-		zap.Uint64("commitDB.firstLLSN", uint64(cLLSN)),
-		zap.Uint64("dataDB.firstLLSN", uint64(dLLSN)),
+		zap.Uint64("commitStore.firstLLSN", uint64(cLLSN)),
+		zap.Uint64("valueStore.firstLLSN", uint64(dLLSN)),
 	)
 	for cLLSN != dLLSN {
 		if dLLSN < cLLSN {
@@ -210,7 +210,7 @@ func (s *Storage) getLastLogSequenceNumber(cit, dit *pebble.Iterator, first *var
 func (s *Storage) readUncommittedLogEntryBoundaries(uncommittedBegin types.LLSN) (begin, end types.LLSN, err error) {
 	dk := make([]byte, dataKeyLength)
 	dk = encodeDataKeyInternal(uncommittedBegin, dk)
-	it, err := s.dataStore.NewIter(&pebble.IterOptions{
+	it, err := s.valueStore.NewIter(&pebble.IterOptions{
 		LowerBound: dk,
 		UpperBound: []byte{dataKeySentinelPrefix},
 	})

--- a/internal/storage/scanner.go
+++ b/internal/storage/scanner.go
@@ -119,7 +119,7 @@ func (s *Scanner) initLazyIterator(beginKey []byte, beginLLSN types.LLSN) (err e
 		UpperBound: s.lazy.dkUpper,
 	}
 
-	s.lazy.dataIt, err = s.stg.dataStore.NewIter(itOpt)
+	s.lazy.dataIt, err = s.stg.valueStore.NewIter(itOpt)
 	if err != nil {
 		return err
 	}

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -62,7 +62,7 @@ func TestStorage_New(t *testing.T) {
 				_, err := New(
 					WithPath(path),
 					WithCache(cache),
-					WithDataStoreOptions(
+					WithValueStoreOptions(
 						WithWAL(false),
 						WithSync(true),
 					),
@@ -1134,7 +1134,7 @@ func TestStorage_Trim(t *testing.T) {
 				err := stg.Trim(types.MinGLSN)
 				assert.NoError(t, err)
 
-				it, err := stg.dataStore.NewIter(&pebble.IterOptions{
+				it, err := stg.valueStore.NewIter(&pebble.IterOptions{
 					LowerBound: []byte{dataKeyPrefix},
 					UpperBound: []byte{dataKeySentinelPrefix},
 				})
@@ -1168,7 +1168,7 @@ func TestStorage_Trim(t *testing.T) {
 				assert.NoError(t, err)
 				assert.NoError(t, err)
 
-				it, err := stg.dataStore.NewIter(&pebble.IterOptions{
+				it, err := stg.valueStore.NewIter(&pebble.IterOptions{
 					LowerBound: []byte{dataKeyPrefix},
 					UpperBound: []byte{dataKeySentinelPrefix},
 				})
@@ -1195,7 +1195,7 @@ func TestStorage_Trim(t *testing.T) {
 				err := stg.Trim(types.MaxGLSN)
 				assert.NoError(t, err)
 
-				it, err := stg.dataStore.NewIter(&pebble.IterOptions{
+				it, err := stg.valueStore.NewIter(&pebble.IterOptions{
 					LowerBound: []byte{dataKeyPrefix},
 					UpperBound: []byte{dataKeySentinelPrefix},
 				})

--- a/internal/storage/testing.go
+++ b/internal/storage/testing.go
@@ -18,7 +18,7 @@ func TestNewStorage(tb testing.TB, opts ...Option) *Storage {
 	defaultOpts := []Option{
 		WithPath(tb.TempDir()),
 		WithCache(cache),
-		WithDataStoreOptions(
+		WithValueStoreOptions(
 			WithSync(false), // Use only in mac since sync is too slow in mac os.
 		),
 	}
@@ -31,9 +31,9 @@ func TestNewStorage(tb testing.TB, opts ...Option) *Storage {
 // storage.
 func TestGetUnderlyingStore(tb testing.TB, stg *Storage) (dataStore, commitStore *pebble.DB) {
 	require.NotNil(tb, stg)
-	require.NotNil(tb, stg.dataStore)
+	require.NotNil(tb, stg.valueStore)
 	require.NotNil(tb, stg.commitStore)
-	return stg.dataStore, stg.commitStore
+	return stg.valueStore, stg.commitStore
 }
 
 // TestWriteLogEntry stores data located by the llsn. The data is not committed
@@ -68,7 +68,7 @@ func TestDeleteCommitContext(tb testing.TB, stg *Storage) {
 }
 
 func TestDeleteLogEntry(tb testing.TB, stg *Storage, lsn varlogpb.LogSequenceNumber) {
-	dataBatch := stg.dataStore.NewBatch()
+	dataBatch := stg.valueStore.NewBatch()
 	commitBatch := stg.commitStore.NewBatch()
 	defer func() {
 		err := errors.Join(dataBatch.Close(), commitBatch.Close())


### PR DESCRIPTION
### What this PR does

This change renames dataStore to valueStore to clarify its role: it stores user
log entry values. In contrast, commitStore stores the GLSN
(GlobalLogSequenceNumber), which is issued by the metadata repository. The GLSN
acts as the key for the log entry value. While the commitStore could be called
keyStore, we retain the name "commitStore" because it stores global state as
well as GLSNs.

This commit does not change any user-facing features such as the CLI or
environments.
