### PR TITLE
perf(client,subscribe): reduce heap allocations in the dispatcher loop

### DIFF
--- a/pkg/varlog/subscribe.go
+++ b/pkg/varlog/subscribe.go
@@ -501,7 +501,11 @@ func (p *dispatcher) dispatch(_ context.Context) {
 	sentErr := false
 	for res := range p.sleq.recvC() {
 		if sentErr {
-			p.logger.Panic("multiple errors in dispatcher", zap.Any("res", res), zap.Error(res.Error))
+			p.logger.Panic("multiple errors in dispatcher",
+				zap.Uint64("glsn", uint64(res.GLSN)),
+				zap.Uint64("llsn", uint64(res.LLSN)),
+				zap.Error(res.Error),
+			)
 		}
 		p.onNextFunc(res.LogEntry, res.Error)
 		sentErr = sentErr || res.Error != nil


### PR DESCRIPTION
### What this PR does

The `res` variable in the subscriber's dispatcher loop was escaping to the heap.
This was caused by passing the entire struct to the logger using `zap.Any()`,
which forces an allocation for the interface conversion. This behavior leads to
unnecessary memory allocations.

```go
for res := range p.sleq.recvC() {
    if sentErr {
        p.logger.Panic("multiple errors in dispatcher", zap.Any("res", res), zap.Error(res.Error))
    }
}
```

This commit resolves the issue by logging the individual fields of the `res`
struct. By using `zap.Uint64` and `zap.Error` instead of `zap.Any`, the Go
compiler can keep the `res` variable on the stack, thus preventing the heap
allocation and improving performance.
