### PR TITLE
test(metarepos): resolve data race exposed by testify v1.11.0

### DIFF
--- a/internal/metarepos/raft_metadata_repository_test.go
+++ b/internal/metarepos/raft_metadata_repository_test.go
@@ -1499,9 +1499,9 @@ func TestMRUpdateLogStream(t *testing.T) {
 				err = mr.UnregisterStorageNode(t.Context(), snIDs[0])
 				So(err, ShouldBeNil)
 
-				require.EventuallyWithT(t, func(c *assert.CollectT) {
+				require.Eventually(t, func() bool {
 					reporterClient := clus.reporterClientFac.(*DummyStorageNodeClientFactory).lookupClient(snIDs[0])
-					assert.Nil(c, reporterClient)
+					return reporterClient == nil
 				}, testDuration, testTick)
 
 				require.EventuallyWithT(t, func(c *assert.CollectT) {


### PR DESCRIPTION
### What this PR does

This change replaces assert.Nil() with require.Eventually() to avoid race
condition caused by testify reflection accessing DummyStorageNodeClient fields
concurrently. The race was exposed after upgrading testify from v1.10.0 to
v1.11.0 due to immediate condition checking in Eventually functions.
