### PR TITLE
refactor(client): improve naming of internal subscribe components

### DIFF
--- a/pkg/varlog/benchmark_test.go
+++ b/pkg/varlog/benchmark_test.go
@@ -10,24 +10,24 @@ import (
 	"github.com/kakao/varlog/proto/varlogpb"
 )
 
-func BenchmarkTransmitQueue(b *testing.B) {
+func BenchmarkAggregationBuffer(b *testing.B) {
 	sizes := []int{1 << 7, 1 << 10, 1 << 13}
 	tcs := []struct {
-		generate func(int) *transmitQueue
+		generate func(int) *aggregationBuffer
 		name     string
 	}{
 		{
 			name: "NoAlloc",
-			generate: func(int) *transmitQueue {
-				return &transmitQueue{
+			generate: func(int) *aggregationBuffer {
+				return &aggregationBuffer{
 					pq: &PriorityQueue{},
 				}
 			},
 		},
 		{
 			name: "PreAlloc",
-			generate: func(size int) *transmitQueue {
-				return &transmitQueue{
+			generate: func(size int) *aggregationBuffer {
+				return &aggregationBuffer{
 					pq: newPriorityQueue(size / 2),
 				}
 			},
@@ -42,7 +42,7 @@ func BenchmarkTransmitQueue(b *testing.B) {
 				for range b.N {
 					tq := tc.generate(size)
 					for range size {
-						tr := transmitResult{
+						tr := aggregationItem{
 							result: client.SubscribeResult{
 								LogEntry: varlogpb.LogEntry{
 									LogEntryMeta: varlogpb.LogEntryMeta{

--- a/pkg/varlog/stats.go
+++ b/pkg/varlog/stats.go
@@ -8,16 +8,16 @@ import (
 // SubscribeStats contains statistics for a single log entry processed by a
 // subscription. It is passed to the SubscribeObserver for each log entry.
 type SubscribeStats struct {
-	// TransmitEnqueueDuration is the time it takes to enqueue a single log
-	// entry into the internal transmit queue. A long duration may indicate
+	// AggregationEnqueueDuration is the time it takes to enqueue a single log
+	// entry into the internal aggregation buffer. A long duration may indicate
 	// high load or lock contention within the client.
-	TransmitEnqueueDuration time.Duration
+	AggregationEnqueueDuration time.Duration
 
-	// TransmitQueueWait is the time a single log entry spends waiting in the
-	// transmit queue. A high value can indicate that the internal transmitter
-	// goroutine is not being scheduled frequently enough, possibly due to high
-	// CPU load or scheduler latency.
-	TransmitQueueWait time.Duration
+	// AggregationBufferWait is the time a single log entry spends waiting in
+	// the aggregation buffer. A high value can indicate that the internal
+	// aggregator goroutine is not being scheduled frequently enough, possibly
+	// due to high CPU load or scheduler latency.
+	AggregationBufferWait time.Duration
 
 	// DispatchQueueWait is the time a single log entry spends waiting in the
 	// dispatch queue before being passed to the user's callback.


### PR DESCRIPTION
### What this PR does

This commit refactors the internal components of the `Subscribe` pipeline to use
more descriptive and accurate names, improving code readability and
maintainability.

The previous names, such as `Transmitter` and `TransmitQueue`, were too generic
and did not fully capture the core responsibility of the components, which is to
collect log entries from multiple streams and reorder them into a globally
sorted stream.

The following changes have been made:

- `Transmitter` -> `Aggregator`: The new name more accurately reflects its broad
  responsibilities, which include managing subscribers, fetching data, and
  aggregating/reordering the results into a single stream.
- `TransmitQueue` -> `AggregationBuffer`: Renamed to align with `Aggregator`.
  "Buffer" is also a more precise term for a priority queue that serves as a
  temporary holding area for reordering, as it doesn't imply a strict FIFO
  order.
- `transmitResult` -> `aggregationItem`: The unit of work flowing through the
  pipeline is renamed for consistency.
- Key methods within the `Aggregator` have been renamed to better describe their
  actions (e.g., `transmit` -> `run`, `transmitLoop` -> `processBuffer`).

Internal components of Subscribe:

```
     [Log Stream 1 (ordered)] ... [Log Stream N (ordered)]
                 |                           |
(Fetches logs)   |                           | (via Subscribe RPC)
                 v                           v
         [Subscriber 1] ...          [Subscriber N]
                   \                       /
                    \                     / (Pushes locally ordered,
                     \                   /   globally unordered items)
                      v                 v
                   +---------------------+
                   | AggregationBuffer   |
                   | (Priority Queue)    |
                   +---------------------+
                              ^
                              | Pop() in global GLSN order
                              |
                       +--------------+
                       |  Aggregator  |
                       +--------------+
                              |
                              | Push() ordered items
                              v
                   +---------------------+
                   |    DispatchQueue    |
                   |   (FIFO Channel)    |
                   +---------------------+
                              ^
                              | Recv()
                              |
                       +--------------+
                       |  Dispatcher  | --(Executes onNext)--> (User Callback)
                       +--------------+
```

### Which issue(s) this PR resolves

Update: #654
