### PR TITLE
fix(storagenode): use correct flags for commit store WAL and sync options

### DIFF
--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -235,8 +235,8 @@ func parseStorageOptions(c *cli.Context, commonStoreOpts ...storage.StoreOption)
 	}, getStorageDBOptions(0))
 
 	commitStoreOpts := slices.Concat(commonStoreOpts, []storage.StoreOption{
-		storage.WithWAL(!c.Bool(flagStorageDataDBDisableWAL.Name)),
-		storage.WithSync(!c.Bool(flagStorageDataDBNoSync.Name)),
+		storage.WithWAL(!c.Bool(flagStorageCommitDBDisableWAL.Name)),
+		storage.WithSync(!c.Bool(flagStorageCommitDBNoSync.Name)),
 		storage.WithVerbose(c.Bool(flagStorageVerbose.Name)),
 	}, getStorageDBOptions(1))
 


### PR DESCRIPTION
### What this PR does

Previously, the commit store was incorrectly using the data DB's WAL and sync
disable flags (`--storage-datadb-disable-wal` and `--storage-datadb-no-sync`).
This commit updates the code to use the correct flags
(`--storage-commitdb-disable-wal` and `--storage-commitdb-no-sync`) for the
commit store's WAL and sync options, ensuring that these options can be
correctly configured for the commit store as intended.
