### PR TITLE
feat(varlog): add observer to subscribe API for metrics

### DIFF
--- a/pkg/varlog/options.go
+++ b/pkg/varlog/options.go
@@ -246,7 +246,8 @@ func defaultSubscribeOptions() subscribeOptions {
 }
 
 type subscribeOptions struct {
-	timeout time.Duration
+	timeout  time.Duration
+	observer SubscribeObserver
 }
 
 type SubscribeOption interface {
@@ -268,5 +269,15 @@ func newSubscribeOption(f func(*subscribeOptions)) *subscribeOption {
 func WithSubscribeTimeout(timeout time.Duration) SubscribeOption {
 	return newSubscribeOption(func(opts *subscribeOptions) {
 		opts.timeout = timeout
+	})
+}
+
+// WithSubscribeObserver sets the observer for a subscription.
+//
+// The provided observer will be called for each log entry to report internal
+// statistics, which can be used for monitoring and diagnostics.
+func WithSubscribeObserver(observer SubscribeObserver) SubscribeOption {
+	return newSubscribeOption(func(opts *subscribeOptions) {
+		opts.observer = observer
 	})
 }

--- a/pkg/varlog/stats.go
+++ b/pkg/varlog/stats.go
@@ -1,0 +1,36 @@
+package varlog
+
+import (
+	"context"
+	"time"
+)
+
+// SubscribeStats contains statistics for a single log entry processed by a
+// subscription. It is passed to the SubscribeObserver for each log entry.
+type SubscribeStats struct {
+	// TransmitEnqueueDuration is the time it takes to enqueue a single log
+	// entry into the internal transmit queue. A long duration may indicate
+	// high load or lock contention within the client.
+	TransmitEnqueueDuration time.Duration
+
+	// TransmitQueueWait is the time a single log entry spends waiting in the
+	// transmit queue. A high value can indicate that the internal transmitter
+	// goroutine is not being scheduled frequently enough, possibly due to high
+	// CPU load or scheduler latency.
+	TransmitQueueWait time.Duration
+
+	// DispatchQueueWait is the time a single log entry spends waiting in the
+	// dispatch queue before being passed to the user's callback.
+	DispatchQueueWait time.Duration
+
+	// ProcessDuration is the time it takes for the user-provided callback to
+	// execute for a single log entry.
+	ProcessDuration time.Duration
+}
+
+// SubscribeObserver is an interface for observing subscription statistics.
+type SubscribeObserver interface {
+	// Observe is called for each log entry processed by the subscription,
+	// allowing the user to collect and handle statistics.
+	Observe(context.Context, SubscribeStats)
+}


### PR DESCRIPTION
### What this PR does

This change introduces an observer to the Subscribe API, allowing users to
monitor internal latencies and diagnose performance issues. Previously, the
internal pipeline of the subscribe client was a black box, making it difficult
to pinpoint the cause of performance issues.

With this feature, users can implement the `SubscribeObserver` interface and
register it using the `WithSubscribeObserver` option. The `Observe` method will
be called for each log entry, providing a `SubscribeStats` struct that contains
a detailed breakdown of the time spent in different stages of the internal
pipeline.

The following statistics are provided:

- TransmitEnqueueDuration: The time taken to enqueue a subscribed log entry into
  the internal transmit queue.
- TransmitQueueWait: The time a log entry waits in the transmit queue, which can
  indicate scheduling delays or high CPU load if the value is high.
- DispatchQueueWait: The time a log entry waits in the dispatch queue before
  being passed to the user's callback.
- ProcessDuration: The execution time of the user-provided callback for a single
  log entry.
