### PR TITLE
refactor(storagenode): remove unused closedC channel from StorageNode struct

### DIFF
--- a/internal/storagenode/storagenode.go
+++ b/internal/storagenode/storagenode.go
@@ -57,7 +57,6 @@ type StorageNode struct {
 	server       *grpc.Server
 	healthServer *health.Server
 	closed       bool
-	closedC      chan struct{}
 
 	mux cmux.CMux
 
@@ -113,7 +112,6 @@ func NewStorageNode(opts ...Option) (*StorageNode, error) {
 		executors:    executorsmap.New(hintNumExecutors),
 		server:       rpc.NewServer(grpcServerOpts...),
 		healthServer: health.NewServer(),
-		closedC:      make(chan struct{}),
 		snPaths:      snPaths,
 		pprofServer:  pprof.New(cfg.pprofOpts...),
 		metrics:      metrics,
@@ -220,7 +218,6 @@ func (sn *StorageNode) Close() (err error) {
 		return nil
 	}
 	sn.closed = true
-	close(sn.closedC)
 
 	sn.mux.Close()
 	sn.pprofServer.Close(context.Background())


### PR DESCRIPTION
### What this PR does

The closedC channel field was declared in the StorageNode struct but was never
used in the codebase. This commit removes the field to simplify the struct and
reduce unnecessary code. No functional changes are introduced.
