### PR TITLE
refactor(storage): remove unnecessary Flush before DB close

### DIFF
--- a/internal/storage/store.go
+++ b/internal/storage/store.go
@@ -126,11 +126,8 @@ func newStore(path string, opts ...StoreOption) (*store, error) {
 	return s, nil
 }
 
-func (s *store) close() (err error) {
-	if !s.readOnly {
-		err = s.db.Flush()
-	}
-	return errors.Join(err, s.db.Close())
+func (s *store) close() error {
+	return s.db.Close()
 }
 
 type telemetryConfig struct {


### PR DESCRIPTION
### What this PR does

This commit removes the explicit call to `Flush` before closing the Pebble DB in
store. When closing, Pebble persists data via the WAL, so flushing memtables is
unnecessary.
