### PR TITLE
feat(storage): add enable_telemetry option to control metrics recording

### DIFF
--- a/cmd/varlogsn/flags.go
+++ b/cmd/varlogsn/flags.go
@@ -262,6 +262,8 @@ type StorageStoreSetting struct {
 
 	maxOpenFiles int
 
+	enableTelemetry bool
+
 	verbose bool
 }
 
@@ -282,6 +284,7 @@ func (setting *StorageStoreSetting) init() {
 		lbaseMaxBytes:               storage.DefaultLBaseMaxBytes,
 		maxConcurrentCompactions:    storage.DefaultMaxConcurrentCompactions,
 		maxOpenFiles:                storage.DefaultMaxOpenFiles,
+		enableTelemetry:             false,
 		verbose:                     false,
 	}
 }
@@ -376,6 +379,11 @@ func (setting *StorageStoreSetting) Set(value string) (err error) {
 			if err != nil {
 				return fmt.Errorf("invalid value for max_open_files: %w", err)
 			}
+		case "enable_telemetry":
+			setting.enableTelemetry, err = strconv.ParseBool(v)
+			if err != nil {
+				return fmt.Errorf("invalid value for enable_telemetry: %w", err)
+			}
 		case "verbose":
 			setting.verbose, err = strconv.ParseBool(v)
 			if err != nil {
@@ -439,6 +447,9 @@ func (setting *StorageStoreSetting) String() string {
 	}
 	if setting.maxOpenFiles > 0 {
 		opts = append(opts, fmt.Sprintf("max_open_files=%d", setting.maxOpenFiles))
+	}
+	if setting.enableTelemetry {
+		opts = append(opts, "enable_telemetry=true")
 	}
 	if setting.verbose {
 		opts = append(opts, "verbose=true")

--- a/cmd/varlogsn/varlogsn.go
+++ b/cmd/varlogsn/varlogsn.go
@@ -128,6 +128,7 @@ func start(c *cli.Context) error {
 			storage.WithTrimDelay(s.trimDelay),
 			storage.WithTrimRateByte(int(s.trimRate)),
 			storage.WithMaxOpenFiles(s.maxOpenFiles),
+			storage.EnableTelemetry(s.enableTelemetry),
 			storage.WithVerbose(s.verbose),
 		}
 		switch flagStorageStore.Name {


### PR DESCRIPTION
### What this PR does

This commit introduces the `enable_telemetry` option to the storage store flag.
When enabled, the store collects metrics using OpenTelemetry.

Since collecting metrics in the storage layer can be bursty and costly, it is
disabled by default. Enable this option when internal storage metrics are
needed.
