### PR TITLE
refactor(stats/opentelemetry): simplify runtime instrumentation logic

### DIFF
--- a/internal/stats/opentelemetry/metric_provider.go
+++ b/internal/stats/opentelemetry/metric_provider.go
@@ -3,7 +3,6 @@ package opentelemetry
 import (
 	"context"
 	"errors"
-	"os"
 	"slices"
 	"time"
 
@@ -106,20 +105,7 @@ func initHostInstrumentation(mp metric.MeterProvider) error {
 }
 
 func initRuntimeInstrumentation(mp metric.MeterProvider, opts []runtime.Option) error {
-	const deprecatedRuntimeFeature = "OTEL_GO_X_DEPRECATED_RUNTIME_METRICS"
-	old := os.Getenv(deprecatedRuntimeFeature)
-	defer func() {
-		_ = os.Setenv(deprecatedRuntimeFeature, old)
-	}()
-
 	opts = slices.Concat(opts, []runtime.Option{runtime.WithMeterProvider(mp)})
-
-	_ = os.Setenv(deprecatedRuntimeFeature, "false")
-	if err := runtime.Start(slices.Clone(opts)...); err != nil {
-		return err
-	}
-
-	_ = os.Setenv(deprecatedRuntimeFeature, "true")
 	return runtime.Start(slices.Clone(opts)...)
 }
 


### PR DESCRIPTION
### What this PR does

The initialization logic for OpenTelemetry runtime instrumentation unnecessarily
set the `OTEL_GO_X_DEPRECATED_RUNTIME_METRICS` environment variable. This was a
workaround for older versions of the library to collect both new and deprecated
metrics.

The latest version of the `go.opentelemetry.io/contrib/instrumentation/runtime`
library now produces both sets of metrics when this environment variable is set
to `true`, making the in-code manipulation redundant.

This commit removes the workaround, simplifying the code. To additionally
collect deprecated metrics, users should now set the
`OTEL_GO_X_DEPRECATED_RUNTIME_METRICS=true` environment variable.
