### PR TITLE
fix(storagenode): stop syncRunner when log stream executor closes

### DIFF
--- a/internal/storagenode/logstream/executor.go
+++ b/internal/storagenode/logstream/executor.go
@@ -625,6 +625,7 @@ func (lse *Executor) Metrics() *telemetry.LogStreamMetrics {
 
 func (lse *Executor) Close() (err error) {
 	lse.esm.store(executorStateClosed)
+	lse.syncRunner.Stop()
 	lse.rcs.close()
 	if lse.cm != nil {
 		lse.cm.stop()


### PR DESCRIPTION
### What this PR does

The `internal/storagenode/logstream.(*Executor).syncRunner` is a background
runner for the Sync RPC, responsible for copying log entries from sealed
replicas to read-only replicas during recovery. This commit ensures that the log
stream executor stops the syncRunner when it closes, preventing potential
resource leaks and ensuring proper shutdown behavior.
