### PR TITLE
refactor(storage): rename sync option to syncWAL for clarity

### DIFF
--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -230,13 +230,13 @@ func parseStorageOptions(c *cli.Context, commonStoreOpts ...storage.StoreOption)
 
 	valueStoreOpts := slices.Concat(commonStoreOpts, []storage.StoreOption{
 		storage.WithWAL(!c.Bool(flagStorageDataDBDisableWAL.Name)),
-		storage.WithSync(!c.Bool(flagStorageDataDBNoSync.Name)),
+		storage.WithSyncWAL(!c.Bool(flagStorageDataDBNoSync.Name)),
 		storage.WithVerbose(c.Bool(flagStorageVerbose.Name)),
 	}, getStorageDBOptions(0))
 
 	commitStoreOpts := slices.Concat(commonStoreOpts, []storage.StoreOption{
 		storage.WithWAL(!c.Bool(flagStorageCommitDBDisableWAL.Name)),
-		storage.WithSync(!c.Bool(flagStorageCommitDBNoSync.Name)),
+		storage.WithSyncWAL(!c.Bool(flagStorageCommitDBNoSync.Name)),
 		storage.WithVerbose(c.Bool(flagStorageVerbose.Name)),
 	}, getStorageDBOptions(1))
 

--- a/internal/storage/benchmark_test.go
+++ b/internal/storage/benchmark_test.go
@@ -25,7 +25,7 @@ func BenchmarkStorage_WriteBatch(b *testing.B) {
 			b.Run(name, func(b *testing.B) {
 				stg := TestNewStorage(b,
 					WithValueStoreOptions(
-						WithSync(false), // Use only in mac since sync is too slow in mac os.
+						WithSyncWAL(false), // Use only in mac since sync is too slow in mac os.
 						WithL0CompactionThreshold(2),
 						WithL0StopWritesThreshold(1000),
 						WithLBaseMaxBytes(64<<20),
@@ -66,7 +66,7 @@ func BenchmarkStorage_ScanWithGLSN(b *testing.B) {
 		b.Run(fmt.Sprintf("numLogs=%d", numLogs), func(b *testing.B) {
 			stg := TestNewStorage(b,
 				WithValueStoreOptions(
-					WithSync(false), // Use only in mac since sync is too slow in mac os.
+					WithSyncWAL(false), // Use only in mac since sync is too slow in mac os.
 					WithL0CompactionThreshold(2),
 					WithL0StopWritesThreshold(1000),
 					WithLBaseMaxBytes(64<<20),

--- a/internal/storage/storage_test.go
+++ b/internal/storage/storage_test.go
@@ -54,7 +54,7 @@ func TestStorage_New(t *testing.T) {
 					WithPath(path),
 					WithValueStoreOptions(
 						WithWAL(false),
-						WithSync(true),
+						WithSyncWAL(true),
 					),
 				)
 				require.Error(t, err)

--- a/internal/storage/testing.go
+++ b/internal/storage/testing.go
@@ -18,11 +18,11 @@ func TestNewStorage(tb testing.TB, opts ...Option) *Storage {
 	defaultOpts := []Option{
 		WithPath(tb.TempDir()),
 		WithValueStoreOptions(
-			WithSync(false), // Use only in mac since sync is too slow in mac os.
+			WithSyncWAL(false), // Use only in mac since sync is too slow in mac os.
 			WithCache(cache),
 		),
 		WithCommitStoreOptions(
-			WithSync(false), // Use only in mac since sync is too slow in mac os.
+			WithSyncWAL(false), // Use only in mac since sync is too slow in mac os.
 			WithCache(cache),
 		),
 	}


### PR DESCRIPTION
### What this PR does

This commit clarifies the purpose of the sync option by renaming it to syncWAL.
This makes it explicit that the option controls synchronization of the Pebble
Write-Ahead Log (WAL) to disk. No changes to user-facing CLI flags; existing CLI
usage remains unchanged.
